### PR TITLE
fix rollup module resolution

### DIFF
--- a/internal/rollup/rollup.config.spec.js
+++ b/internal/rollup/rollup.config.spec.js
@@ -13,14 +13,16 @@ TMPL_stamp_data = '';
 
 const baseDir = '/root/base';
 const files = [
-  '/root/base/bazel-bin/path/to/a.esm5/my_workspace/path/to/foo_lib/bar',
-  '/root/base/bazel-bin/path/to/b.esm5/other_wksp/path/to/other_lib/thing',
-  '/root/base/bazel-bin/path/to/b.esm5/some_wksp/path/to/a/index.js',
+  '/root/base/bazel-bin/path/to/a.esm5/path/to/foo_lib/bar',
+  '/root/base/bazel-bin/path/to/b.esm5/external/other_wksp/path/to/other_lib/thing',
+  '/root/base/bazel-bin/path/to/a.esm5/external/some_wksp/path/to/a/public_api.js',
+  '/root/base/bazel-bin/path/to/b.esm5/external/some_wksp/path/to/a/index.js',
 ];
 const resolve =
     (p) => {
       p = p.replace(/\\/g, '/');
       if (files.includes(p)) return p;
+      if (files.includes(p + '.js')) return p + '.js';
       if (files.includes(p + '/index.js')) return p + '/index.js';
       throw new Error('resolve failed');
     }
@@ -28,34 +30,50 @@ const resolve =
 const rollupConfig = require('./rollup.config');
 
 function doResolve(importee, importer) {
-  return rollupConfig.resolveBazel(importee, importer, baseDir, resolve).replace(/\\/g, '/');
+  const resolved = rollupConfig.resolveBazel(importee, importer, baseDir, resolve);
+  if (resolved) {
+    return resolved.replace(/\\/g, '/');
+  } else {
+    fail(`did not resolve path for import ${importee} (from ${importer})`);
+  }
 }
 
 describe('rollup config', () => {
-  fit('should resolve relative imports', () => {
+  it('should resolve relative imports', () => {
     expect(doResolve(
                `.${sep}a`,
-               join(baseDir, 'bazel-bin', 'path', 'to', 'b.esm5', 'some_wksp', 'path', 'to', 'b')))
-        .toEqual(`${baseDir}/bazel-bin/path/to/b.esm5/some_wksp/path/to/a/index.js`);
+               join(
+                   baseDir, 'bazel-bin', 'path', 'to', 'b.esm5', 'external', 'some_wksp', 'path',
+                   'to', 'b')))
+        .toEqual(`${baseDir}/bazel-bin/path/to/b.esm5/external/some_wksp/path/to/a/index.js`);
     expect(doResolve(
                `..${sep}a`,
                join(
-                   baseDir, 'bazel-bin', 'path', 'to', 'b.esm5', 'some_wksp', 'path', 'to', 'b',
-                   'sub')))
-        .toEqual(`${baseDir}/bazel-bin/path/to/b.esm5/some_wksp/path/to/a/index.js`);
+                   baseDir, 'bazel-bin', 'path', 'to', 'b.esm5', 'external', 'some_wksp', 'path',
+                   'to', 'b', 'sub')))
+        .toEqual(`${baseDir}/bazel-bin/path/to/b.esm5/external/some_wksp/path/to/a/index.js`);
+  });
+
+  it('should resolve relative imports from other root', () => {
+    expect(doResolve(
+               `.${sep}public_api`,
+               join(
+                   baseDir, 'bazel-bin', 'path', 'to', 'b.esm5', 'external', 'some_wksp', 'path',
+                   'to', 'a', 'index.js')))
+        .toEqual(`${baseDir}/bazel-bin/path/to/a.esm5/external/some_wksp/path/to/a/public_api.js`);
   });
 
   it('should find paths using module mapping', () => {
-    expect(doResolve('foo/bar'))
-        .toEqual(`${baseDir}/bazel-bin/path/to/a.esm5/my_workspace/path/to/foo_lib/bar`);
-    expect(doResolve('other/thing'))
-        .toEqual(`${baseDir}/bazel-bin/path/to/b.esm5/other_wksp/path/to/other_lib/thing`);
+    expect(doResolve(`foo${sep}bar`))
+        .toEqual(`${baseDir}/bazel-bin/path/to/a.esm5/path/to/foo_lib/bar`);
+    expect(doResolve(`other${sep}thing`))
+        .toEqual(`${baseDir}/bazel-bin/path/to/b.esm5/external/other_wksp/path/to/other_lib/thing`);
   });
 
   it('should find paths in any root', () => {
-    expect(doResolve('my_workspace/path/to/foo_lib/bar'))
-        .toEqual(`${baseDir}/bazel-bin/path/to/a.esm5/my_workspace/path/to/foo_lib/bar`);
-    expect(doResolve('some_wksp/path/to/a'))
-        .toEqual(`${baseDir}/bazel-bin/path/to/b.esm5/some_wksp/path/to/a/index.js`);
+    expect(doResolve('path/to/foo_lib/bar'))
+        .toEqual(`${baseDir}/bazel-bin/path/to/a.esm5/path/to/foo_lib/bar`);
+    expect(doResolve('external/some_wksp/path/to/a'))
+        .toEqual(`${baseDir}/bazel-bin/path/to/b.esm5/external/some_wksp/path/to/a/index.js`);
   })
 });


### PR DESCRIPTION
- the tests were not running because of an fit, and some were broken at head :(
- I changed re-rooting to look like execroot, so it uses external/wksp
- handle the case of a relative import across roots