### PR TITLE
Only include .js files when collecting devmode outputs of transitive …

### DIFF
--- a/internal/common/sources_aspect.bzl
+++ b/internal/common/sources_aspect.bzl
@@ -34,7 +34,8 @@ def _sources_aspect_impl(target, ctx):
   if hasattr(target, "typescript"):
     result = depset(transitive=[result, target.typescript.es5_sources])
   elif hasattr(target, "files"):
-    result = depset(transitive=[result, target.files])
+    result = depset([f for f in target.files if f.path.endswith(".js")],
+                    transitive=[result])
   return struct(node_sources = result)
 
 sources_aspect = aspect(

--- a/internal/rollup/rollup_bundle.bzl
+++ b/internal/rollup/rollup_bundle.bzl
@@ -244,7 +244,8 @@ def _rollup_bundle(ctx):
   umd_rollup_config = write_rollup_config(ctx, filename = "_%s_umd.rollup.conf.js", output_format = "umd")
   run_rollup(ctx, collect_es6_sources(ctx), umd_rollup_config, ctx.outputs.build_umd)
   run_sourcemapexplorer(ctx, ctx.outputs.build_es5_min, source_map, ctx.outputs.explore_html)
-  return DefaultInfo(files=depset([ctx.outputs.build_es5_min, source_map]))
+  files = [ctx.outputs.build_es5_min, source_map]
+  return DefaultInfo(files = depset(files), runfiles = ctx.runfiles(files))
 
 ROLLUP_ATTRS = {
     "entry_point": attr.string(


### PR DESCRIPTION
…deps