### PR TITLE
Remove usage of deprecated Bazel features

### DIFF
--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -132,7 +132,6 @@ _NODEJS_EXECUTABLE_ATTRS = {
     "data": attr.label_list(
         doc = """Runtime dependencies which may be loaded during execution.""",
         allow_files = True,
-        cfg = "data",
         aspects=[sources_aspect, module_mappings_runtime_aspect]),
     "templated_args": attr.string_list(
         doc = """Arguments which are passed to every execution of the program.

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -151,23 +151,19 @@ _NODEJS_EXECUTABLE_ATTRS = {
     "node": attr.label(
         doc = """The node entry point target.""",
         default = Label("@nodejs//:node"),
-        allow_files = True,
-        single_file = True),
+        allow_single_file = True),
     "_node_runfiles": attr.label(
         default = Label("@nodejs//:node_runfiles"),
         allow_files = True),
     "_repository_args": attr.label(
         default = Label("@nodejs//:bin/node_args.sh"),
-        allow_files = True,
-        single_file = True),
+        allow_single_file = True),
     "_launcher_template": attr.label(
         default = Label("//internal/node:node_launcher.sh"),
-        allow_files = True,
-        single_file = True),
+        allow_single_file = True),
     "_loader_template": attr.label(
         default = Label("//internal/node:node_loader.js"),
-        allow_files = True,
-        single_file = True),
+        allow_single_file = True),
 }
 
 _NODEJS_EXECUTABLE_OUTPUTS = {

--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -124,14 +124,10 @@ cd "{root}" && "{npm}" {npm_args}
 npm_install = repository_rule(
     attrs = {
         "package_json": attr.label(
-            allow_files = True,
+            allow_single_file = True,
             mandatory = True,
-            single_file = True,
         ),
-        "package_lock_json": attr.label(
-            allow_files = True,
-            single_file = True,
-        ),
+        "package_lock_json": attr.label(allow_single_file = True),
         "prod_only": attr.bool(
             default = False,
             doc = "Don't install devDependencies",
@@ -190,14 +186,12 @@ def _yarn_install_impl(repository_ctx):
 yarn_install = repository_rule(
     attrs = {
         "package_json": attr.label(
-            allow_files = True,
+            allow_single_file = True,
             mandatory = True,
-            single_file = True,
         ),
         "yarn_lock": attr.label(
-            allow_files = True,
+            allow_single_file = True,
             mandatory = True,
-            single_file = True,
         ),
         "prod_only": attr.bool(
             default = False,

--- a/internal/rollup/rollup_bundle.bzl
+++ b/internal/rollup/rollup_bundle.bzl
@@ -304,12 +304,10 @@ ROLLUP_ATTRS = {
         default = Label("@build_bazel_rules_nodejs//internal/rollup:source-map-explorer")),
     "_rollup_config_tmpl": attr.label(
         default = Label("@build_bazel_rules_nodejs//internal/rollup:rollup.config.js"),
-        allow_files = True,
-        single_file = True),
+        allow_single_file = True),
     "_uglify_config_tmpl": attr.label(
         default = Label("@build_bazel_rules_nodejs//internal/rollup:uglify.config.json"),
-        allow_files = True,
-        single_file = True),
+        allow_single_file = True),
 }
 
 ROLLUP_OUTPUTS = {


### PR DESCRIPTION
This makes rules_nodejs compatible with `--all_incompatible_changes`, best I can tell.