### PR TITLE
Fix rollup path mapping with slashes

### DIFF
--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -83,13 +83,16 @@ function resolveBazel(importee, importer, baseDir = process.cwd(), resolve = req
     // possible workspace import or external import if importee matches a module
     // mapping
     for (const k in moduleMappings) {
-      if (importee == k || importee.startsWith(k + path.sep)) {
+      // Since mappings are always in POSIX paths, when comparing the importee to mappings
+      // we should normalize the importee.
+      const normalizedImportee = importee.replace(/\\/g, '/');
+      if (normalizedImportee == k || normalizedImportee.startsWith(k + '/')) {
         // replace the root module name on a mappings match
         // note that the module_root attribute is intended to be used for type-checking
         // so it uses eg. "index.d.ts". At runtime, we have only index.js, so we strip the
         // .d.ts suffix and let node require.resolve do its thing.
         var v = moduleMappings[k].replace(/\.d\.ts$/, '');
-        const mappedImportee = path.join(v, importee.slice(k.length + 1));
+        const mappedImportee = path.join(v, normalizedImportee.slice(k.length + 1));
         if (DEBUG) console.error(`Rollup: module mapped '${importee}' to '${mappedImportee}'`);
         resolved = resolveInRootDir(mappedImportee);
         if (resolved) break;

--- a/internal/rollup/rollup.config.spec.js
+++ b/internal/rollup/rollup.config.spec.js
@@ -3,6 +3,7 @@ const {sep, join} = require('path');
 TMPL_module_mappings = {
   'foo': 'path/to/foo_lib',
   'other': 'external/other_wksp/path/to/other_lib',
+  '@bar/baz': 'path/to/bar/baz_lib',
 };
 
 const rootDir = 'bazel-bin/path/to/a.esm5';
@@ -16,6 +17,7 @@ const baseDir = '/root/base';
 const files = [
   '/root/base/bazel-bin/path/to/a.esm5/path/to/foo_lib/bar',
   '/root/base/bazel-bin/path/to/a.esm5/external/other_wksp/path/to/other_lib/thing',
+  '/root/base/bazel-bin/path/to/a.esm5/path/to/bar/baz_lib/foo',
   '/root/base/bazel-bin/path/to/a.esm5/external/some_wksp/path/to/a/public_api.js',
   '/root/base/bazel-bin/path/to/a.esm5/external/some_wksp/path/to/a/index.js',
 ];
@@ -69,6 +71,8 @@ describe('rollup config', () => {
         .toEqual(`${baseDir}/bazel-bin/path/to/a.esm5/path/to/foo_lib/bar`);
     expect(doResolve(`other${sep}thing`))
         .toEqual(`${baseDir}/bazel-bin/path/to/a.esm5/external/other_wksp/path/to/other_lib/thing`);
+    expect(doResolve(`@bar${sep}baz${sep}foo`))
+      .toEqual(`${baseDir}/bazel-bin/path/to/a.esm5/path/to/bar/baz_lib/foo`);        
   });
 
   it('should find paths in any root', () => {


### PR DESCRIPTION
Path mappings are described with POSIX paths so we should normalize imports when comparing them.