### PR TITLE
Add a check for minimum bazel version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
       - run: bazel info release
       - run: bazel run @yarn//:yarn
       - run: bazel build ...
+      - run: bazel test ...
       - run: bazel run examples/rollup -- --help
 
       - save_cache:

--- a/defs.bzl
+++ b/defs.bzl
@@ -16,5 +16,6 @@
 
 Users should not load files under "/internal"
 """
+load("//internal:check_bazel_version.bzl", "check_bazel_version")
 load("//internal:node.bzl", "nodejs_binary")
 load("//internal:node_install.bzl", "node_repositories")

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -15,3 +15,10 @@
 package(default_visibility = ["//visibility:public"])
 
 exports_files(["node_launcher.sh", "node_loader.js"])
+
+py_test(
+    name = "check_bazel_version_test",
+    srcs = ["check_bazel_version_test.py"],
+    data = [":check_bazel_version.bzl"],
+    size = "small",
+)

--- a/internal/check_bazel_version.bzl
+++ b/internal/check_bazel_version.bzl
@@ -1,0 +1,50 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# From https://github.com/tensorflow/tensorflow/blob/5541ef4fbba56cf8930198373162dd3119e6ee70/tensorflow/workspace.bzl#L44
+
+# Parse the bazel version string from `native.bazel_version`.
+# The format is "<major>.<minor>.<patch>-<date> <commit>"
+# Returns a 3-tuple of numbers: (<major>, <minor>, <patch>)
+def _parse_bazel_version(bazel_version):
+  # Remove commit from version.
+  version = bazel_version.split(" ", 1)[0]
+
+  # Split into (release, date) parts and only return the release
+  # as a tuple of integers.
+  parts = version.split("-", 1)
+
+  # Turn "release" into a tuple of numbers
+  version_tuple = ()
+  for number in parts[0].split("."):
+    version_tuple += (int(number),)
+  return version_tuple
+
+
+# Check that a specific bazel version is being used.
+# Args: bazel_version in the form "<major>.<minor>.<patch>"
+def check_bazel_version(bazel_version):
+  if "bazel_version" not in dir(native):
+    fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" %
+         bazel_version)
+  elif not native.bazel_version:
+    print("\nCurrent Bazel is not a release version, cannot check for " +
+          "compatibility.")
+    print("Make sure that you are running at least Bazel %s.\n" % bazel_version)
+  else:
+    current_bazel_version = _parse_bazel_version(native.bazel_version)
+    minimum_bazel_version = _parse_bazel_version(bazel_version)
+    if minimum_bazel_version > current_bazel_version:
+      fail("\nCurrent Bazel version is {}, expected at least {}\n".format(
+          native.bazel_version, bazel_version))

--- a/internal/check_bazel_version_test.py
+++ b/internal/check_bazel_version_test.py
@@ -1,0 +1,47 @@
+import os
+import unittest
+
+
+class MockSkylark:
+  """A class that returns mocked bazel version and fail().
+
+  Used to stub out skylark runtime.
+  """
+
+  failure = None
+
+  def setVersion(self, version):
+    self.bazel_version = version
+
+  def fail(self, message):
+    self.failure = message
+
+
+class CheckBazelVersionTest(unittest.TestCase):
+  BZL_PATH = 'build_bazel_rules_nodejs/internal/check_bazel_version.bzl'
+
+  def setUp(self):
+    self.mock = MockSkylark()
+    self.globals = {
+        'native': self.mock,
+        'fail': self.mock.fail.__get__(self.mock, MockSkylark),
+    }
+    execfile(os.path.join(os.environ['TEST_SRCDIR'], self.BZL_PATH), self.globals)
+
+  def testVeryOldBazel(self):
+    # Don't call setVersion, so there is no bazel_version property
+    self.globals['check_bazel_version']('1.2.3')
+    self.assertIn('Current Bazel version is lower than 0.2.1', self.mock.failure)
+
+  def testVersionComparison(self):
+    self.mock.setVersion('1.2.2')
+    self.globals['check_bazel_version']('1.2.3')
+    self.assertIn('expected at least 1.2.3', self.mock.failure)
+
+  def testNotAlphaComparison(self):
+    self.mock.setVersion('1.12.3')
+    self.globals['check_bazel_version']('1.2.1')
+    self.assertIsNone(self.mock.failure)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/internal/node_install.bzl
+++ b/internal/node_install.bzl
@@ -122,7 +122,12 @@ _yarn_repo = repository_rule(
     attrs = { "package_json": attr.label_list() },
 )
 
+load(":check_bazel_version.bzl", "check_bazel_version")
+
 def node_repositories(package_json):
+  # Windows users need sh_binary wrapped as an .exe
+  check_bazel_version("0.5.4")
+
   _node_repo(name = "nodejs")
 
   _yarn_repo(name = "yarn", package_json = package_json)


### PR DESCRIPTION
Downstream repos (eg. typescript, Angular) may have their own minimal version constraint,
so expose a function they can use.