### PR TITLE
Allow built-in modules to resolve in rollup

### DIFF
--- a/internal/rollup/package.json
+++ b/internal/rollup/package.json
@@ -1,6 +1,7 @@
 {
     "description": "runtime dependencies for rollup_bundle",
     "devDependencies": {
+        "is-builtin-module": "2.0.0",
         "rollup": "0.52.3",
         "rollup-plugin-node-resolve": "3.0.0",
         "rollup-plugin-sourcemaps": "^0.4.2",

--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -4,6 +4,7 @@
 const rollup = require('rollup');
 const nodeResolve = require('rollup-plugin-node-resolve');
 const sourcemaps = require('rollup-plugin-sourcemaps');
+const isBuiltinModule = require('is-builtin-module');
 const path = require('path');
 const fs = require('fs');
 
@@ -114,6 +115,9 @@ if (banner_file) {
 }
 
 function notResolved(importee, importer) {
+  if (isBuiltinModule(importee)) {
+    return null;
+  }
   throw new Error(`Could not resolve import '${importee}' from '${importer}'`);
 }
 

--- a/internal/rollup/yarn.lock
+++ b/internal/rollup/yarn.lock
@@ -53,6 +53,10 @@ builtin-modules@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+builtin-modules@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-2.0.0.tgz#60b7ef5ae6546bd7deefa74b08b62a43a232648e"
+
 commander@~2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
@@ -161,6 +165,12 @@ inherits@2:
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-builtin-module@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-2.0.0.tgz#431104b3b4ba838ec7a17d82bb3bccd2233e8cd9"
+  dependencies:
+    builtin-modules "^2.0.0"
 
 is-dotfile@^1.0.0:
   version "1.0.3"

--- a/internal/test/package.json
+++ b/internal/test/package.json
@@ -1,6 +1,7 @@
 {
   "description": "runtime dependencies for tests",
   "devDependencies": {
+    "is-builtin-module": "^2.0.0",
     "jasmine": "~2.8.0",
     "node_resolve_index": "file:./node_resolve_index",
     "node_resolve_index_2": "file:./node_resolve_index_2",

--- a/internal/test/yarn.lock
+++ b/internal/test/yarn.lock
@@ -49,6 +49,10 @@ builtin-modules@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+builtin-modules@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-2.0.0.tgz#60b7ef5ae6546bd7deefa74b08b62a43a232648e"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -153,6 +157,12 @@ inherits@2:
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-builtin-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-2.0.0.tgz#431104b3b4ba838ec7a17d82bb3bccd2233e8cd9"
+  dependencies:
+    builtin-modules "^2.0.0"
 
 is-dotfile@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
Not sure how I missed this but it is needed along with the resolve check in rollup.