### PR TITLE
Follow-up to #264: less spam about source maps

### DIFF
--- a/internal/npm_package/BUILD.bazel
+++ b/internal/npm_package/BUILD.bazel
@@ -10,6 +10,7 @@ nodejs_binary(
         "@nodejs//:run_npm.sh.template",
     ],
     entry_point = "build_bazel_rules_nodejs/internal/npm_package/packager.js",
+    install_source_map_support = False,
     node_modules = "@build_bazel_rules_nodejs_npm_install_deps//:node_modules",
     visibility = ["//visibility:public"],
 )

--- a/internal/rollup/BUILD.bazel
+++ b/internal/rollup/BUILD.bazel
@@ -28,6 +28,7 @@ exports_files([
 nodejs_binary(
     name = "rollup",
     entry_point = "build_bazel_rules_nodejs_rollup_deps/node_modules/rollup/bin/rollup",
+    install_source_map_support = False,
     node_modules = "@build_bazel_rules_nodejs_rollup_deps//:node_modules",
     visibility = ["//visibility:public"],
 )
@@ -35,6 +36,7 @@ nodejs_binary(
 nodejs_binary(
     name = "tsc",
     entry_point = "build_bazel_rules_nodejs_rollup_deps/node_modules/typescript/bin/tsc",
+    install_source_map_support = False,
     node_modules = "@build_bazel_rules_nodejs_rollup_deps//:node_modules",
     visibility = ["//visibility:public"],
 )
@@ -42,6 +44,7 @@ nodejs_binary(
 nodejs_binary(
     name = "uglify",
     entry_point = "build_bazel_rules_nodejs_rollup_deps/node_modules/uglify-es/bin/uglifyjs",
+    install_source_map_support = False,
     node_modules = "@build_bazel_rules_nodejs_rollup_deps//:node_modules",
     visibility = ["//visibility:public"],
 )
@@ -49,6 +52,7 @@ nodejs_binary(
 nodejs_binary(
     name = "source-map-explorer",
     entry_point = "build_bazel_rules_nodejs_rollup_deps/node_modules/source-map-explorer",
+    install_source_map_support = False,
     node_modules = "@build_bazel_rules_nodejs_rollup_deps//:node_modules",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
After introducing an option to disable the source-map-support installation, we still need to use that option to avoid spam from our JS-authored programs