### PR TITLE
Ensure "files" from data attribute of nodejs_binary rule make it into runfiles

### DIFF
--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -85,6 +85,8 @@ def _nodejs_binary_impl(ctx):
     for d in ctx.attr.data:
       if hasattr(d, "node_sources"):
         sources += d.node_sources.to_list()
+      if hasattr(d, "files"):
+        sources += d.files.to_list()
 
     _write_loader_script(ctx)
 


### PR DESCRIPTION
This fixes `//internal/npm_package/test:test` when preserve-symlinks is turned on