### PR TITLE
mocha_node_test rule

### DIFF
--- a/internal/mocha_node_test/BUILD
+++ b/internal/mocha_node_test/BUILD
@@ -1,0 +1,47 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+load(":mocha_node_test.bzl", "mocha_node_test")
+load("//internal/js_library:js_library.bzl", "js_library")
+
+exports_files([
+    "mocha_runner.js",
+    # Exported to be consumed for generating skydoc.
+    "mocha_node_test.bzl",
+])
+
+js_library(
+    name = "exampleLib",
+    srcs = glob(["exampleLib/*.js"]),
+    module_name = "example-lib",
+    module_root = "exampleLib/index.js",
+)
+
+mocha_node_test(
+    name = "test",
+    data = [
+        ":testOne.js",
+        ":testTwo.js",
+        ":exampleLib",
+    ],
+    test_entrypoints = [
+        "internal/mocha_node_test/testOne.js",
+        "internal/mocha_node_test/testTwo.js",
+    ],
+    node_modules = "//internal/test:node_modules",
+)
+
+

--- a/internal/mocha_node_test/exampleLib/index.js
+++ b/internal/mocha_node_test/exampleLib/index.js
@@ -1,0 +1,2 @@
+const foo = require('./internalFile');
+exports.content = foo.content;

--- a/internal/mocha_node_test/exampleLib/internalFile.js
+++ b/internal/mocha_node_test/exampleLib/internalFile.js
@@ -1,0 +1,1 @@
+exports.content = 'hello from example-lib';

--- a/internal/mocha_node_test/mocha_node_test.bzl
+++ b/internal/mocha_node_test/mocha_node_test.bzl
@@ -1,0 +1,50 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NodeJS testing
+
+These rules let you run tests using the Mocha library.
+
+Unlike the typical mocha testing setup, we do not use the mocha binary that is
+provided by the mocha library. The method used by these rules to patch the
+module loader with extra module name -> path mappings (node_loader.js) does not
+persist across processes. The mocha binary provided by the mocha library
+ultimately spawns a new process to run the actual tests, and so the patched
+module loader will not be respected. This approach instead programmatically runs
+the Mocha library on the desired files; see
+https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically.
+"""
+load("//internal/node:node.bzl", "nodejs_test")
+
+def mocha_node_test(
+  name,
+  test_entrypoints = [], # these should NOT contain the preceding workspace name.
+  data = [],
+  expected_exit_code = 0,
+  **kwargs):
+
+  all_data = data
+  all_data += [Label("//internal/mocha_node_test:mocha_runner.js")]
+  all_data += [Label("@bazel_tools//tools/bash/runfiles")]
+  entry_point = "build_bazel_rules_nodejs/internal/mocha_node_test/mocha_runner.js"
+
+  nodejs_test(
+      name = name,
+      data = all_data,
+      entry_point = entry_point,
+      templated_args = test_entrypoints,
+      testonly = 1,
+      expected_exit_code = expected_exit_code,
+      **kwargs
+  )

--- a/internal/mocha_node_test/mocha_runner.js
+++ b/internal/mocha_node_test/mocha_runner.js
@@ -1,0 +1,47 @@
+const Mocha = require('mocha');
+const fs = require('fs');
+const path = require('path');
+
+const mocha = new Mocha();
+
+// Set the StackTraceLimit to infinity. This will make stack capturing slower, but more useful.
+// Since we are running tests having proper stack traces is very useful and should be always set to
+// the maximum (See: https://nodejs.org/api/errors.html#errors_error_stacktracelimit)
+Error.stackTraceLimit = Infinity;
+
+// tested files are provided as process.argv[2] and on
+const filesToTest = process.argv.slice(2);
+filesToTest.forEach(file => mocha.addFile(file));
+
+// These exit codes are handled specially by Bazel:
+// https://github.com/bazelbuild/bazel/blob/486206012a664ecb20bdb196a681efc9a9825049/src/main/java/com/google/devtools/build/lib/util/ExitCode.java#L44
+const BAZEL_EXIT_TESTS_FAILED = 3;
+const BAZEL_EXIT_NO_TESTS_FOUND = 4;
+
+
+let hasFailure = false;
+let hasTest = false;
+
+const runner = mocha.run(function(failures) {
+  if (failures) {
+    hasFailure = true;
+  }
+});
+
+runner.on('test', () => {
+  hasTest = true;
+});
+
+
+
+process.on('exit', (code) => {
+  // if the code has executed normally, potentially overwrite the process code
+  // based on test results.
+  if (code === 0) {
+    if (hasFailure) {
+      process.exitCode = BAZEL_EXIT_TESTS_FAILED;
+    } else if (!hasTest) {
+      process.exitCode = BAZEL_EXIT_NO_TESTS_FOUND;
+    } 
+  }
+});

--- a/internal/mocha_node_test/testOne.js
+++ b/internal/mocha_node_test/testOne.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+
+describe('mocha_node_test testOne', () => {
+  it('should resolve module names via patched loader', () => {
+    const content = require('example-lib').content;
+    assert.equal(content, 'hello from example-lib');
+  });
+});

--- a/internal/mocha_node_test/testTwo.js
+++ b/internal/mocha_node_test/testTwo.js
@@ -1,0 +1,7 @@
+const assert = require('assert');
+
+describe('mocha_node_test testTwo', () => {
+  it('should run multiple test files at once.', () => {
+    assert.equal(1,1);
+  });
+});

--- a/internal/test/package.json
+++ b/internal/test/package.json
@@ -3,6 +3,7 @@
   "devDependencies": {
     "is-builtin-module": "^2.0.0",
     "jasmine": "~2.8.0",
+    "mocha": "5.2.0",
     "node_resolve_index": "file:./node_resolve_index",
     "node_resolve_index_2": "file:./node_resolve_index_2",
     "node_resolve_index_3": "file:./node_resolve_index_3",

--- a/internal/test/yarn.lock
+++ b/internal/test/yarn.lock
@@ -53,6 +53,10 @@ browser-resolve@^1.11.0:
   dependencies:
     resolve "1.1.7"
 
+browser-stdout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+
 builtin-modules@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -61,17 +65,35 @@ builtin-modules@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-2.0.0.tgz#60b7ef5ae6546bd7deefa74b08b62a43a232648e"
 
+commander@2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
+debug@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
+diff@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
 diff@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/diff/-/diff-2.2.3.tgz#60eafd0d28ee906e4e8ff0a52c1229521033bf99"
+
+escape-string-regexp@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
 estree-walker@^0.3.0:
   version "0.3.1"
@@ -140,7 +162,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.6:
+glob@7.1.2, glob@^7.0.6:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -150,6 +172,18 @@ glob@^7.0.6:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -272,11 +306,41 @@ micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
     brace-expansion "^1.1.7"
+
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+mkdirp@0.5.1:
+  version "0.5.1"
+  resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  dependencies:
+    minimist "0.0.8"
+
+mocha@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
+  dependencies:
+    browser-stdout "1.3.1"
+    commander "2.15.1"
+    debug "3.1.0"
+    diff "3.5.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.2"
+    growl "1.10.5"
+    he "1.1.1"
+    minimatch "3.0.4"
+    mkdirp "0.5.1"
+    supports-color "5.4.0"
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 "node_resolve_index@file:./node_resolve_index":
   version "0.0.0"
@@ -421,6 +485,12 @@ source-map-resolve@^0.5.0:
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
+
+supports-color@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
 
 unidiff@^0.0.4:
   version "0.0.4"


### PR DESCRIPTION
This is a simple PR that adds a mocha_node_test rule that generally follows the example set by jasmine_node_test.

Mocha is a very popular node.js testing framework, so it seems like a reasonable addition.

I was not 100% sure where to put tests, so I included some in the mocha_node_test folder, but let me know if they should go elsewhere.