### PR TITLE
Use ctx.version_file in place of a genrule with stamp=True

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,26 +206,9 @@ Bazel supports this natively, using the following approach:
 
    For a more full-featured script, take a look at the [bazel_stamp_vars in Angular]
 
-1) A `genrule()` with `stamp=True` can read the result.
-   Bazel puts the output of the `bazel_stamp_vars.sh` in the magic location `bazel-out/volatile-status.txt`.
-   (Note, this doesn't require that you actually have a `bazel-out` folder in your project.)
-   We recommend adding this target to your `tools/BAZEL.build`:
+Ideally, `rollup_bundle` and `npm_package` should honor the `--stamp` argument to `bazel build`. However this is not currently possible, see https://github.com/bazelbuild/bazel/issues/1054
 
-    ```python
-    genrule(
-        name = "stamp_data",
-        outs = ["stamp_data.txt"],
-        cmd = "cat bazel-out/volatile-status.txt > $@",
-        stamp = True,
-        visibility = ["//:__subpackages__"],
-    )
-    ```
-
-1) Now you can pass this target to the `stamp_data` attribute of `rollup_bundle` or `npm_package`:
-
-    ```python
-    stamp_data = "//tools:stamp_data"
-    ```
+> WARNING: Bazel doesn't rebuild a target if only the result of the workspace_status_command has changed. That means changes to the version information may not be reflected if you re-build the package or bundle, and nothing in the package or bundle has changed.
 
 See https://www.kchodorow.com/blog/2017/03/27/stamping-your-builds/ for more background.
 

--- a/internal/e2e/rollup/BUILD.bazel
+++ b/internal/e2e/rollup/BUILD.bazel
@@ -10,7 +10,6 @@ rollup_bundle(
     entry_point = "internal/e2e/rollup/foo.js",
     license_banner = ":license.txt",
     node_modules = "//internal/test:node_modules",
-    stamp_data = ":versions.txt",
     deps = ["//internal/e2e/rollup/fum:fumlib"],
 )
 

--- a/internal/e2e/rollup/versions.txt
+++ b/internal/e2e/rollup/versions.txt
@@ -1,4 +1,0 @@
-# Normally this file should be generated via Bazel as described in the README.md
-
-# For this test, we just hard-code a value:
-BUILD_SCM_VERSION 1.2.3

--- a/internal/rollup/rollup_bundle.bzl
+++ b/internal/rollup/rollup_bundle.bzl
@@ -70,7 +70,7 @@ def write_rollup_config(ctx, plugins=[], root_dirs=None, filename="_%s.rollup.co
           "TMPL_module_mappings": str(mappings),
           "TMPL_additional_plugins": ",\n".join(plugins),
           "TMPL_banner_file": "\"%s\"" % ctx.file.license_banner.path if ctx.file.license_banner else "undefined",
-          "TMPL_stamp_data": "\"%s\"" % ctx.file.stamp_data.path if ctx.file.stamp_data else "undefined",
+          "TMPL_stamp_data": "\"%s\"" % ctx.version_file.path if ctx.version_file else "undefined",
       })
 
   return config
@@ -93,8 +93,8 @@ def run_rollup(ctx, sources, config, output):
   inputs = sources + ctx.files.node_modules + [config]
   if ctx.file.license_banner:
     inputs += [ctx.file.license_banner]
-  if ctx.file.stamp_data:
-    inputs += [ctx.file.stamp_data]
+  if ctx.version_file:
+    inputs += [ctx.version_file]
 
   ctx.action(
       executable = ctx.executable._rollup,
@@ -185,7 +185,6 @@ ROLLUP_ATTRS = {
     "deps": attr.label_list(aspects = [rollup_module_mappings_aspect]),
     "node_modules": attr.label(default = Label("@//:node_modules")),
     "license_banner": attr.label(allow_single_file = FileType([".txt"])),
-    "stamp_data": attr.label(allow_single_file = FileType([".txt"])),
     "_rollup": attr.label(
         executable = True,
         cfg="host",

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -2,3 +2,6 @@ test --test_output=errors
 build --symlink_prefix=/
 
 build:ci --noshow_progress
+
+# Mock versoning command to test the --stamp behavior
+build --workspace_status_command="echo BUILD_SCM_VERSION 1.2.3"


### PR DESCRIPTION
Fixes #156

See discussion in https://github.com/bazelbuild/bazel/issues/4842
and this fix is based on https://github.com/bazelbuild/bazel/issues/1054#issuecomment-219151351
