### PR TITLE
Filter out files that match test.js and spec.js but are in node_modules

### DIFF
--- a/internal/jasmine_node_test/jasmine_runner.js
+++ b/internal/jasmine_node_test/jasmine_runner.js
@@ -33,7 +33,9 @@ function main(args) {
       // deps such as "@npm//:typescript" if executed may cause the test to
       // fail or have unexpected side-effects. "@npm//:typescript" would
       // try to execute tsc, print its help, and process.exit(1)
-      .filter(f => /[^a-zA-Z0-9](spec|test)\.js$/.test(f))
+      .filter(f => /[^a-zA-Z0-9](spec|test)\.js$/i.test(f))
+      // Filter out files from node_modules that match test.js or spec.js
+      .filter(f => !/\/node_modules\//.test(f))
       .forEach(f => jrunner.addSpecFile(f));
 
   var noSpecsFound = true;


### PR DESCRIPTION
Since fine grained deps don't exclude `**/test/**` you can get files such as `node_modules/jasmine/test/test.js` included as specs unintentionally.

This is the same logic that ts_web_test_suite uses: https://github.com/bazelbuild/rules_typescript/blob/master/internal/karma/karma.conf.js#L120