### PR TITLE
Fixed downstream rules_typescript break after #246 by attaching stdin to node background process

### DIFF
--- a/internal/node/node_launcher.sh
+++ b/internal/node/node_launcher.sh
@@ -140,7 +140,7 @@ _int() {
 }
 
 set +e
-"${node}" "${NODE_OPTIONS[@]}" "${script}" "${ARGS[@]}" &
+"${node}" "${NODE_OPTIONS[@]}" "${script}" "${ARGS[@]}" <&0 &
 child=$!
 trap _term SIGTERM
 trap _int SIGINT


### PR DESCRIPTION
Replaces #256. Fixes downstream issue with rules_typescript after #246 since background node process was not receiving stdin which is required for tsc_wrapped in rules_typescript.