### PR TITLE
Fix(rollup): escape rootDir path (fixes #180)

### DIFF
--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -123,4 +123,3 @@ module.exports = {
     sourcemaps(),
   ])
 }
-v

--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -24,9 +24,9 @@ Rollup: running with
 
 // This resolver mimics the TypeScript Path Mapping feature, which lets us resolve
 // modules based on a mapping of short names to paths.
-function resolveBazel(importee, importer, baseDir = process.cwd(), resolve = require.resolve) {
+function resolveBazel(importee, importer, baseDir = process.cwd(), resolve = require.resolve, root = rootDir) {
   function resolveInRootDir(importee) {
-    var candidate = path.join(baseDir, rootDir, importee);
+    var candidate = path.join(baseDir, root, importee);
     if (DEBUG) console.error('Rollup: try to resolve at', candidate);
     try {
       var result = resolve(candidate);
@@ -48,7 +48,7 @@ function resolveBazel(importee, importer, baseDir = process.cwd(), resolve = req
     // relative import
     if (importer) {
       let importerRootRelative = path.dirname(importer);
-      const relative = path.relative(path.join(baseDir, rootDir), importerRootRelative);
+      const relative = path.relative(path.join(baseDir, root), importerRootRelative);
       if (!relative.startsWith('.')) {
         importerRootRelative = relative;
       }
@@ -123,3 +123,4 @@ module.exports = {
     sourcemaps(),
   ])
 }
+v

--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -11,7 +11,7 @@ const DEBUG = false;
 
 const moduleMappings = TMPL_module_mappings;
 const workspaceName = 'TMPL_workspace_name';
-const rootDir = TMPL_rootDir;
+const rootDir = 'TMPL_rootDir';
 const banner_file = TMPL_banner_file;
 const stamp_data = TMPL_stamp_data;
 

--- a/internal/rollup/rollup.config.spec.js
+++ b/internal/rollup/rollup.config.spec.js
@@ -6,7 +6,6 @@ TMPL_module_mappings = {
 };
 
 const rootDir = 'bazel-bin/path/to/a.esm5';
-TMPL_workspace_name = 'my_workspace';
 TMPL_additional_plugins = [];
 TMPL_banner_file = '';
 TMPL_stamp_data = '';

--- a/internal/rollup/rollup.config.spec.js
+++ b/internal/rollup/rollup.config.spec.js
@@ -5,7 +5,7 @@ TMPL_module_mappings = {
   'other': 'external/other_wksp/path/to/other_lib',
 };
 
-TMPL_rootDir = 'bazel-bin/path/to/a.esm5';
+const rootDir = 'bazel-bin/path/to/a.esm5';
 TMPL_workspace_name = 'my_workspace';
 TMPL_additional_plugins = [];
 TMPL_banner_file = '';
@@ -30,7 +30,7 @@ const resolve =
 const rollupConfig = require('./rollup.config');
 
 function doResolve(importee, importer) {
-  const resolved = rollupConfig.resolveBazel(importee, importer, baseDir, resolve);
+  const resolved = rollupConfig.resolveBazel(importee, importer, baseDir, resolve, rootDir);
   if (resolved) {
     return resolved.replace(/\\/g, '/');
   } else {

--- a/internal/rollup/rollup_bundle.bzl
+++ b/internal/rollup/rollup_bundle.bzl
@@ -76,7 +76,7 @@ def write_rollup_config(ctx, plugins=[], root_dir=None, filename="_%s.rollup.con
       template =  ctx.file._rollup_config_tmpl,
       substitutions = {
           "TMPL_workspace_name": ctx.workspace_name,
-          "TMPL_rootDir": "\"%s\"" % root_dir,
+          "TMPL_rootDir": root_dir,
           "TMPL_global_name": ctx.attr.global_name if ctx.attr.global_name else ctx.label.name,
           "TMPL_module_mappings": str(mappings),
           "TMPL_additional_plugins": ",\n".join(plugins),


### PR DESCRIPTION
The following patch fixes an issue where bazel is undefined during build. This is due to rootDir not being escaped which is allowing node to interpolate the string path as variables.

#180 