### PR TITLE
Add version stamping to npm_package

### DIFF
--- a/internal/e2e/rollup/versions.txt
+++ b/internal/e2e/rollup/versions.txt
@@ -1,23 +1,4 @@
-# Normally this file should be generated via Bazel as follows:
-#
-# 1) tools/bazel.rc should set this command
-#   build --workspace_status_command=./tools/bazel_stamp_vars.sh
-#
-# 2) tools/bazel_stamp_vars.sh is a script that exports some variables:
-#   #!/usr/bin/env bash
-#   BUILD_SCM_VERSION=$(git describe --abbrev=7 --tags HEAD)
-#
-# 3) a genrule() with stamp=True can read the result
-#   native.genrule(
-#     name = "my_stamp_data",
-#     outs = ["stamp_data.txt"],
-#     stamp = True,
-#     cmd = "cat bazel-out/volatile-status.txt > $@",
-#   )
-# 4) Now you can pass this value to the stamp_data attribute of rollup_bundle:
-#    stamp_data = ":stamp_data.txt"
-#
-# See https://www.kchodorow.com/blog/2017/03/27/stamping-your-builds/
+# Normally this file should be generated via Bazel as described in the README.md
 
 # For this test, we just hard-code a value:
 BUILD_SCM_VERSION 1.2.3

--- a/internal/npm_package/npm_package.bzl
+++ b/internal/npm_package/npm_package.bzl
@@ -27,6 +27,7 @@ def create_package(ctx, devmode_sources):
   package_dir = ctx.actions.declare_directory(ctx.label.name)
 
   args = ctx.actions.args()
+  args.use_param_file("%s", use_always = True)
   args.add(package_dir.path)
   args.add(ctx.label.package)
   args.add([s.path for s in ctx.files.srcs], join_with=",")
@@ -35,10 +36,15 @@ def create_package(ctx, devmode_sources):
   args.add([s.path for s in devmode_sources], join_with=",")
   args.add(ctx.attr.replacements)
   args.add([ctx.outputs.pack.path, ctx.outputs.publish.path])
+  args.add(ctx.file.stamp_data.path if ctx.file.stamp_data else '')
+
+  inputs = ctx.files.srcs + devmode_sources + [ctx.file._run_npm_template]
+  if ctx.file.stamp_data:
+    inputs.append(ctx.file.stamp_data)
 
   ctx.action(
       executable = ctx.executable._packager,
-      inputs = ctx.files.srcs + devmode_sources + [ctx.file._run_npm_template],
+      inputs = inputs,
       outputs = [package_dir, ctx.outputs.pack, ctx.outputs.publish],
       arguments = [args],
   )
@@ -59,6 +65,7 @@ NPM_PACKAGE_ATTRS = {
     "srcs": attr.label_list(allow_files = True),
     "deps": attr.label_list(aspects = [sources_aspect]),
     "replacements": attr.string_dict(),
+    "stamp_data": attr.label(allow_single_file = FileType([".txt"])),
     "_packager": attr.label(
         default = Label("//internal/npm_package:packager"),
         cfg = "host", executable = True),

--- a/internal/npm_package/packager.js
+++ b/internal/npm_package/packager.js
@@ -33,17 +33,33 @@ function write(p, content, replacements) {
   fs.writeFileSync(p, content);
 }
 
-// TODO(alexeagle): add support for version stamping, we might want to replace
-// the version number in some of the files (eg. take the latest git tag and
-// overwrite the version in package.json)
+function unquoteArgs(s) {
+  return s.replace(/^'(.*)'$/, '$1');
+}
 
 function main(args) {
-  const [outDir, baseDir, srcsArg, binDir, genDir, depsArg, replacementsArg, packPath, publishPath] = args;
+  args = fs.readFileSync(args[0], {encoding: 'utf-8'}).split('\n').map(unquoteArgs);
+  const
+      [outDir, baseDir, srcsArg, binDir, genDir, depsArg, replacementsArg, packPath, publishPath,
+       stampFile] = args;
 
   const replacements = [
     // Strip content between BEGIN-INTERNAL / END-INTERNAL comments
     [/(#|\/\/)\s+BEGIN-INTERNAL[\w\W]+END-INTERNAL/g, ''],
   ];
+  if (stampFile) {
+    // The stamp file is expected to look like
+    // BUILD_SCM_HASH 83c699db39cfd74526cdf9bebb75aa6f122908bb
+    // BUILD_SCM_LOCAL_CHANGES true
+    // BUILD_SCM_VERSION 6.0.0-beta.6+12.sha-83c699d.with-local-changes
+    // BUILD_TIMESTAMP 1520021990506
+    const version = fs.readFileSync(stampFile, {encoding: 'utf-8'})
+                        .split('\n')
+                        .find(s => s.startsWith('BUILD_SCM_VERSION'))
+                        .split(' ')[1]
+                        .trim();
+    replacements.push([/0.0.0-PLACEHOLDER/g, version]);
+  }
   const rawReplacements = JSON.parse(replacementsArg);
   for (let key of Object.keys(rawReplacements)) {
     replacements.push([new RegExp(key, 'g'), rawReplacements[key]])


### PR DESCRIPTION
This is needed to produce the `@angular/bazel` package.
Also add missing stamping docs to the README