### PR TITLE
Don't add workspace to expanded ../ paths

### DIFF
--- a/internal/common/expand_into_runfiles.bzl
+++ b/internal/common/expand_into_runfiles.bzl
@@ -48,6 +48,8 @@ def expand_path_into_runfiles(ctx, path):
   """
   targets = ctx.attr.data if hasattr(ctx.attr, "data") else []
   expanded = ctx.expand_location(path, targets)
+  if expanded.startswith('../'):
+    return expanded[len('../'):]
   if expanded.startswith(ctx.bin_dir.path):
     expanded = expanded[len(ctx.bin_dir.path + "/"):]
   if expanded.startswith(ctx.genfiles_dir.path):


### PR DESCRIPTION
Otherwise they will become 'workspace/../path', which is the same as just 'path'.

Although both are valid, these paths are meant to be looked up in the runfiles so they should be normalized already instead of leavinf it for the consuming tool.
This is especially important in windows where the runfiles manifest contains strings of normalized paths.