### PR TITLE
fix(examples): add bazel_skylib to examples/program workspace

### DIFF
--- a/examples/program/WORKSPACE
+++ b/examples/program/WORKSPACE
@@ -1,5 +1,12 @@
 workspace(name = "program_example")
 
+http_archive(
+    name = "bazel_skylib",
+    url = "https://github.com/bazelbuild/bazel-skylib/archive/0.3.1.zip",
+    strip_prefix = "bazel-skylib-0.3.1",
+    sha256 = "95518adafc9a2b656667bbf517a952e54ce7f350779d0dd95133db4eb5c27fb1",
+)
+
 local_repository(
     name = "build_bazel_rules_nodejs",
     path = "../..",


### PR DESCRIPTION
ref: https://github.com/bazelbuild/rules_nodejs/commit/ce8148b7de3a3d7621e47d26dc30e21fd0849a14