### PR TITLE
npm_install: correct path

### DIFF
--- a/internal/npm_install.bzl
+++ b/internal/npm_install.bzl
@@ -49,7 +49,7 @@ npm_install = repository_rule(
         ),
         "_npm": attr.label(
             executable = True,
-            default = Label("@nodejs//:bin/npm"),
+            default = Label("@nodejs//:npm"),
             cfg = "host",
         ),
     },


### PR DESCRIPTION
The npm path is not within `bin`.

I ran into this problem while trying to address https://github.com/bazelbuild/rules_typescript/issues/56. Starting from master, these were the commands I ran in order to see the error:

```
kamik@T460p MINGW64 /d/sandbox/rules_typescript (master)
$ bazel clean --expunge
INFO: Starting clean (this may take a while). Consider using --expunge_async if the clean takes more than several minutes.

kamik@T460p MINGW64 /d/sandbox/rules_typescript (master)
$ bazel run @yarn//:yarn
...............
INFO: Analysed target @yarn//:yarn (7 packages loaded).
INFO: Found 1 target...
Target @yarn//:yarn up-to-date:
  C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/execroot/build_bazel_rules_typescript/bazel-out/x64_windows-fastbuild/bin/external/yarn/yarn
  C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/execroot/build_bazel_rules_typescript/bazel-out/x64_windows-fastbuild/bin/external/yarn/yarn.exe
INFO: Elapsed time: 33.328s, Critical Path: 0.03s
INFO: Build completed successfully, 5 total actions

INFO: Running command line: C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/execroot/build_bazel_rules_typescript/bazel-out/x64_windows-fastbuild/bin/external/yarn/yarn.exe
yarn install v1.3.2
[1/4] Resolving packages...
success Already up-to-date.
Done in 0.27s.

kamik@T460p MINGW64 /d/sandbox/rules_typescript (master)
$ bazel build internal/tsc_wrapped
ERROR: D:/sandbox/rules_typescript/internal/tsc_wrapped/BUILD.bazel:27:1: no such package '@build_bazel_rules_typescript_deps//': Traceback (most recent call last):
        File "C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/external/build_bazel_rules_nodejs/internal/npm_install.bzl", line 36
                repository_ctx.execute([repository_ctx.path(repository_...("")])
        File "C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/external/build_bazel_rules_nodejs/internal/npm_install.bzl", line 37, in repository_ctx.execute
                repository_ctx.path(repository_ctx.attr._npm)
Not a regular file: C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/external/nodejs/bin/npm and referenced by '//internal/tsc_wrapped:tsc_wrapped'
ERROR: D:/sandbox/rules_typescript/internal/tsc_wrapped/BUILD.bazel:27:1: no such package '@build_bazel_rules_typescript_deps//': Traceback (most recent call last):
        File "C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/external/build_bazel_rules_nodejs/internal/npm_install.bzl", line 36
                repository_ctx.execute([repository_ctx.path(repository_...("")])
        File "C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/external/build_bazel_rules_nodejs/internal/npm_install.bzl", line 37, in repository_ctx.execute
                repository_ctx.path(repository_ctx.attr._npm)
Not a regular file: C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/external/nodejs/bin/npm and referenced by '//internal/tsc_wrapped:tsc_wrapped'
ERROR: Analysis of target '//internal/tsc_wrapped:tsc_wrapped' failed; build aborted: no such package '@build_bazel_rules_typescript_deps//': Traceback (most recent call last):
        File "C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/external/build_bazel_rules_nodejs/internal/npm_install.bzl", line 36
                repository_ctx.execute([repository_ctx.path(repository_...("")])
        File "C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/external/build_bazel_rules_nodejs/internal/npm_install.bzl", line 37, in repository_ctx.execute
                repository_ctx.path(repository_ctx.attr._npm)
Not a regular file: C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/external/nodejs/bin/npm
INFO: Elapsed time: 0.475s
FAILED: Build did NOT complete successfully (5 packages loaded)

kamik@T460p MINGW64 /d/sandbox/rules_typescript (master)
$ ls C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/external/nodejs/bin
ls: cannot access 'C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/external/nodejs/bin': No such file or directory

kamik@T460p MINGW64 /d/sandbox/rules_typescript (master)
$ ls C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/external/nodejs/
BUILD.bazel  CHANGELOG.md  LICENSE  node.exe  node_etw_provider.man  node_modules  node_perfctr_provider.man  nodevars.bat  npm  npm.cmd  npx  npx.cmd  README.md  WORKSPACE
```

The main problem seems to be `Not a regular file: C:/users/kamik/appdata/local/temp/_bazel_kamik/y9xg3tkg/external/nodejs/bin/npm`. Indeed, the file does not seem to exist in `nodejs/bin/npm` but rather just `nodejs/npm`.

I don't know why this did not come up in this repo or linux CIs in `rules_typescript`.