### PR TITLE
Fix rollup_bundle issue with resolved paths growing too large

### DIFF
--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -20,7 +20,7 @@ class NormalizePaths {
       resolved = `${process.cwd()}/${binDirPath}/${buildFileDirname}/${labelName}.es6/${importee.replace(`${workspaceName}/`, "")}`;
     } else if (importee.startsWith(`./`) || importee.startsWith(`../`)) {
       // relative import
-      resolved = `${importer ? path.dirname(importer) : ""}/${importee}`;
+      resolved = path.join(importer ? path.dirname(importer) : '', importee);
     }
     // add .js extension if needed
     if (resolved) {


### PR DESCRIPTION
path.join catches instances of ./ and ../ in the importee and resolves
them correctly. Previously, importers could potentially grow too large
over time due to repetitive sequences of ./ and ../<package>, resulting
in ENAMETOOLONG errors.

Example error fixed with this change: 

```ENAMETOOLONG: name too long, open '[workspace_root]/node_modules/@firebase/firestore/dist/esm/./src/platform_browser/../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/./../platform/../util/../core/version.js'```
