### PR TITLE
Add node_modules/.bin/* to yarn_install and npm_install

### DIFF
--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -40,7 +40,7 @@ filegroup(
             # e.g. node_modules/puppeteer/.local-chromium/mac-536395/chrome-mac/Chromium.app/Contents/Versions/66.0.3347.0/Chromium Framework.framework/Chromium Framework
             "node_modules/**/.*/**"
         ],
-    ),
+    ) + glob(["node_modules/.bin/*"]),
 )
 """)
 


### PR DESCRIPTION
According to this issue: https://github.com/bazelbuild/rules_nodejs/issues/155 .bin directory is not available in node_modules target. 

This behaviour was introduced with https://github.com/bazelbuild/rules_nodejs/pull/130