### PR TITLE
Revert "Add documentation clarifying which node_modules are used"

### DIFF
--- a/internal/node_loader.js
+++ b/internal/node_loader.js
@@ -108,9 +108,18 @@ module.constructor._resolveFilename =
     request,
     resolveRunfiles(request),
     resolveRunfiles(
-      'TEMPLATED_workspace_name', 'TEMPLATED_label_package',
+      'TEMPLATED_user_workspace_name', 'TEMPLATED_label_package',
       'node_modules', request),
-  ];
+    ];
+  // Additional search path in case the build is across workspaces.
+  // See comment in node.bzl.
+  if ('TEMPLATED_label_workspace_name') {
+    resolveLocations.push(
+      resolveRunfiles(
+        'TEMPLATED_label_workspace_name', 'TEMPLATED_label_package',
+        'node_modules', request)
+    );
+  }
   for (var location of resolveLocations) {
     try {
       return originalResolveFilename(location, parent);


### PR DESCRIPTION
This reverts commit 6b9979b5c1b7f213acdfcf29fa258f76be1ec055.

The idea here is misguided, it depends on how the package manager
lays out the node_modules.
Just because @bazel/typescript depends on typescript doesn't mean
we can find node_modules/@bazel/typescript/node_modules/typescript/...
(relative to node_modules/@bazel/typescript/WORKSPACE)
because the user might also depend on typescript at the same
version, and there will only be
node_modules/typescript
(not under the @build_bazel_rules_typescript workspace)