### PR TITLE
Add a utility to re-root files from nested trees (eg. typescript)

### DIFF
--- a/internal/collect_es6_sources.bzl
+++ b/internal/collect_es6_sources.bzl
@@ -1,0 +1,54 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Used by production rules to expose a file tree of only es6 files.
+
+These are expected to be used by the production toolchain, such as bundlers.
+The tree will be flattened, such that all the es6 files are under a single tree.
+"""
+
+def collect_es6_sources(ctx):
+  """Returns a file tree containing only production files.
+
+  Args:
+    ctx: ctx.
+
+  Returns:
+    A file tree containing only production files.
+  """
+
+  non_rerooted_files = depset()
+  for dep in ctx.attr.deps:
+    if hasattr(dep, "typescript"):
+      non_rerooted_files = depset(transitive = [non_rerooted_files, dep.typescript.transitive_es6_sources])
+
+  rerooted_files = []
+  for file in non_rerooted_files.to_list():
+    rerooted_file = ctx.actions.declare_file(
+      "%s.es6/%s" % (
+        ctx.label.name,
+        # the .closure.js filename is an artifact of the rules_typescript layout
+        file.short_path.replace(".closure.js", ".js")))
+    # Cheap way to create an action that copies a file
+    # TODO(alexeagle): discuss with Bazel team how we can do something like
+    # runfiles to create a re-rooted tree. This has performance implications.
+    ctx.actions.expand_template(
+      output = rerooted_file,
+      template = file,
+      substitutions = {}
+    )
+    rerooted_files += [rerooted_file]
+
+  #TODO(mrmeku): we should include the files and closure_js_library contents too
+  return depset(direct = rerooted_files)


### PR DESCRIPTION
It will be tested in rules_typescript shortly. We'll modify the rollup example to consume it as well, in a followup PR.