### PR TITLE
fix(rollup_bundle): Upgrade rollup packages for compatibility

### DIFF
--- a/internal/e2e/rollup/bundle-umd_golden.js_
+++ b/internal/e2e/rollup/bundle-umd_golden.js_
@@ -4,33 +4,33 @@
  */
 
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('some_global_var')) :
-	typeof define === 'function' && define.amd ? define(['exports', 'some_global_var'], factory) :
-	(factory((global.bundle = {}),global.runtime_name_of_global_var));
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('some_global_var')) :
+  typeof define === 'function' && define.amd ? define(['exports', 'some_global_var'], factory) :
+  (factory((global.bundle = {}),global.runtime_name_of_global_var));
 }(this, (function (exports,some_global_var) { 'use strict';
 
-const fum = 'Wonderland';
+  const fum = 'Wonderland';
 
-var hello = 'Hello';
+  var hello = 'Hello';
 
-const name = 'Alice';
+  const name = 'Alice';
 
-console.log(`${hello}, ${name} in ${fum}`);
+  console.log(`${hello}, ${name} in ${fum}`);
 
-// Test for sequences = false
-class A {
-  a() {
-    return document.a;
+  // Test for sequences = false
+  class A {
+    a() {
+      return document.a;
+    }
   }
-}
-function inline_me() {
-  return 'abc';
-}
-console.error(new A().a(), inline_me(), some_global_var.thing);
+  function inline_me() {
+    return 'abc';
+  }
+  console.error(new A().a(), inline_me(), some_global_var.thing);
 
-exports.A = A;
+  exports.A = A;
 
-Object.defineProperty(exports, '__esModule', { value: true });
+  Object.defineProperty(exports, '__esModule', { value: true });
 
 })));
 //# sourceMappingURL=bundle.umd.js.map

--- a/internal/rollup/package.json
+++ b/internal/rollup/package.json
@@ -2,8 +2,8 @@
     "description": "runtime dependencies for rollup_bundle",
     "devDependencies": {
         "is-builtin-module": "2.0.0",
-        "rollup": "0.52.3",
-        "rollup-plugin-node-resolve": "3.0.0",
+        "rollup": "0.59.3",
+        "rollup-plugin-node-resolve": "3.3.0",
         "rollup-plugin-sourcemaps": "^0.4.2",
         "source-map-explorer": "^1.5.0",
         "typescript": "2.6.2",

--- a/internal/rollup/yarn.lock
+++ b/internal/rollup/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+
+"@types/node@*":
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.1.2.tgz#1b928a0baa408fc8ae3ac012cc81375addc147c6"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -39,19 +47,9 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-browser-resolve@^1.11.0:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
-  dependencies:
-    resolve "1.1.7"
-
 btoa@^1.1.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
-
-builtin-modules@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
 builtin-modules@^2.0.0:
   version "2.0.0"
@@ -343,10 +341,6 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-
 resolve@^1.1.6:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
@@ -357,12 +351,11 @@ rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
-rollup-plugin-node-resolve@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz#8b897c4c3030d5001277b0514b25d2ca09683ee0"
+rollup-plugin-node-resolve@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.3.0.tgz#c26d110a36812cbefa7ce117cadcd3439aa1c713"
   dependencies:
-    browser-resolve "^1.11.0"
-    builtin-modules "^1.1.0"
+    builtin-modules "^2.0.0"
     is-module "^1.0.0"
     resolve "^1.1.6"
 
@@ -380,9 +373,12 @@ rollup-pluginutils@^2.0.1:
     estree-walker "^0.3.0"
     micromatch "^2.3.11"
 
-rollup@0.52.3:
-  version "0.52.3"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.52.3.tgz#020d99fffe9619351e47b3894fd397c26f5e1bf6"
+rollup@0.59.3:
+  version "0.59.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.59.3.tgz#15dae74cb1b6a6b39a63c7096c1d6f47d8f2a5bd"
+  dependencies:
+    "@types/estree" "0.0.39"
+    "@types/node" "*"
 
 source-map-explorer@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
This PR fixes compatibility with `ts_proto_library` which uses `protobufjs` under the covers. `protobufjs` is affected by this rollup issue: https://github.com/rollup/rollup/issues/1859 . That issue is fixed in upstream releases so I upgraded all rollup packages to their latest release.