### PR TITLE
Add test for previous commit.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,17 +12,16 @@ jobs:
       - run: bazel info release
 
       - run: bazel run @yarn//:yarn
-      # We must subtract any targets under examples/program because it is a separate Workspace
-      # TODO(alexeagle): understand better why bazel doesn't always do this
-      - run: bazel build -- ... -examples/program/...
-      - run: bazel test  -- ... -examples/program/...
+      - run: bazel build ...
+      - run: bazel test ...
       # TODO(alexeagle): move this into the example proper
       - run: bazel run examples/rollup -- --help
 
-      # This is a separate workspace
-      - run: (cd examples/program; bazel run @yarn//:yarn && bazel build ... && bazel test ...)
+      # We should also be able to test targets in a different workspace
+      - run: bazel test @program_example//...
 
       - save_cache:
           key: angular_bazel_example-{{ .Branch }}-{{ checksum "examples/rollup/yarn.lock" }}
           paths:
             - "examples/rollup/node_modules"
+            - "examples/program/node_modules"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,10 @@ workspace(name = "build_bazel_rules_nodejs")
 
 load("//:defs.bzl", "node_repositories")
 
+local_repository(
+    name = "program_example",
+    path = "examples/program",
+)
 # Install a hermetic version of node.
 # After this is run, these labels will be available:
 # - The nodejs install:
@@ -23,7 +27,10 @@ load("//:defs.bzl", "node_repositories")
 #   @nodejs//:bin/npm
 # - The yarn package manager:
 #   @yarn//:yarn
-node_repositories(package_json = ["//examples/rollup:package.json"])
+node_repositories(package_json = [
+    "//examples/rollup:package.json",
+    "@program_example//:package.json",
+])
 
 # Now the user must run either
 # bazel run @yarn//:yarn

--- a/examples/program/BUILD.bazel
+++ b/examples/program/BUILD.bazel
@@ -29,4 +29,5 @@ jasmine_node_test(
     name = "test",
     srcs = glob(["*.spec.js"]),
     deps = [":program", ":mock_ts_lib"],
+    node_modules = "//:node_modules"
 )

--- a/internal/node.bzl
+++ b/internal/node.bzl
@@ -53,7 +53,10 @@ def _write_loader_script(ctx):
           "TEMPLATED_module_roots": "\n  " + ",\n  ".join(module_mappings),
           "TEMPLATED_entry_point": ctx.attr.entry_point,
           "TEMPLATED_label_package": ctx.attr.node_modules.label.package,
-          "TEMPLATED_workspace_name": ctx.workspace_name,
+          "TEMPLATED_workspace_name": (
+              ctx.label.workspace_root.split("/")[1]
+              if ctx.label.workspace_root
+              else ctx.workspace_name),
       },
       executable=True,
   )


### PR DESCRIPTION
We should be able to test jasmine targets under a different (possibly nested) workspace.

Also remove awkward subtraction patterns, by declaring the examples/program as a workspace
in the root WORKSPACE file.

Note the WORKSPACE files now have a cyclical dependency, but this is fine.