### PR TITLE
jasmine_node_test: empty srcs; fix no-spec case

### DIFF
--- a/internal/jasmine_node_test.bzl
+++ b/internal/jasmine_node_test.bzl
@@ -1,7 +1,7 @@
 load("//internal:node.bzl", "nodejs_test")
 load("//internal:devmode_js_sources.bzl", "devmode_js_sources")
 
-def jasmine_node_test(name, srcs, data = [], deps = [], **kwargs):
+def jasmine_node_test(name, srcs = [], data = [], deps = [], **kwargs):
   devmode_js_sources(
       name = "%s_devmode_srcs" % name,
       deps = srcs + deps,

--- a/internal/jasmine_runner.js
+++ b/internal/jasmine_runner.js
@@ -14,26 +14,25 @@ function main(args) {
   if (!args.length) {
     throw new Error('Spec file manifest expected argument missing');
   }
-  const specFilesManifest = require.resolve(args[0]);
+  const manifest = require.resolve(args[0]);
   // Remove the manifest, some tested code may process the argv.
   process.argv.splice(2, 1)[0];
 
-  let testFiles =
-      fs.readFileSync(specFilesManifest, UTF8)
-      .split('\n')
-      .filter(l => l.length > 0);
-  if (!testFiles.length) {
-    return BLAZE_EXIT_NO_TESTS_FOUND;
-  }
-
   const jrunner = new JasmineRunner();
-  for (file of testFiles) {
-    console.error('file', file);
-    jrunner.addSpecFile(file);
-  }
+  fs.readFileSync(manifest, UTF8)
+      .split('\n')
+      .filter(l => l.length > 0)
+      .forEach(f => jrunner.addSpecFile(f));
+
+  var noSpecsFound = true;
+  jrunner.addReporter({
+    specDone: () => { noSpecsFound = false },
+  });
 
   jrunner.onComplete((passed) => {
-    process.exit(passed ? 0 : BAZEL_EXIT_TESTS_FAILED);
+    let exitCode = passed ? 0 : BAZEL_EXIT_TESTS_FAILED;
+    if (noSpecsFound) exitCode = BAZEL_EXIT_NO_TESTS_FOUND;
+    process.exit(exitCode);
   });
 
   jrunner.execute();


### PR DESCRIPTION
Previously we only gave an error when there were no files at all.
Also due to a typo, if we ever did hit that case we'd just crash.

fixes #64