### PR TITLE
Capture all stack frames in tests

### DIFF
--- a/internal/e2e/node/jasmine_node_test.spec.js
+++ b/internal/e2e/node/jasmine_node_test.spec.js
@@ -1,0 +1,55 @@
+describe('jasmine_node_test', () => {
+  it('should capture all stack frames', () => {
+    try {
+      deepThrow0();
+      fail();
+    } catch (e) {
+      const trace = e.stack;
+      const lines = trace.split(/\n/);
+      // Assert that we capture more than 10 frames (the default);
+      expect(lines.length > 12).toBeTruthy();
+      expect(trace.indexOf('deepThrow0')).toBeTruthy();
+      expect(trace.indexOf('deepThrow12')).toBeTruthy();
+    }
+  });
+});
+
+function deepThrow0() {
+  deepThrow1();
+}
+function deepThrow1() {
+  deepThrow2();
+}
+function deepThrow2() {
+  deepThrow3();
+}
+function deepThrow3() {
+  deepThrow4();
+}
+function deepThrow4() {
+  deepThrow5();
+}
+function deepThrow5() {
+  deepThrow6();
+}
+function deepThrow6() {
+  deepThrow7();
+}
+function deepThrow7() {
+  deepThrow8();
+}
+function deepThrow8() {
+  deepThrow9();
+}
+function deepThrow9() {
+  deepThrow10();
+}
+function deepThrow10() {
+  deepThrow11();
+}
+function deepThrow11() {
+  deepThrow12();
+}
+function deepThrow12() {
+  throw new Error('Deep Stack');
+}

--- a/internal/jasmine_node_test/jasmine_runner.js
+++ b/internal/jasmine_node_test/jasmine_runner.js
@@ -11,6 +11,11 @@ const UTF8 = {
 const BAZEL_EXIT_TESTS_FAILED = 3;
 const BAZEL_EXIT_NO_TESTS_FOUND = 4;
 
+// Set the StackTraceLimit to infinity. This will make stack capturing slower, but more useful.
+// Since we are running tests having proper stack traces is very useful and should be always set to
+// the maximum (See: https://nodejs.org/api/errors.html#errors_error_stacktracelimit)
+Error.stackTraceLimit = Infinity;
+
 function main(args) {
   if (!args.length) {
     throw new Error('Spec file manifest expected argument missing');


### PR DESCRIPTION
By default V8 only captures 10 stack frames. This makes debugging hard
and most developers don’t know how to get more stack frames to show up.
Since this is for running tests, the penalty of slower stack capture 
is more than offset by better debugging experience.