### PR TITLE
Downgrade to bazel 0.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@
 
 ## IMPORTANT
 # If you change the `docker_image` version, also change the `cache_key` version
-var_1: &docker_image angular/ngcontainer:0.3.1
-var_2: &cache_key angular/ngcontainer:0.3.1-{{ .Branch }}-{{ checksum "yarn.lock" }}-examples/rollup:{{ checksum "examples/rollup/yarn.lock" }}-examples/program:{{ checksum "examples/program/yarn.lock" }}-internal/test:{{ checksum "internal/test/yarn.lock" }}
+var_1: &docker_image angular/ngcontainer:0.3.0
+var_2: &cache_key angular/ngcontainer:0.3.0-{{ .Branch }}-{{ checksum "yarn.lock" }}-examples/rollup:{{ checksum "examples/rollup/yarn.lock" }}-examples/program:{{ checksum "examples/program/yarn.lock" }}-internal/test:{{ checksum "internal/test/yarn.lock" }}
 var_3: &setup-bazel-remote-cache
   run:
     name: Start up bazel remote cache proxy

--- a/internal/jasmine_node_test/jasmine_node_test.bzl
+++ b/internal/jasmine_node_test/jasmine_node_test.bzl
@@ -48,7 +48,6 @@ def jasmine_node_test(
   all_data = data + srcs + deps
   all_data += [Label("//internal/jasmine_node_test:jasmine_runner.js")]
   all_data += [":%s_devmode_srcs.MF" % name]
-  all_data += [Label("@bazel_tools//tools/bash/runfiles")]
   entry_point = "build_bazel_rules_nodejs/internal/jasmine_node_test/jasmine_runner.js"
 
   nodejs_test(

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -239,7 +239,7 @@ The runtime will pause before executing the program, allowing you to connect a
 remote debugger.
 """
 
-def nodejs_binary_macro(name, data=[], args=[], visibility=None, tags=[], testonly=0, **kwargs):
+def nodejs_binary_macro(name, args=[], visibility=None, tags=[], testonly=0, **kwargs):
   """This macro exists only to wrap the nodejs_binary as an .exe for Windows.
 
   This is exposed in the public API at `//:defs.bzl` as `nodejs_binary`, so most
@@ -247,7 +247,6 @@ def nodejs_binary_macro(name, data=[], args=[], visibility=None, tags=[], teston
 
   Args:
     name: name of the label
-    data: runtime dependencies
     args: applied to the wrapper binary
     visibility: applied to the wrapper binary
     tags: applied to the wrapper binary
@@ -256,7 +255,6 @@ def nodejs_binary_macro(name, data=[], args=[], visibility=None, tags=[], teston
   """
   nodejs_binary(
       name = "%s_bin" % name,
-      data = data + ["@bazel_tools//tools/bash/runfiles"],
       testonly = testonly,
       visibility = ["//visibility:private"],
       **kwargs
@@ -272,7 +270,7 @@ def nodejs_binary_macro(name, data=[], args=[], visibility=None, tags=[], teston
       visibility = visibility,
   )
 
-def nodejs_test_macro(name, data=[], args=[], visibility=None, tags=[], **kwargs):
+def nodejs_test_macro(name, args=[], visibility=None, tags=[], **kwargs):
   """This macro exists only to wrap the nodejs_test as an .exe for Windows.
 
   This is exposed in the public API at `//:defs.bzl` as `nodejs_test`, so most
@@ -280,7 +278,6 @@ def nodejs_test_macro(name, data=[], args=[], visibility=None, tags=[], **kwargs
 
   Args:
     name: name of the label
-    data: runtime dependencies
     args: applied to the wrapper binary
     visibility: applied to the wrapper binary
     tags: applied to the wrapper binary
@@ -288,7 +285,6 @@ def nodejs_test_macro(name, data=[], args=[], visibility=None, tags=[], **kwargs
   """
   nodejs_test(
       name = "%s_bin" % name,
-      data = data + ["@bazel_tools//tools/bash/runfiles"],
       testonly = 1,
       tags = ["manual"],
       **kwargs

--- a/internal/node/node_launcher.sh
+++ b/internal/node/node_launcher.sh
@@ -15,32 +15,6 @@
 
 set -e
 
-# --- begin runfiles.bash initialization ---
-# Source the runfiles library:
-# https://github.com/bazelbuild/bazel/blob/master/tools/bash/runfiles/runfiles.bash
-# The runfiles library defines rlocation, which is a platform independent function
-# used to lookup the runfiles locations. This code snippet is needed at the top
-# of scripts that use rlocation to lookup the location of runfiles.bash and source it
-if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-    if [[ -f "$0.runfiles_manifest" ]]; then
-      export RUNFILES_MANIFEST_FILE="$0.runfiles_manifest"
-    elif [[ -f "$0.runfiles/MANIFEST" ]]; then
-      export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
-    elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-      export RUNFILES_DIR="$0.runfiles"
-    fi
-fi
-if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
-elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
-  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \
-            "$RUNFILES_MANIFEST_FILE" | cut -d ' ' -f 2-)"
-else
-  echo >&2 "ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash"
-  exit 1
-fi
-# --- end runfiles.bash initialization ---
-
 # Launcher for NodeJS applications.
 # Find our runfiles. We need this to launch node with the correct
 # entry point.
@@ -113,9 +87,35 @@ TEMPLATED_env_vars
 # This redirects to stderr so it doesn't interfere with Bazel's worker protocol
 # find . -name thingImLookingFor 1>&2
 
-readonly node=$(rlocation "TEMPLATED_node")
-readonly repository_args=$(rlocation "TEMPLATED_repository_args")
-readonly script=$(rlocation "TEMPLATED_script_path")
+# On Windows, the runfiles symlink tree does not exist, so we must resolve paths
+# using the mapping in the runfiles_manifest file.
+# See https://github.com/bazelbuild/bazel/issues/3726
+readonly MANIFEST="${RUNFILES}/MANIFEST"
+if [ -e "${MANIFEST}" ]; then
+  # Lookup the real paths from the runfiles manifest with no dependency on posix
+  while read line; do
+    declare -a PARTS=($line)
+    if [ "${PARTS[0]}" == "TEMPLATED_node" ]; then
+      readonly node="${PARTS[1]}"
+    elif [ "${PARTS[0]}" == "TEMPLATED_repository_args" ]; then
+      readonly repository_args="${PARTS[1]}"
+    elif [ "${PARTS[0]}" == "TEMPLATED_script_path" ]; then
+      readonly script="${PARTS[1]}"
+    fi
+  done < ${MANIFEST}
+  if [ -z "${node}" ]; then
+    echo "Failed to find node binary TEMPLATED_node in manifest ${MANIFEST}"
+    exit 1
+  fi
+  if [ -z "${script}" ]; then
+    echo "Failed to find script TEMPLATED_script_path in manifest ${MANIFEST}"
+    exit 1
+  fi
+else
+  readonly node="${RUNFILES}/TEMPLATED_node"
+  readonly repository_args="${RUNFILES}/TEMPLATED_repository_args"
+  readonly script="${RUNFILES}/TEMPLATED_script_path"
+fi
 
 source $repository_args
 

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -428,8 +428,8 @@ def node_repositories(
       files need to be included in your node_modules filegroup. This option is desirable as it gives a stronger
       guarantee of hermiticity which is required for remote execution.
   """
-  # @bazel_tools//tools/bash/runfiles is required for nodejs
-  check_bazel_version("0.14.0")
+  # Windows users need sh_binary wrapped as an .exe
+  check_bazel_version("0.5.4")
 
   _nodejs_repo(
     name = "nodejs",


### PR DESCRIPTION
Bazel 0.14.0 & 0.14.1 show random out of memory crashes on CircleCI. Downgrading to bazel 0.13.0 and removing the 0.14.0 requirement recently introduced because of `@bazel_tools//tools/bash/runfiles`.