### PR TITLE
Revert "Change node module load order"

### DIFF
--- a/internal/node_loader.js
+++ b/internal/node_loader.js
@@ -104,13 +104,13 @@ var originalResolveFilename = module.constructor._resolveFilename;
 module.constructor._resolveFilename =
     function(request, parent) {
   var failedResolutions = [];
-  // Locations to search for require'd modules.
-  var resolveLocations = [];
-  // First we look in more specific paths under the label being built
-  // This allows a test to specify a subdirectory where we should find modules
-  resolveLocations.push(resolveRunfiles(
+  var resolveLocations = [
+    request,
+    resolveRunfiles(request),
+    resolveRunfiles(
       'TEMPLATED_user_workspace_name', 'TEMPLATED_label_package',
-      'node_modules', request));
+      'node_modules', request),
+    ];
   // Additional search path in case the build is across workspaces.
   // See comment in node.bzl.
   if ('TEMPLATED_label_workspace_name') {
@@ -120,13 +120,6 @@ module.constructor._resolveFilename =
         'node_modules', request)
     );
   }
-  // Finally we look in the current working directory
-  // and in the runfiles manifest
-  resolveLocations.push(
-    request,
-    resolveRunfiles(request)
-  );
-
   for (var location of resolveLocations) {
     try {
       return originalResolveFilename(location, parent);


### PR DESCRIPTION
This reverts commit ebbad65504cd0a0007987b6adce3b77a8a898ee8.
It is no longer needed for the original purpose (tsickle testing)
and it broke something else downstream in the karma rules.

Before rolling this forward again, I need to have a CI for
downstream projects, and also understand the module resolution
more deeply.