### PR TITLE
Allow to install prod dependencies only with yarn.

### DIFF
--- a/examples/packages/setup_workspace.bzl
+++ b/examples/packages/setup_workspace.bzl
@@ -25,6 +25,8 @@ def packages_example_setup_workspace():
       package_json = "@packages_example//:package.json",
       package_lock_json = "@packages_example//:package-lock.json",
       data = ["@packages_example//:postinstall.js"],
+      # Just here as a smoke test for this attribute
+      prod_only = True,
   )
 
   npm_install(

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -462,6 +462,8 @@ def node_repositories(
       name = "build_bazel_rules_nodejs_npm_install_deps",
       package_json = "@build_bazel_rules_nodejs//internal/npm_install:package.json",
       yarn_lock = "@build_bazel_rules_nodejs//internal/npm_install:yarn.lock",
+      # Just here as a smoke test for this attribute
+      prod_only = True,
   )
 
   yarn_install(

--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -161,12 +161,18 @@ def _yarn_install_impl(repository_ctx):
   # A local cache is used as multiple yarn rules cannot run simultaneously using a shared
   # cache and a shared cache is non-hermetic.
   # To see the output, pass: quiet=False
-  result = repository_ctx.execute([
+  args = [
     repository_ctx.path(yarn),
     "--cache-folder",
     repository_ctx.path("_yarn_cache"),
     "--cwd",
-    repository_ctx.path("")])
+    repository_ctx.path(""),
+  ]
+
+  if repository_ctx.attr.prod_only:
+    args.append("--prod")
+
+  result = repository_ctx.execute(args)
 
   if result.return_code:
     fail("yarn_install failed: %s (%s)" % (result.stdout, result.stderr))
@@ -182,6 +188,9 @@ yarn_install = repository_rule(
             allow_files = True,
             mandatory = True,
             single_file = True,
+        ),
+        "prod_only": attr.bool(
+            default = False,
         ),
         "data": attr.label_list(),
         "node_modules_filegroup": attr.string(


### PR DESCRIPTION
We are slowly starting to adopt bazel internally for our nodejs code and right now we still make use of both devDependencies and dependencies as not everything is fully converted to bazel. So creating a docker `nodejs_image` for prod is much larger than needed as it includes all deps. This PR allows us to workaround the issue for now.

Instead of having a `prod_only` flag I would also be happy to have a more generic `additional_args` or `args` attribute to add any custom flags to the call.  Happy to add whichever would be preferred.