### PR TITLE
Add Windows to .bazelci/presubmit.yml.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,20 +4,27 @@ platforms:
     run_targets:
     - "@yarn//:yarn"
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."
   ubuntu1604:
     run_targets:
     - "@yarn//:yarn"
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."
   macos:
     run_targets:
     - "@yarn//:yarn"
     build_targets:
-    - "..."
+    - "//..."
     test_targets:
-    - "..."
+    - "//..."
+  windows:
+    run_targets:
+    - "@yarn//:yarn"
+    build_targets:
+    - "//..."
+    test_targets:
+    - "//..."


### PR DESCRIPTION
Our Buildkite CI has working Windows agents now, so do you want to give this a try?

Do you need anything installed on the Windows machines (e.g. nodejs)?

(FYI @buchgr)