### PR TITLE
nodejs_binary attribute that disables source-map-support

### DIFF
--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -50,6 +50,7 @@ def _write_loader_script(ctx):
           "TEMPLATED_entry_point": ctx.attr.entry_point,
           "TEMPLATED_user_workspace_name": ctx.workspace_name,
           "TEMPLATED_node_modules_root": node_modules_root,
+          "TEMPLATED_install_source_map_support": str(ctx.attr.install_source_map_support).lower(),
       },
       is_executable=True,
   )
@@ -123,6 +124,11 @@ _NODEJS_EXECUTABLE_ATTRS = {
         zone.js before the first `describe`.
         """,
         default = []),
+    "install_source_map_support": attr.bool(
+        doc = """Install the source-map-support package.
+        Enable this to get stack traces that point to original sources, e.g. if the program was written
+        in TypeScript.""",
+        default = True),
     "data": attr.label_list(
         doc = """Runtime dependencies which may be loaded during execution.""",
         allow_files = True,

--- a/internal/node/node_loader.js
+++ b/internal/node/node_loader.js
@@ -346,14 +346,16 @@ module.constructor._resolveFilename =
 
 // Before loading anything that might print a stack, install the
 // source-map-support.
-try {
-  require('source-map-support').install();
-} catch (e) {
-  console.error(`WARNING: source-map-support module not installed.
-   Stack traces from languages like TypeScript will point to generated .js files.
-   `);
+if (TEMPLATED_install_source_map_support) {
+  try {
+    require('source-map-support').install();
+  } catch (e) {
+    console.error(`WARNING: source-map-support module not installed.
+    Stack traces from languages like TypeScript will point to generated .js files.
+    Set install_source_map_support = False in TEMPLATED_target to turn off this warning.
+    `);
+  }
 }
-
 // Load all bootstrap modules before loading the entrypoint.
 for (var i = 0; i < BOOTSTRAP.length; i++) {
   try {


### PR DESCRIPTION
This avoids printing a warning for binaries that don't need source maps.
Fixes #263