### PR TITLE
Add more exclusions for generated :node_modules glob

### DIFF
--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -26,7 +26,14 @@ filegroup(
     srcs = glob(["node_modules/**/*"],
         # Exclude directories that commonly contain filenames which are
         # illegal bazel labels
-        exclude = ["node_modules/*/test/**"]))
+        exclude = [
+            # e.g. node_modules/adm-zip/test/assets/attributes_test/New folder/hidden.txt
+            "node_modules/**/test/**",
+            # e.g. node_modules/xpath/docs/function resolvers.md
+            "node_modules/**/docs/**",
+        ],
+    ),
+)
 """)
 
   # Put our package descriptors in the right place.

--- a/internal/yarn_install.bzl
+++ b/internal/yarn_install.bzl
@@ -26,7 +26,14 @@ filegroup(
     srcs = glob(["node_modules/**/*"],
         # Exclude directories that commonly contain filenames which are
         # illegal bazel labels
-        exclude = ["node_modules/*/test/**"]))
+        exclude = [
+            # e.g. node_modules/adm-zip/test/assets/attributes_test/New folder/hidden.txt
+            "node_modules/**/test/**",
+            # e.g. node_modules/xpath/docs/function resolvers.md
+            "node_modules/**/docs/**",
+        ],
+    ),
+)
 """)
 
   # Put our package descriptors in the right place.


### PR DESCRIPTION
Found these while switching the Angular repo over to this pattern.