### PR TITLE
Add ability for npm_package to include other npm_package's

### DIFF
--- a/internal/npm_package/npm_package.bzl
+++ b/internal/npm_package/npm_package.bzl
@@ -34,11 +34,12 @@ def create_package(ctx, devmode_sources):
   args.add(ctx.bin_dir.path)
   args.add(ctx.genfiles_dir.path)
   args.add([s.path for s in devmode_sources], join_with=",")
+  args.add([p.path for p in ctx.files.packages], join_with=",")
   args.add(ctx.attr.replacements)
   args.add([ctx.outputs.pack.path, ctx.outputs.publish.path])
   args.add(ctx.file.stamp_data.path if ctx.file.stamp_data else '')
 
-  inputs = ctx.files.srcs + devmode_sources + [ctx.file._run_npm_template]
+  inputs = ctx.files.srcs + devmode_sources + ctx.files.packages + [ctx.file._run_npm_template]
   if ctx.file.stamp_data:
     inputs.append(ctx.file.stamp_data)
 
@@ -64,6 +65,7 @@ def _npm_package(ctx):
 NPM_PACKAGE_ATTRS = {
     "srcs": attr.label_list(allow_files = True),
     "deps": attr.label_list(aspects = [sources_aspect]),
+    "packages": attr.label_list(allow_files = True),
     "replacements": attr.string_dict(),
     "stamp_data": attr.label(allow_single_file = FileType([".txt"])),
     "_packager": attr.label(

--- a/internal/npm_package/test/BUILD.bazel
+++ b/internal/npm_package/test/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//:defs.bzl", "npm_package", "jasmine_node_test")
+
+genrule(
+    name = "produces_files",
+    outs = ["a_dep"],
+    cmd = "echo \"a_dep content\" > $@",
+)
+
+npm_package(
+    name = "dependent_pkg",
+    srcs = ["dependent_file"],
+)
+
+npm_package(
+    name = "test_pkg",
+    srcs = ["some_file"],
+    packages = [":dependent_pkg"],
+    replacements = {"replace_me": "replaced"},
+    deps = [":produces_files"],
+)
+
+jasmine_node_test(
+    name = "test",
+    srcs = ["npm_package.spec.js"],
+    data = [":test_pkg"],
+    node_modules = "//internal/test:node_modules",
+)

--- a/internal/npm_package/test/dependent_file
+++ b/internal/npm_package/test/dependent_file
@@ -1,0 +1,1 @@
+dependent_file content

--- a/internal/npm_package/test/npm_package.spec.js
+++ b/internal/npm_package/test/npm_package.spec.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+function read(p) {
+  // We want to look up the test_pkg directory artifact in the runfiles.
+  // The manifest does have an entry for it, but since it's a directory we cannot use require.resolve
+  // to lookup that entry.
+  // So instead we lookup the sibling file (the primary output of the test rule)
+  // and bootstrap the filesystem lookup from there.
+  const dir = path.dirname(require.resolve('build_bazel_rules_nodejs/internal/npm_package/test/test'));
+  return fs.readFileSync(path.join(dir, 'test_pkg', p), {encoding: 'utf-8'}).trim();
+}
+
+describe('npm_package srcs', () => {
+  it('copies srcs and replaces contents', () => {
+    expect(read('some_file')).toEqual('replaced');
+  });
+  it('copies dependencies from bazel-genfiles', () => {
+    expect(read('a_dep')).toEqual('a_dep content');
+  });
+  it('copies files from other packages', () => {
+    expect(read('dependent_file')).toEqual('dependent_file content');
+  });
+});

--- a/internal/npm_package/test/some_file
+++ b/internal/npm_package/test/some_file
@@ -1,0 +1,1 @@
+replace_me


### PR DESCRIPTION
this allows ng_package rule to be a macro composing some special packaging with a regular npm_package, reducing duplication