### PR TITLE
Add @bazel/bazel and platform-specific packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea
-bazel-*
+/bazel-*
 node_modules

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,14 @@
+# npm packages
+
+Folders in this directory are published to npm
+in the @bazel/ scoped package.
+
+## Publishing
+
+Run `mirror.sh` to fetch a Bazel release and populate the `bazel-*` packages. The script will also update the `package.json` files.
+
+The script relies on the excellent [jq](https://stedolan.github.io/jq) tool, which you'll need to install if you don't have it already.
+
+Login to npm using the `angular` account. The password is shared in http://valentine.
+
+Inspect the directories, then `cd` into each of the `bazel*` directories and run `npm publish`.

--- a/packages/bazel-darwin_x64/package.json
+++ b/packages/bazel-darwin_x64/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@bazel/bazel-darwin_x64",
+  "bin": {
+    "bazel": "./bazel-0.18.0-darwin-x86_64"
+  },
+  "os": [
+    "darwin"
+  ],
+  "version": "0.18.0",
+  "description": "Build and test software of any size, quickly and reliably",
+  "homepage": "https://bazel.build/",
+  "license": "Apache 2.0",
+  "bugs": {
+    "url": "https://github.com/bazelbuild/bazel/issues"
+  }
+}

--- a/packages/bazel-linux_x64/package.json
+++ b/packages/bazel-linux_x64/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@bazel/bazel-linux_x64",
+  "bin": {
+    "bazel": "./bazel-0.18.0-linux-x86_64"
+  },
+  "os": [
+    "linux"
+  ],
+  "version": "0.18.0",
+  "description": "Build and test software of any size, quickly and reliably",
+  "homepage": "https://bazel.build/",
+  "license": "Apache 2.0",
+  "bugs": {
+    "url": "https://github.com/bazelbuild/bazel/issues"
+  }
+}

--- a/packages/bazel-win32_x64/package.json
+++ b/packages/bazel-win32_x64/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@bazel/bazel-win32_x64",
+  "bin": {
+    "bazel": "./bazel-0.18.0-windows-x86_64.exe"
+  },
+  "//": "Even though the platform is 64-bit, process.platform returns win32",
+  "os": [
+    "win32"
+  ],
+  "version": "0.18.0",
+  "description": "Build and test software of any size, quickly and reliably",
+  "homepage": "https://bazel.build/",
+  "license": "Apache 2.0",
+  "bugs": {
+    "url": "https://github.com/bazelbuild/bazel/issues"
+  }
+}

--- a/packages/bazel/bazel.js
+++ b/packages/bazel/bazel.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+// This file is a shim to execute the bazel binary from the right platform-specific package.
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const spawn = require('child_process').spawn;
+
+/**
+ * @returns the native `bazel` binary for the current platform
+ * @throws when the `bazel` executable can not be found
+ */
+function getNativeBinary() {
+  const nativePackage = require.resolve(`@bazel/bazel-${os.platform()}_${os.arch()}/package.json`);
+  if (!fs.existsSync(nativePackage)) {
+    const message = 'Bazel has not published an executable for your platform. ' +
+    `(${os.platform()}_${os.arch()})\n` +
+    'Consider installing it following instructions at https://bazel.build instead.\n';
+    throw new Error(message);
+  }
+  const binary = JSON.parse(fs.readFileSync(nativePackage))['bin']['bazel'];
+  return path.resolve(path.dirname(nativePackage), binary);
+}
+
+spawn(getNativeBinary(), process.argv.slice(2), {stdio: 'inherit'});

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@bazel/bazel",
+  "bin": {
+    "bazel": "./bazel.js"
+  },
+  "version": "0.18.0",
+  "description": "Build and test software of any size, quickly and reliably",
+  "homepage": "https://bazel.build/",
+  "bugs": {
+    "url": "https://github.com/bazelbuild/bazel/issues"
+  },
+  "optionalDependencies": {
+    "@bazel/bazel-linux_x64": "0.18.0",
+    "@bazel/bazel-darwin_x64": "0.18.0",
+    "@bazel/bazel-win32_x64": "0.18.0"
+  }
+}

--- a/packages/mirror.sh
+++ b/packages/mirror.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -x
+
+git clean -fx
+
+# VERSION is e.g. 0.18.0
+readonly VERSION=$1
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: mirror.sh [version]"
+  exit 1
+fi
+# RC can be supplied, e.g. rc4
+# otherwise we take the final release
+readonly RC=$2
+if [[ -z "$RC" ]]; then
+  readonly FOLDER="release"
+  readonly NEWVERSION=$VERSION
+else
+  readonly FOLDER=$RC
+  readonly NEWVERSION="${VERSION}-${RC}"
+fi
+readonly BASENAME="bazel-${VERSION}${RC}"
+readonly BASEURI="https://releases.bazel.build/${VERSION}/${FOLDER}"
+
+
+function doMirror () {
+  local PACKAGE=$1
+  local FILENAME=$2
+
+  wget -P ${PACKAGE}/ ${BASEURI}/${FILENAME}
+  tmp=$(mktemp)
+  jq ".bin.bazel = \"./${FILENAME}\" | .version = \"${NEWVERSION}\"" < ${PACKAGE}/package.json > $tmp
+  mv $tmp ${PACKAGE}/package.json
+}
+
+doMirror bazel-win32_x64 ${BASENAME}-windows-x86_64.exe
+doMirror bazel-darwin_x64 ${BASENAME}-darwin-x86_64
+doMirror bazel-linux_x64 ${BASENAME}-linux-x86_64
+
+tmp=$(mktemp)
+jq ".version = \"${NEWVERSION}\" | .optionalDependencies[] = \"${NEWVERSION}\"" < bazel/package.json > $tmp
+mv $tmp bazel/package.json
+
+echo "Done, inspect the result and then publish the packages"
+


### PR DESCRIPTION
note, there isn't a native node api to replace the node process with bazel, so it stays a child process.

We could use https://github.com/jprichardson/node-kexec/blob/master/src/kexec.cc but then it's different between windows and mac/linux