### PR TITLE
Pass node_modules location to rollup bundler.

### DIFF
--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -120,6 +120,12 @@ module.exports = {
   },
   plugins: [TMPL_additional_plugins].concat([
     {resolveId: resolveBazel},
-    nodeResolve({jsnext: true, module: true}),
+    nodeResolve({
+        jsnext: true,
+        module: true,
+        customResolveOptions: {
+            moduleDirectory: TMPL_node_modules_common_prefix,
+        }
+    }),
   ])
 }


### PR DESCRIPTION
The assumption is that all `node_modules` have a common root path, which should be safe since most javascript tools seem to operate with this assumption anyways.

Without this patch, external node_modules, i.e. tracked by bazel are not found by rollup. This change does not change anything if node_modules is in your root path - which seems to be the common case for users of this repository.