### PR TITLE
Don't include sources from npm fine grained deps in result of sources_aspect

### DIFF
--- a/internal/common/sources_aspect.bzl
+++ b/internal/common/sources_aspect.bzl
@@ -25,6 +25,12 @@
 
 def _sources_aspect_impl(target, ctx):
   result = depset()
+
+  # Sources from npm fine grained deps which are tagged with NODE_MODULE_MARKER
+  # should not be included
+  if hasattr(ctx.rule.attr, "tags") and "NODE_MODULE_MARKER" in ctx.rule.attr.tags:
+    return struct(node_sources = result)
+
   if hasattr(ctx.rule.attr, "deps"):
     for dep in ctx.rule.attr.deps:
       if hasattr(dep, "node_sources"):


### PR DESCRIPTION
This is needed for ts_web_test_suite downstream since it uses sources aspect and with npm fine grained deps sources from `@npm//:foo` deps get included in karma. Same thing would apply to all other rules that use the `sources_aspect`. Behavior of using `@npm//:foo` in deps should be the same as when using the legacy `node_modules`.