### PR TITLE
Handle version that looks like "x.x.xrcx" in check_bazel_version.bzl

### DIFF
--- a/internal/check_bazel_version.bzl
+++ b/internal/check_bazel_version.bzl
@@ -24,6 +24,8 @@ def _parse_bazel_version(bazel_version):
   # Split into (release, date) parts and only return the release
   # as a tuple of integers.
   parts = version.split("-", 1)
+  # Handle format x.x.xrcx
+  parts = parts[0].split("rc", 1)
 
   # Turn "release" into a tuple of numbers
   version_tuple = ()

--- a/internal/check_bazel_version_test.py
+++ b/internal/check_bazel_version_test.py
@@ -55,5 +55,10 @@ class CheckBazelVersionTest(unittest.TestCase):
     self.globals['check_bazel_version']('1.2.1')
     self.assertIsNone(self.mock.failure)
 
+  def testReleaseCandidate(self):
+    self.mock.setVersion('0.8.0rc2')
+    self.globals['check_bazel_version']('0.8.0')
+    self.assertIsNone(self.mock.failure)
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
0.8.0rc2 is labeled like this