### PR TITLE
Handle .d.ts module roots in nodejs loader

### DIFF
--- a/internal/e2e/node/BUILD.bazel
+++ b/internal/e2e/node/BUILD.bazel
@@ -4,9 +4,10 @@ jasmine_node_test(
     name = "test",
     srcs = [
         "jasmine_node_test.spec.js",
-        "rollup.spec.js",
+        "module_resolution.spec.js",
     ],
     node_modules = "//internal/test:node_modules",
+    deps = ["//internal/e2e/node/lib1"],
 )
 
 jasmine_node_test(

--- a/internal/e2e/node/lib1/BUILD.bazel
+++ b/internal/e2e/node/lib1/BUILD.bazel
@@ -1,0 +1,11 @@
+package(default_visibility = ["//internal:__subpackages__"])
+
+load("//internal/js_library:js_library.bzl", "js_library")
+
+js_library(
+    name = "lib1",
+    srcs = glob(["**/*.js"]),
+    module_name = "lib1",
+    # Don't allow deep imports under here
+    module_root = "src/index.d.ts",
+)

--- a/internal/e2e/node/lib1/src/index.js
+++ b/internal/e2e/node/lib1/src/index.js
@@ -1,0 +1,2 @@
+var foo_1 = require('./some');
+exports.a = foo_1.a;

--- a/internal/e2e/node/lib1/src/some.js
+++ b/internal/e2e/node/lib1/src/some.js
@@ -1,0 +1,1 @@
+exports.a = 'lib1 content';

--- a/internal/e2e/node/module_resolution.spec.js
+++ b/internal/e2e/node/module_resolution.spec.js
@@ -5,6 +5,8 @@ const node_resolve_index_4 = require('node_resolve_index_4');
 const node_resolve_main = require('node_resolve_main');
 const node_resolve_main_2 = require('node_resolve_main_2');
 const node_resolve_nested_main = require('node_resolve_nested_main');
+const lib1 = require('lib1');
+const lib1some = require('lib1/src/some');
 
 describe('node npm resolution', () => {
   it('should resolve to index.js by default', () => {
@@ -27,5 +29,11 @@ describe('node npm resolution', () => {
   });
   it('should resolve to main.js from a nested package.json', () => {
     expect(node_resolve_nested_main).toEqual('node_resolve_nested_main');
+  });
+  it('should resolve a nested index', () => {
+    expect(lib1.a).toEqual('lib1 content');
+  });
+  it('should be able to deep-import from a nested src dir', () => {
+    expect(lib1some.a).toEqual('lib1 content');
   });
 });


### PR DESCRIPTION
This allows libraries to have a nested structure where the index file is in a subdirectory of the package where the js_library/ts_library rule is declared.

Fixes #220