### PR TITLE
Mark _bin test target in test macro as manual

### DIFF
--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -293,6 +293,7 @@ def nodejs_test_macro(name, args=[], visibility=None, tags=[], **kwargs):
   nodejs_test(
       name = "%s_bin" % name,
       testonly = 1,
+      tags = ["manual"],
       **kwargs
   )
 


### PR DESCRIPTION
The nodejs_test macro uses a sh_test wrapper around an internal `%s_bin` target.
However this target is not tagged as "manual" and thus will get matched by
target wildcard, e.g.: `bazel test //...` would run the same test twice
(and probably fail on windows, since that's the documented rationale for having the sh_test
wrapper in the first place).