### PR TITLE
Jasmine test: source-map-support if present

### DIFF
--- a/internal/jasmine_runner.js
+++ b/internal/jasmine_runner.js
@@ -1,6 +1,12 @@
 const fs = require('fs');
 const path = require('path');
 const JasmineRunner = require('jasmine/lib/jasmine');
+try {
+  require('source-map-support').install();
+} catch (e) {
+  console.error(`WARNING: source-map-support module not installed.
+   Stack traces from languages like TypeScript will point to generated .js files.`);
+}
 
 const UTF8 = {encoding: 'utf-8'};
 


### PR DESCRIPTION
This fixes stack traces to have `.ts` references.
Since we are in rules_nodejs here, we don't ship to npm, so we can't include npm dependencies. Anyway if the user writes pure JavaScript they don't need this installed.