### PR TITLE
Only use the runfiles manifest on windows.

### DIFF
--- a/internal/node_loader.js
+++ b/internal/node_loader.js
@@ -67,7 +67,9 @@ function resolveToModuleRoot(path) {
  * See https://github.com/bazelbuild/bazel/issues/3726
  */
 function loadRunfilesManifest(manifestPath) {
-  if (!fs.existsSync(manifestPath)) {
+  // If the runfiles directory exists, we're not running on Windows, so
+  // we don't need the runfiles manifest
+  if (fs.existsSync(process.env.RUNFILES)) {
     return;
   }
   const result = Object.create(null);


### PR DESCRIPTION
If we're on linux or macos, symlinks work, so we don't need to use the runfiles manifest.  Therefore, if the runfiles directory exists, we can ignore the runfiles manifest.