### PR TITLE
Allow sources to be in multiple root dirs

### DIFF
--- a/internal/collect_es6_sources.bzl
+++ b/internal/collect_es6_sources.bzl
@@ -37,17 +37,16 @@ def collect_es6_sources(ctx):
 
   rerooted_files = []
   for file in non_rerooted_files.to_list():
-    if file.short_path.startswith(".."):
-      rerooted_path = "/".join(file.short_path.split("/")[1:])
-    else:
-      rerooted_path = "/".join([ctx.workspace_name, file.short_path])
+    path = file.short_path
+    if (path.startswith("../")):
+      path = "external/" + path[3:]
 
     rerooted_file = ctx.actions.declare_file(
       "%s.es6/%s" % (
         ctx.label.name,
         # the .closure.js filename is an artifact of the rules_typescript layout
         # TODO(mrmeku): pin to end of string, eg. don't match foo.closure.jso.js
-        rerooted_path.replace(".closure.js", ".js")))
+        path.replace(".closure.js", ".js")))
     # Cheap way to create an action that copies a file
     # TODO(alexeagle): discuss with Bazel team how we can do something like
     # runfiles to create a re-rooted tree. This has performance implications.

--- a/internal/e2e/rollup/BUILD.bazel
+++ b/internal/e2e/rollup/BUILD.bazel
@@ -5,6 +5,7 @@ filegroup(
     srcs = glob([
         "node_modules/**/*",
     ]),
+    visibility = ["//internal:__subpackages__"],
 )
 
 load("//:defs.bzl", "rollup_bundle")

--- a/internal/e2e/rollup/foo.js
+++ b/internal/e2e/rollup/foo.js
@@ -3,26 +3,6 @@ import {fum} from 'fumlib';
 
 console.log(`Hello, ${name} in ${fum}`);
 
-/** This class should be tree-shaken away */
-var ReflectiveInjector = /** @class */ (function () {
-  function ReflectiveInjector() {
-  }
-  return ReflectiveInjector;
-}());
-
-/** This class should be tree-shaken away */
-var ReflectiveInjector_ = /** @class */ (function () {
-  function ReflectiveInjector_(_providers, _parent) {}
-  ReflectiveInjector_.prototype.resolveAndInstantiate =
-  function (provider) {
-    return ReflectiveInjector;
-  };
-  Object.defineProperty(ReflectiveInjector_, "displayName", "foo");
-  return ReflectiveInjector_;
-}());
-
-ngDevMode && console.log("Should have been tree-shaken");
-
 // Test for sequences = false
 class A {
   a() { return document.a; }

--- a/internal/e2e/rollup/package.json
+++ b/internal/e2e/rollup/package.json
@@ -1,5 +1,7 @@
 {
   "devDependencies": {
-    "jasmine": "~2.8.0"
+    "jasmine": "~2.8.0",
+    "rollup": "0.52.3",
+    "rollup-plugin-node-resolve": "3.0.0"
   }
 }

--- a/internal/e2e/rollup/rollup.spec.js
+++ b/internal/e2e/rollup/rollup.spec.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 function read(relativePath) {
   // TODO(#32) Can shorten the path if https://github.com/bazelbuild/rules_nodejs/issues/32 is resolved
   const path = `build_bazel_rules_nodejs/internal/e2e/rollup/${relativePath}`;
-  return fs.readFileSync(require.resolve(path), { encoding: 'utf-8' });
+  return fs.readFileSync(require.resolve(path), { encoding: 'utf-8' }).replace(/\r\n/g, '\n');
 }
 describe('bundling', () => {
   it('should work', () => {

--- a/internal/e2e/rollup/yarn.lock
+++ b/internal/e2e/rollup/yarn.lock
@@ -2,6 +2,24 @@
 # yarn lockfile v1
 
 
+acorn@^5.2.1:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
+
+arr-diff@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
+  dependencies:
+    arr-flatten "^1.0.1"
+
+arr-flatten@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+
+array-unique@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -13,17 +31,98 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+braces@^1.8.2:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
+  dependencies:
+    expand-range "^1.8.1"
+    preserve "^0.2.0"
+    repeat-element "^1.1.2"
+
+browser-resolve@^1.11.0:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+  dependencies:
+    resolve "1.1.7"
+
+builtin-modules@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
+estree-walker@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.3.1.tgz#e6b1a51cf7292524e7237c312e5fe6660c1ce1aa"
+
+estree-walker@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.1.tgz#64fc375053abc6f57d73e9bd2f004644ad3c5854"
 
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
 
+expand-brackets@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
+  dependencies:
+    is-posix-bracket "^0.1.0"
+
+expand-range@^1.8.1:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
+  dependencies:
+    fill-range "^2.1.0"
+
+extglob@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
+  dependencies:
+    is-extglob "^1.0.0"
+
+filename-regex@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
+
+fill-range@^2.1.0:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-2.2.3.tgz#50b77dfd7e469bc7492470963699fe7a8485a723"
+  dependencies:
+    is-number "^2.1.0"
+    isobject "^2.0.0"
+    randomatic "^1.1.3"
+    repeat-element "^1.1.2"
+    repeat-string "^1.5.2"
+
+for-in@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+
+for-own@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
+  dependencies:
+    for-in "^1.0.1"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+glob-base@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
+  dependencies:
+    glob-parent "^2.0.0"
+    is-glob "^2.0.0"
+
+glob-parent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
+  dependencies:
+    is-glob "^2.0.0"
 
 glob@^7.0.6:
   version "7.1.2"
@@ -47,6 +146,68 @@ inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
+is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-dotfile@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
+
+is-equal-shallow@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
+  dependencies:
+    is-primitive "^2.0.0"
+
+is-extendable@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+
+is-extglob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
+
+is-glob@^2.0.0, is-glob@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
+  dependencies:
+    is-extglob "^1.0.0"
+
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+
+is-number@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-number@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-posix-bracket@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
+
+is-primitive@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
+
+isarray@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isobject@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
+  dependencies:
+    isarray "1.0.0"
+
 jasmine-core@~2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.8.0.tgz#bcc979ae1f9fd05701e45e52e65d3a5d63f1a24e"
@@ -59,11 +220,60 @@ jasmine@~2.8.0:
     glob "^7.0.6"
     jasmine-core "~2.8.0"
 
+kind-of@^3.0.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  dependencies:
+    is-buffer "^1.1.5"
+
+magic-string@^0.22.4:
+  version "0.22.4"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.4.tgz#31039b4e40366395618c1d6cf8193c53917475ff"
+  dependencies:
+    vlq "^0.2.1"
+
+micromatch@^2.3.11:
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
+  dependencies:
+    arr-diff "^2.0.0"
+    array-unique "^0.2.1"
+    braces "^1.8.2"
+    expand-brackets "^0.1.4"
+    extglob "^0.3.1"
+    filename-regex "^2.0.0"
+    is-extglob "^1.0.0"
+    is-glob "^2.0.1"
+    kind-of "^3.0.2"
+    normalize-path "^2.0.1"
+    object.omit "^2.0.0"
+    parse-glob "^3.0.4"
+    regex-cache "^0.4.2"
+
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
     brace-expansion "^1.1.7"
+
+normalize-path@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+  dependencies:
+    remove-trailing-separator "^1.0.1"
+
+object.omit@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
+  dependencies:
+    for-own "^0.1.4"
+    is-extendable "^0.1.1"
 
 once@^1.3.0:
   version "1.4.0"
@@ -71,9 +281,95 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
+parse-glob@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
+  dependencies:
+    glob-base "^0.3.0"
+    is-dotfile "^1.0.0"
+    is-extglob "^1.0.0"
+    is-glob "^2.0.0"
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+preserve@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+randomatic@^1.1.3:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
+
+regex-cache@^0.4.2:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
+  dependencies:
+    is-equal-shallow "^0.1.3"
+
+remove-trailing-separator@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+
+repeat-element@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
+
+repeat-string@^1.5.2:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+
+resolve@1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.1.6, resolve@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  dependencies:
+    path-parse "^1.0.5"
+
+rollup-plugin-commonjs@8.2.6:
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.2.6.tgz#27e5b9069ff94005bb01e01bb46a1e4873784677"
+  dependencies:
+    acorn "^5.2.1"
+    estree-walker "^0.5.0"
+    magic-string "^0.22.4"
+    resolve "^1.4.0"
+    rollup-pluginutils "^2.0.1"
+
+rollup-plugin-node-resolve@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz#8b897c4c3030d5001277b0514b25d2ca09683ee0"
+  dependencies:
+    browser-resolve "^1.11.0"
+    builtin-modules "^1.1.0"
+    is-module "^1.0.0"
+    resolve "^1.1.6"
+
+rollup-pluginutils@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz#7ec95b3573f6543a46a6461bd9a7c544525d0fc0"
+  dependencies:
+    estree-walker "^0.3.0"
+    micromatch "^2.3.11"
+
+rollup@0.52.3:
+  version "0.52.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.52.3.tgz#020d99fffe9619351e47b3894fd397c26f5e1bf6"
+
+vlq@^0.2.1:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
 
 wrappy@1:
   version "1.0.2"

--- a/internal/jasmine_runner.js
+++ b/internal/jasmine_runner.js
@@ -5,7 +5,8 @@ try {
   require('source-map-support').install();
 } catch (e) {
   console.error(`WARNING: source-map-support module not installed.
-   Stack traces from languages like TypeScript will point to generated .js files.`);
+   Stack traces from languages like TypeScript will point to generated .js files.
+   `);
 }
 
 const UTF8 = {encoding: 'utf-8'};

--- a/internal/js_library.bzl
+++ b/internal/js_library.bzl
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""js_library allows defining a set of javascript sources and assigning a module_name and module_root
+"""js_library allows defining a set of javascript sources and assigning a module_name and module_root.
+
+DO NOT USE - this is not fully designed, and exists only to enable testing within this repo.
 """
 
 def _js_library(ctx):

--- a/internal/rollup/BUILD.bazel
+++ b/internal/rollup/BUILD.bazel
@@ -14,7 +14,7 @@
 
 licenses(["notice"])  # Apache 2.0
 
-load("//internal:node.bzl", nodejs_binary = "nodejs_binary_macro")
+load("//:defs.bzl", "jasmine_node_test", "nodejs_binary")
 
 package(default_visibility = ["//internal:__subpackages__"])
 
@@ -39,4 +39,11 @@ nodejs_binary(
     entry_point = "build_bazel_rules_nodejs_rollup_deps/node_modules/uglify-js/bin/uglifyjs",
     node_modules = "@build_bazel_rules_nodejs_rollup_deps//:node_modules",
     visibility = ["//visibility:public"],
+)
+
+jasmine_node_test(
+    name = "test",
+    srcs = glob(["*.spec.js"]),
+    data = glob(["*.js"], exclude=["*.spec.js"]),
+    node_modules = "//internal/e2e/rollup:node_modules",
 )

--- a/internal/rollup/package.json
+++ b/internal/rollup/package.json
@@ -2,7 +2,6 @@
     "description": "runtime dependencies for rollup",
     "devDependencies": {
         "rollup": "0.52.3",
-        "rollup-plugin-commonjs": "8.2.6",
         "rollup-plugin-node-resolve": "3.0.0",
         "typescript": "2.6.2",
         "uglify-js": "3.3.9"

--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -5,60 +5,72 @@
 // For Windows, we must deep-import the actual .js file, not rely on reading the "main" from package.json
 const rollup = require('rollup/dist/rollup');
 const nodeResolve = require('rollup-plugin-node-resolve/dist/rollup-plugin-node-resolve.cjs');
-const commonjs = require('rollup-plugin-commonjs/dist/rollup-plugin-commonjs.cjs');
 const path = require('path');
 
-const binDirPath = "TMPL_bin_dir_path";
-const workspaceName = "TMPL_workspace_name";
-const buildFileDirname = "TMPL_build_file_dirname";
-const labelName = "TMPL_label_name";
-const moduleMappings = TMPL_module_mappings;
+const DEBUG = false;
 
-class NormalizePaths {
-  resolveId(importee, importer) {
-    // process.cwd() is the execroot and ends up looking something like /.../2c2a834fcea131eff2d962ffe20e1c87/bazel-sandbox/872535243457386053/execroot/<workspace_name>
-    // from that path to the es6 output is <bin_dir_path>/<build_file_dirname>/<label_name>.es6
-    // from there, sources from the user's workspace are under <user_workspace_name>/<path_to_source>
-    // and sources from external workspaces are under <external_workspace_name>/<path_to_source>
-    var resolved;
-    if (importee.startsWith(`./`) || importee.startsWith(`../`)) {
-      // relative import
-      resolved = path.join(importer ? path.dirname(importer) : '', importee);
-    } else if (importee.startsWith(`${workspaceName}/`)) {
-      // workspace import
-      resolved = path.join(process.cwd(), binDirPath, buildFileDirname, `${labelName}.es6`, importee);
-    } else {
-      // possible workspace import or external import if importee matches a module mapping
-      for (const k in moduleMappings) {
-        if (importee == k || importee.startsWith(`${k}/`)) {
-          // replace the root module name on a mappings match
-          var v = moduleMappings[k];
-          var userWorkspace = workspaceName;
-          if (v.startsWith('external/')) {
-            // for external workspaces, drop the 'external/' from the module mapping and clear the user workspace name
-            v = v.slice('external/'.length);
-            userWorkspace = '';
-          }
-          importee = path.join(userWorkspace, v, importee.slice(k.length+1))
-          resolved = path.join(process.cwd(), binDirPath, buildFileDirname, `${labelName}.es6`, importee);
-          break;
-        }
+const moduleMappings = TMPL_module_mappings;
+const rootDirs = TMPL_rootDirs;
+if (DEBUG) console.error(`
+Rollup: running with
+  rootDirs: ${rootDirs}
+  moduleMappings: ${JSON.stringify(moduleMappings)}
+`);
+
+function resolveBazel(importee, importer, baseDir = process.cwd(), resolve = require.resolve) {
+  function resolveInRootDirs(importee) {
+    for (var i=0; i<rootDirs.length; i++) {
+      var root = rootDirs[i];
+      var candidate = path.join(baseDir, root, importee);
+      if (DEBUG) console.error("Rollup: try to resolve at", candidate);
+      try {
+        var result = resolve(candidate);
+        return result;
+      } catch (e) {
+        continue;
       }
     }
-    if (resolved) {
-      // resolve with node path resolution (it will handle index.js)
-      return require.resolve(resolved);
+  }
+
+  // process.cwd() is the execroot and ends up looking something like /.../2c2a834fcea131eff2d962ffe20e1c87/bazel-sandbox/872535243457386053/execroot/<workspace_name>
+  // from that path to the es6 output is <bin_dir_path>/<build_file_dirname>/<label_name>.es6
+  // from there, sources from the user's workspace are under <user_workspace_name>/<path_to_source>
+  // and sources from external workspaces are under <external_workspace_name>/<path_to_source>
+  var resolved;
+  if (importee.startsWith('.' + path.sep) || importee.startsWith('..' + path.sep)) {
+    // relative import
+    resolved = path.join(importer ? path.dirname(importer) : '', importee);
+    if (resolved) resolved = resolve(resolved);
+  }
+
+  if (!resolved) {
+    // possible workspace import or external import if importee matches a module mapping
+    for (const k in moduleMappings) {
+      if (importee == k || importee.startsWith(k + path.sep)) {
+        // replace the root module name on a mappings match
+        var v = moduleMappings[k];
+        importee = path.join(v, importee.slice(k.length+1));
+        resolved = resolveInRootDirs(importee);
+        break;
+      }
     }
   }
+
+  if (!resolved) {
+    // workspace import
+    resolved = resolveInRootDirs(importee);
+  }
+
+  return resolved;
 }
 
-export default {
+module.exports = {
+  resolveBazel,
   output: {format: 'iife'},
   plugins: [
       TMPL_additional_plugins
   ].concat([
-      new NormalizePaths(),
-      commonjs(),
+      {resolveId: resolveBazel},
       nodeResolve({jsnext: true, module: true}),
     ])
 }

--- a/internal/rollup/uglify.config.json
+++ b/internal/rollup/uglify.config.json
@@ -1,7 +1,6 @@
 {
   "compress": {
     "pure_getters": true,
-    "pure_funcs": ["Object.defineProperty"],
     "passes": 3,
     "global_defs": {
       "ngDevMode": false


### PR DESCRIPTION
For es6, we currently have this clumsy thing:
https://github.com/bazelbuild/rules_nodejs/blob/master/internal/collect_es6_sources.bzl#L52
that flattens the re-rooted directories from all the libraries in the transitive closure.

The more performant thing is just to update the module resolution to understand a `rootDirs` option, just like TypeScript does.

It turns out Angular's optimizer doesn't work with ES6, so I need to create another flavor, es5_esm. This refactoring allows Angular to re-use the rollup rule, but pass in that output instead, and leave it in the original roots.