### PR TITLE
Include declarations when bundling typescript sources

### DIFF
--- a/examples/program/BUILD.bazel
+++ b/examples/program/BUILD.bazel
@@ -15,7 +15,10 @@ filegroup(
 
 mock_typescript_lib(
     name = "mock_ts_lib",
-    srcs = ["decrement.js"],
+    srcs = [
+        "decrement.d.ts",
+        "decrement.js",
+    ],
 )
 
 # This is like a "js_library", but there are no actions to run on JS files so a

--- a/examples/program/decrement.d.ts
+++ b/examples/program/decrement.d.ts
@@ -1,0 +1,1 @@
+export declare function decrement(n: number): number;

--- a/internal/common/sources_aspect.bzl
+++ b/internal/common/sources_aspect.bzl
@@ -33,6 +33,7 @@ def _sources_aspect_impl(target, ctx):
   # get TypeScript outputs.
   if hasattr(target, "typescript"):
     result = depset(transitive=[result, target.typescript.es5_sources])
+    result = depset(transitive=[result, target.typescript.declarations])
   elif hasattr(target, "files"):
     result = depset([f for f in target.files if f.path.endswith(".js")],
                     transitive=[result])

--- a/internal/common/typescript_mock_lib.bzl
+++ b/internal/common/typescript_mock_lib.bzl
@@ -20,9 +20,14 @@ rules_typescript without introducing a circular dependency.
 
 def _mock_typescript_lib(ctx):
   es5_sources = depset()
+  declarations = depset()
   for s in ctx.attr.srcs:
-    es5_sources = depset(transitive=[es5_sources, s.files])
-  return struct(typescript = struct(es5_sources = es5_sources))
+    declarations = depset([f for f in s.files if f.path.endswith("d.ts")], transitive=[declarations])
+    es5_sources = depset([f for f in s.files if f.path.endswith("js")], transitive=[es5_sources])
+  return struct(typescript = struct(
+    es5_sources = es5_sources,
+    declarations = declarations
+  ))
 
 mock_typescript_lib = rule(
   implementation = _mock_typescript_lib,


### PR DESCRIPTION
When using the npm_package rule and referencing ts_library rules only the direct dependencies declaration files are included. This causes the TypeScript compiler to complain when trying to resolve the import statements.