### PR TITLE
Forward termination signals to node process.

### DIFF
--- a/internal/node/node_launcher.sh
+++ b/internal/node/node_launcher.sh
@@ -135,11 +135,15 @@ _term() {
   kill -TERM "$child" 2>/dev/null
 }
 
+_int() {
+  kill -INT "$child" 2>/dev/null
+}
+
 set +e
 "${node}" "${NODE_OPTIONS[@]}" "${script}" "${ARGS[@]}" &
 child=$!
 trap _term SIGTERM
-trap _term SIGINT
+trap _int SIGINT
 wait "$child"
 RESULT="$?"
 set -e

--- a/internal/node/node_launcher.sh
+++ b/internal/node/node_launcher.sh
@@ -129,8 +129,19 @@ for ARG in "${ALL_ARGS[@]}"; do
   esac
 done
 
+# Note: Bash does not forward any termination signals to any child process when running in docker
+# so need to manually trap and forward the signals
+_term() {
+  kill -TERM "$child" 2>/dev/null
+}
+
+trap _term SIGTERM
+trap _term SIGINT
+
 set +e
-"${node}" "${NODE_OPTIONS[@]}" "${script}" "${ARGS[@]}"
+"${node}" "${NODE_OPTIONS[@]}" "${script}" "${ARGS[@]}" &
+child=$!
+wait "$child"
 RESULT="$?"
 set -e
 

--- a/internal/node/node_launcher.sh
+++ b/internal/node/node_launcher.sh
@@ -129,18 +129,17 @@ for ARG in "${ALL_ARGS[@]}"; do
   esac
 done
 
-# Note: Bash does not forward any termination signals to any child process when running in docker
-# so need to manually trap and forward the signals
+# Note: Bash does not forward termination signals to any child process when
+# running in docker so need to manually trap and forward the signals
 _term() {
   kill -TERM "$child" 2>/dev/null
 }
 
-trap _term SIGTERM
-trap _term SIGINT
-
 set +e
 "${node}" "${NODE_OPTIONS[@]}" "${script}" "${ARGS[@]}" &
 child=$!
+trap _term SIGTERM
+trap _term SIGINT
 wait "$child"
 RESULT="$?"
 set -e


### PR DESCRIPTION
When using nodejs_image of rules_docker there is a problem that `SIGTERM` and `SIGINT` do not get forward to the node process by bash. So when interactively running the container it is not possible to Ctrl+C out and further it would not be possible to implement any custom `SIGTERM` behaviour if needed.

As far as my bash knowledge goes this should be backwards-compatible.