### PR TITLE
Fix CI cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 ## IMPORTANT
 # If you change the `docker_image` version, also change the `cache_key` suffix
 var_1: &docker_image angular/ngcontainer:0.0.8
-var_2: &cache_key angular-{{ .Branch }}-{{ checksum "yarn.lock" }}-0.0.8
+var_2: &cache_key angular-{{ .Branch }}-{{ checksum "examples/rollup/yarn.lock" }}-{{ checksum "examples/program/yarn.lock" }}-0.0.8
 
 version: 2
 jobs:


### PR DESCRIPTION
This fixes the CI cache. CI still works on master but caching is broken:

```
Error computing cache key: template: cacheKey:1:25: executing "cacheKey" at <checksum "yarn.lock">: error calling checksum: open /home/circleci/ng/yarn.lock: no such file or directory
```