### PR TITLE
Exclude .pyc files from node_runfiles

### DIFF
--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -210,6 +210,10 @@ filegroup(
     exclude = [
       "**/*.md",
       "**/*.html",
+      # These files are generated during node-gyp compilation and include
+      # absolute paths, making them non-hermetic.
+      # See https://github.com/bazelbuild/rules_nodejs/issues/347
+      "**/*.pyc",
     ],
   ),
 )


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_nodejs/issues/347