### PR TITLE
Remove empty path segments before looking up runfile in manifest

### DIFF
--- a/internal/node_loader.js
+++ b/internal/node_loader.js
@@ -82,15 +82,21 @@ function loadRunfilesManifest(manifestPath) {
 const runfilesManifest = loadRunfilesManifest(`${process.env.RUNFILES}_manifest`);
 
 function resolveRunfiles(...pathSegments) {
+  // Remove any empty strings from pathSegments
+  pathSegments = pathSegments.filter(segment => segment);
+
+  const defaultPath = path.join(process.env.RUNFILES, ...pathSegments);
+
   if (runfilesManifest) {
-    // Join on forward slash, because even on Windows the runfiles_manifest
-    // file is written with forward slash.
+    // Join on forward slash, because even on Windows the runfiles_manifest file
+    // is written with forward slash.
     const runfilesEntry = pathSegments.join('/');
+
     // Add .js as a workaround for https://github.com/bazelbuild/rules_nodejs/issues/25
-    return runfilesManifest[runfilesEntry] || runfilesManifest[runfilesEntry + '.js'];
-  } else {
-    return path.join(process.env.RUNFILES, ...pathSegments);
+    return runfilesManifest[runfilesEntry] || runfilesManifest[runfilesEntry + '.js'] || defaultPath;
   }
+
+  return defaultPath;
 }
 
 var originalResolveFilename = module.constructor._resolveFilename;


### PR DESCRIPTION
`resolveRunfiles([ 'karma', '', 'node_modules', 'karma/bin/karma' ])` was looking for `'karma//node_modules/karma/bin/karma'`, which is not a valid path.

See also alexeagle/rules_karma#3.  This doesn't fix that, but it makes progress.