### PR TITLE
Fix += for lists in jasmine_node_test

### DIFF
--- a/internal/jasmine_node_test.bzl
+++ b/internal/jasmine_node_test.bzl
@@ -8,14 +8,14 @@ def jasmine_node_test(name, srcs, data = [], deps = [], **kwargs):
       testonly = 1,
   )
 
-  data += srcs + deps
-  data += [Label("//internal:jasmine_runner.js")]
-  data += [":%s_devmode_srcs.MF" % name]
+  all_data = data + srcs + deps
+  all_data += [Label("//internal:jasmine_runner.js")]
+  all_data += [":%s_devmode_srcs.MF" % name]
   entry_point = "build_bazel_rules_nodejs/internal/jasmine_runner.js"
 
   nodejs_test(
       name = name,
-      data = data,
+      data = all_data,
       entry_point = entry_point,
       templated_args = ["$(location :%s_devmode_srcs.MF)" % name],
       testonly = 1,


### PR DESCRIPTION
'+=' for lists now mutates the lhs list instead of creating a new one and assigning to lhs (https://docs.bazel.build/versions/master/skylark/backward-compatibility.html#mutating).

This is a fix for https://ci.bazel.io/blue/organizations/jenkins/Global%2Frules_nodejs/detail/rules_nodejs/56/pipeline/