### PR TITLE
Add node 10.3.0 as an available version for node_repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ node_repositories(package_json = ["//:package.json"])
 You can choose a specific version of Node.js that's built into these rules.
 Currently these versions are:
 
+* 10.3.0
 * 9.11.1
 * 8.11.1
 * 8.9.1

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -30,6 +30,8 @@ DEFAULT_YARN_VERSION = "1.3.2"
 
 # Dictionary mapping NodeJS versions to sets of hosts and their correspoding (filename, strip_prefix, sha256) tuples.
 NODE_REPOSITORIES = {
+  # 10.3.0
+  "10.3.0-darwin_amd64": ("node-v10.3.0-darwin-x64.tar.gz", "node-v10.3.0-darwin-x64", "0bb5b7e3fe8cccda2abda958d1eb0408f1518a8b0cb58b75ade5d507cd5d6053"),
   # 9.11.1
   "9.11.1-darwin_amd64": ("node-v9.11.1-darwin-x64.tar.gz", "node-v9.11.1-darwin-x64", "7b1fb394aa41a62b477e36df16644bd383cc9084808511f6cd318b835a06aac6"),
   "9.11.1-linux_amd64": ("node-v9.11.1-linux-x64.tar.xz", "node-v9.11.1-linux-x64", "4d27a95d5c2f1c8ef99118794c9c4903e63963418d3e16ca7576760cff39879b"),

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -32,6 +32,8 @@ DEFAULT_YARN_VERSION = "1.3.2"
 NODE_REPOSITORIES = {
   # 10.3.0
   "10.3.0-darwin_amd64": ("node-v10.3.0-darwin-x64.tar.gz", "node-v10.3.0-darwin-x64", "0bb5b7e3fe8cccda2abda958d1eb0408f1518a8b0cb58b75ade5d507cd5d6053"),
+  "10.3.0-linux_amd64": ("node-v10.3.0-linux-x64.tar.xz", "node-v10.3.0-linux-x64", "eb3c3e2585494699716ad3197c8eedf4003d3f110829b30c5a0dc34414c47423"),
+  "10.3.0-windows_amd64": ("node-v10.3.0-win-x64.zip", "node-v10.3.0-win-x64", "65d586afb087406a2800d8e51f664c88b26d510f077b85a3b177a1bb79f73677"),
   # 9.11.1
   "9.11.1-darwin_amd64": ("node-v9.11.1-darwin-x64.tar.gz", "node-v9.11.1-darwin-x64", "7b1fb394aa41a62b477e36df16644bd383cc9084808511f6cd318b835a06aac6"),
   "9.11.1-linux_amd64": ("node-v9.11.1-linux-x64.tar.xz", "node-v9.11.1-linux-x64", "4d27a95d5c2f1c8ef99118794c9c4903e63963418d3e16ca7576760cff39879b"),


### PR DESCRIPTION
Node 10.3.0 is needed to enable usage of `npm ci`, which only uses the `package-lock.json` to install dependencies and does not resolve differences.
Adding this version enables consistency through projects that use Bazel and move to node 10.3.0.

Using `npm ci` should result in much faster dependency installation as outlined below (up to 2x-3x speedup):
* https://docs.npmjs.com/cli/ci
* https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable
* https://medium.com/better-things-digital/npm-ci-a-command-you-should-know-d8d67847884c