### PR TITLE
Make node_modules attribute to rules_nodejs optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,12 @@ jobs:
       # TODO(alexeagle): move this into the example proper
       - run: bazel run examples/rollup -- --help
 
+      # These targets should run
+      - run: bazel run //internal/node/test:no_deps
+      - run: bazel run //internal/node/test:has_deps_legacy
+      - run: bazel run //internal/node/test:has_deps
+      - run: bazel run //internal/node/test:has_deps_hybrid
+
       # We should also be able to test targets in a different workspace
       - run: bazel test @program_example//...
       - run: bazel test @packages_example//...

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,1 +1,9 @@
-# Marker file that this directory is a Bazel package
+package(default_visibility = ["//visibility:public"])
+
+# Empty node_modules filegroup used for the default
+# value of the node_modules attribute in nodejs_binary
+# and rollup_bundle
+filegroup(
+    name = "node_modules_none",
+    srcs = [],
+)

--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ with the `node_modules` attribute of nodejs rules.
 
 * `@npm//:node_modules` is includes **all** files under `node_modules`
 * `@npm//:node_modules_lite` is includes only `.js`, `.d.ts`, `.json` and `./bin/*` under `node_modules` (this reduces the number of input files)
-* `@npm//:node_modules_none` is an empty file group which is useful when a nodejs_binary has no node_module dependencies but it still requires its `node_modules` attribute set
 
 ```python
 load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")

--- a/internal/common/node_module_info.bzl
+++ b/internal/common/node_module_info.bzl
@@ -1,0 +1,44 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Definitions for handling path re-mapping, to support short module names.
+# See pathMapping doc: https://github.com/Microsoft/TypeScript/issues/5039
+#
+# This reads the module_root and module_name attributes from typescript rules in
+# the transitive closure, rolling these up to provide a mapping to the
+# TypeScript compiler and to editors.
+#
+
+"""NodeModuleInfo provider and apsect to collect node_modules from deps.
+"""
+
+NodeModuleInfo = provider(
+  doc = "This provider contains information about npm dependencies installed with yarn_install and npm_install rules",
+  fields = {
+    "workspace": "The workspace name that the npm dependencies are provided from"
+  })
+
+def _collect_node_modules_aspect_impl(target, ctx):
+  nm_wksp = None
+
+  if hasattr(ctx.rule.attr, "tags") and "NODE_MODULE_MARKER" in ctx.rule.attr.tags:
+      nm_wksp = target.label.workspace_root.split("/")[1] if target.label.workspace_root else ctx.workspace_name
+      return [NodeModuleInfo(workspace = nm_wksp)]
+
+  return []
+
+collect_node_modules_aspect = aspect(
+    implementation = _collect_node_modules_aspect_impl,
+    attr_aspects = ["deps"],
+)

--- a/internal/e2e/rollup_fine_grained_deps/BUILD.bazel
+++ b/internal/e2e/rollup_fine_grained_deps/BUILD.bazel
@@ -1,0 +1,66 @@
+load("//:defs.bzl", "jasmine_node_test", "rollup_bundle")
+
+# You can have a rollup_bundle with no node_modules attribute
+# and no fine grained deps
+rollup_bundle(
+    name = "bundle_no_deps",
+    srcs = ["no-deps.js"],
+    entry_point = "internal/e2e/rollup_fine_grained_deps/no-deps.js",
+)
+
+# You can have a rollup_bundle with no node_modules attribute
+# and fine grained deps
+rollup_bundle(
+    name = "bundle",
+    srcs = ["has-deps.js"],
+    entry_point = "internal/e2e/rollup_fine_grained_deps/has-deps.js",
+    deps = [
+        "@fine_grained_deps_yarn//:@gregmagolan/test-b",
+    ],
+)
+
+# You can have a rollup_bundle with a node_modules attribute
+# and no fine grained deps
+rollup_bundle(
+    name = "bundle_legacy",
+    srcs = ["has-deps.js"],
+    entry_point = "internal/e2e/rollup_fine_grained_deps/has-deps.js",
+    node_modules = "@fine_grained_deps_yarn//:node_modules_lite",
+)
+
+# You can have a rollup_bundle with both a node_modules attribute
+# and fine grained deps so long as they come from the same root
+rollup_bundle(
+    name = "bundle_hybrid",
+    srcs = ["has-deps.js"],
+    entry_point = "internal/e2e/rollup_fine_grained_deps/has-deps.js",
+    node_modules = "@fine_grained_deps_yarn//:node_modules_lite",
+    deps = [
+        "@fine_grained_deps_yarn//:@gregmagolan/test-b",
+    ],
+)
+
+jasmine_node_test(
+    name = "test",
+    srcs = glob(["*.spec.js"]),
+    data = [
+        ":bundle.es6.js",
+        ":bundle.js",
+        ":bundle.min.js",
+        ":bundle.min_debug.js",
+        ":bundle_hybrid.es6.js",
+        ":bundle_hybrid.js",
+        ":bundle_hybrid.min.js",
+        ":bundle_hybrid.min_debug.js",
+        ":bundle_legacy.es6.js",
+        ":bundle_legacy.js",
+        ":bundle_legacy.min.js",
+        ":bundle_legacy.min_debug.js",
+        ":bundle_no_deps.es6.js",
+        ":bundle_no_deps.js",
+        ":bundle_no_deps.min.js",
+        ":bundle_no_deps.min_debug.js",
+        "@fine_grained_deps_yarn//:@gregmagolan/test-a",
+        "@fine_grained_deps_yarn//:jasmine",
+    ],
+)

--- a/internal/e2e/rollup_fine_grained_deps/has-deps.js
+++ b/internal/e2e/rollup_fine_grained_deps/has-deps.js
@@ -1,0 +1,1 @@
+export * from '@gregmagolan/test-b';

--- a/internal/e2e/rollup_fine_grained_deps/no-deps.js
+++ b/internal/e2e/rollup_fine_grained_deps/no-deps.js
@@ -1,0 +1,1 @@
+module.exports = 'no-deps';

--- a/internal/e2e/rollup_fine_grained_deps/rollup.spec.js
+++ b/internal/e2e/rollup_fine_grained_deps/rollup.spec.js
@@ -1,0 +1,106 @@
+// We expected the bundle with deps to return the following
+// string which indicates that test-b@0.0.2 was imported and
+// bundled and test-a@0.0.2 was required at runtime since test-b
+// had a require('test-a') and rollup should not have bundled
+// test-a@0.0.1
+const expectedDeps = 'test-b-0.0.2/test-a-0.0.2';
+
+const expectedNoDeps = 'no-deps';
+
+describe('bundling main entry point', () => {
+  it('bundle_no_deps.es6.js should work', async () => {
+    const bundle = require(
+        'build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle_no_deps.es6.js')
+    expect(bundle).toEqual(expectedNoDeps);
+  });
+
+  it('bundle_no_deps.js should work', async () => {
+    const bundle =
+        require('build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle_no_deps.js')
+    expect(bundle).toEqual(expectedNoDeps);
+  });
+
+  it('bundle_no_deps.min.js should work', async () => {
+    const bundle = require(
+        'build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle_no_deps.min.js');
+    expect(bundle).toEqual(expectedNoDeps);
+  });
+
+  it('bundle_no_deps.min_debug.js should work', async () => {
+    const bundle = require(
+        'build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle_no_deps.min_debug.js')
+    expect(bundle).toEqual(expectedNoDeps);
+  });
+
+  it('bundle.es6.js should work', async () => {
+    const bundle =
+        require('build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle.es6.js')
+    expect(bundle).toEqual(expectedDeps);
+  });
+
+  it('bundle.js should work', async () => {
+    const bundle =
+        require('build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle.js')
+    expect(bundle).toEqual(expectedDeps);
+  });
+
+  it('bundle.min.js should work', async () => {
+    const bundle =
+        require('build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle.min.js');
+    expect(bundle).toEqual(expectedDeps);
+  });
+
+  it('bundle.min_debug.js should work', async () => {
+    const bundle = require(
+        'build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle.min_debug.js')
+    expect(bundle).toEqual(expectedDeps);
+  });
+
+  it('bundle_legacy.es6.js should work', async () => {
+    const bundle = require(
+        'build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle_legacy.es6.js')
+    expect(bundle).toEqual(expectedDeps);
+  });
+
+  it('bundle_legacy.js should work', async () => {
+    const bundle =
+        require('build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle_legacy.js')
+    expect(bundle).toEqual(expectedDeps);
+  });
+
+  it('bundle_legacy.min.js should work', async () => {
+    const bundle = require(
+        'build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle_legacy.min.js');
+    expect(bundle).toEqual(expectedDeps);
+  });
+
+  it('bundle_legacy.min_debug.js should work', async () => {
+    const bundle = require(
+        'build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle_legacy.min_debug.js')
+    expect(bundle).toEqual(expectedDeps);
+  });
+
+  it('bundle_hybrid.es6.js should work', async () => {
+    const bundle = require(
+        'build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle_hybrid.es6.js')
+    expect(bundle).toEqual(expectedDeps);
+  });
+
+  it('bundle_hybrid.js should work', async () => {
+    const bundle =
+        require('build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle_hybrid.js')
+    expect(bundle).toEqual(expectedDeps);
+  });
+
+  it('bundle_hybrid.min.js should work', async () => {
+    const bundle = require(
+        'build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle_hybrid.min.js');
+    expect(bundle).toEqual(expectedDeps);
+  });
+
+  it('bundle_hybrid.min_debug.js should work', async () => {
+    const bundle = require(
+        'build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/bundle_hybrid.min_debug.js')
+    expect(bundle).toEqual(expectedDeps);
+  });
+});

--- a/internal/node/node_loader.js
+++ b/internal/node/node_loader.js
@@ -471,7 +471,20 @@ if (require.main === module) {
   try {
     module.constructor._load(mainScript, this, /*isMain=*/true);
   } catch (e) {
-    console.error('failed to load main ', e.stack || e);
+    console.error(e.stack || e);
+    if (NODE_MODULES_ROOT === 'build_bazel_rules_nodejs/node_modules') {
+      // This error is possibly due to a breaking change in 0.13.0 where
+      // the default node_modules attribute of nodejs_binary was changed
+      // from @//:node_modules to @build_bazel_rules_nodejs//:node_modules_none
+      // (which is an empty filegroup).
+      // See https://github.com/bazelbuild/rules_nodejs/wiki#migrating-to-rules_nodejs-013
+      console.error(
+          `\nWARNING: Due to a breaking change in rules_nodejs 0.13.0, target TEMPLATED_target\n` +
+          `must now declare either an explicit node_modules attribute, or\n` +
+          `list explicit deps[] or data[] fine grained dependencies on npm labels\n` +
+          `if it has any node_modules dependencies.\n` +
+          `See https://github.com/bazelbuild/rules_nodejs/wiki#migrating-to-rules_nodejs-013\n`);
+    }
     process.exit(1);
   }
 }

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -1,0 +1,41 @@
+load("//:defs.bzl", "nodejs_binary")
+
+# You can have a nodejs_binary with no node_modules attribute
+# and no fine grained deps
+nodejs_binary(
+    name = "no_deps",
+    data = ["no-deps.js"],
+    entry_point = "build_bazel_rules_nodejs/internal/node/test/no-deps",
+)
+
+# You can have a nodejs_binary with a node_modules attribute
+# and no fine grained deps
+nodejs_binary(
+    name = "has_deps_legacy",
+    data = ["has-deps.js"],
+    entry_point = "build_bazel_rules_nodejs/internal/node/test/has-deps",
+    node_modules = "@fine_grained_deps_yarn//:node_modules_lite",
+)
+
+# You can have a nodejs_binary with no node_modules attribute
+# and fine grained deps
+nodejs_binary(
+    name = "has_deps",
+    data = [
+        "has-deps.js",
+        "@fine_grained_deps_yarn//:typescript",
+    ],
+    entry_point = "build_bazel_rules_nodejs/internal/node/test/has-deps",
+)
+
+# You can have a nodejs_binary with both a node_modules attribute
+# and fine grained deps so long as they come from the same root
+nodejs_binary(
+    name = "has_deps_hybrid",
+    data = [
+        "has-deps.js",
+        "@fine_grained_deps_yarn//:typescript",
+    ],
+    entry_point = "build_bazel_rules_nodejs/internal/node/test/has-deps",
+    node_modules = "@fine_grained_deps_yarn//:node_modules_lite",
+)

--- a/internal/node/test/has-deps.js
+++ b/internal/node/test/has-deps.js
@@ -1,0 +1,2 @@
+const ts = require('typescript');
+console.log('a node script with a dep on typescript', ts.version);

--- a/internal/node/test/no-deps.js
+++ b/internal/node/test/no-deps.js
@@ -1,0 +1,1 @@
+console.log('a node script with no npm deps');

--- a/internal/npm_install/generate_build_file.js
+++ b/internal/npm_install/generate_build_file.js
@@ -56,10 +56,6 @@
  *   https://github.com/bazelbuild/bazel/issues/5769 would allow this
  *   filegroup to include those files.
  *
- * `@<workspace>//:node_modules_none`: An empty filegroup which is useful
- *   for nodejs_binary targets with no npm dependencies
- *   but that still need to specify a node_modules attribute.
- *
  * This work is based off the fine grained deps concepts in
  * https://github.com/pubref/rules_node developed by @pcj.
  *
@@ -128,14 +124,6 @@ filegroup(
           "node_modules/**/* *",
         ],
     ),
-)
-
-# An empty filegroup which is useful
-# for nodejs_binary targets with no npm dependencies
-# but that still need to specify a node_modules attribute.
-filegroup(
-    name = "node_modules_none",
-    srcs = [],
 )
 
 `

--- a/internal/npm_install/test/BUILD.bazel.golden
+++ b/internal/npm_install/test/BUILD.bazel.golden
@@ -31,10 +31,6 @@ filegroup(
     ),
 )
 filegroup(
-    name = "node_modules_none",
-    srcs = [],
-)
-filegroup(
     name = "balanced-match",
     srcs = [
         ":balanced-match__files",

--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -15,6 +15,8 @@ const workspaceName = 'TMPL_workspace_name';
 const rootDir = 'TMPL_rootDir';
 const banner_file = TMPL_banner_file;
 const stamp_data = TMPL_stamp_data;
+const nodeModulesRoot = 'TMPL_node_modules_root';
+const defaultNodeModules = TMPL_default_node_modules;
 
 if (DEBUG)
   console.error(`
@@ -126,7 +128,22 @@ function notResolved(importee, importer) {
   if (isBuiltinModule(importee)) {
     return null;
   }
-  throw new Error(`Could not resolve import '${importee}' from '${importer}'`);
+  if (defaultNodeModules) {
+    // This error is possibly due to a breaking change in 0.13.2 where
+    // the default node_modules attribute of rollup_bundle was changed
+    // from @//:node_modules to @build_bazel_rules_nodejs//:node_modules_none
+    // (which is an empty filegroup).
+    // See https://github.com/bazelbuild/rules_nodejs/wiki#migrating-to-rules_nodejs-013
+    throw new Error(
+        `Could not resolve import '${importee}' from '${importer}'` +
+        `\n\nWARNING: Due to a breaking change in rules_nodejs 0.13.2, target TMPL_target\n` +
+        `must now declare either an explicit node_modules attribute, or\n` +
+        `list explicit deps[] fine grained dependencies on npm labels\n` +
+        `if it has any node_modules dependencies.\n` +
+        `See https://github.com/bazelbuild/rules_nodejs/wiki#migrating-to-rules_nodejs-013\n`);
+  } else {
+    throw new Error(`Could not resolve import '${importee}' from '${importer}'`);
+  }
 }
 
 const inputs = [TMPL_inputs];
@@ -143,11 +160,8 @@ const config = {
   },
   plugins: [TMPL_additional_plugins].concat([
     {resolveId: resolveBazel},
-    nodeResolve({
-      jsnext: true,
-      module: true,
-      customResolveOptions: {moduleDirectory: 'TMPL_node_modules_path'}
-    }),
+    nodeResolve(
+        {jsnext: true, module: true, customResolveOptions: {moduleDirectory: nodeModulesRoot}}),
     {resolveId: notResolved},
     sourcemaps(),
   ])

--- a/internal/rollup/rollup.config.spec.js
+++ b/internal/rollup/rollup.config.spec.js
@@ -10,6 +10,7 @@ TMPL_additional_plugins = [];
 TMPL_banner_file = '';
 TMPL_stamp_data = '';
 TMPL_inputs = '';
+TMPL_default_node_modules = false;
 
 const baseDir = '/root/base';
 const files = [


### PR DESCRIPTION
& change rollup_bundle default to `//:node_modules_none`. rollup_bundle also updated to handle fine grained npm deps.