### PR TITLE
jasmine_node_test: pass templated_args through to nodejs_test.

### DIFF
--- a/internal/jasmine_node_test/jasmine_node_test.bzl
+++ b/internal/jasmine_node_test/jasmine_node_test.bzl
@@ -60,6 +60,7 @@ def jasmine_node_test(
     all_data += [Label("//internal/jasmine_node_test:jasmine_runner.js")]
     all_data += [":%s_devmode_srcs.MF" % name]
     entry_point = "build_bazel_rules_nodejs/internal/jasmine_node_test/jasmine_runner.js"
+
     # If the target specified templated_args, pass it through.
     templated_args = kwargs.pop("templated_args", []) + ["$(location :%s_devmode_srcs.MF)" % name]
 

--- a/internal/jasmine_node_test/jasmine_node_test.bzl
+++ b/internal/jasmine_node_test/jasmine_node_test.bzl
@@ -60,12 +60,14 @@ def jasmine_node_test(
     all_data += [Label("//internal/jasmine_node_test:jasmine_runner.js")]
     all_data += [":%s_devmode_srcs.MF" % name]
     entry_point = "build_bazel_rules_nodejs/internal/jasmine_node_test/jasmine_runner.js"
+    # If the target specified templated_args, pass it through.
+    templated_args = kwargs.pop("templated_args", []) + ["$(location :%s_devmode_srcs.MF)" % name]
 
     nodejs_test_macro(
         name = name,
         data = all_data,
         entry_point = entry_point,
-        templated_args = ["$(location :%s_devmode_srcs.MF)" % name],
+        templated_args = templated_args,
         expected_exit_code = expected_exit_code,
         tags = tags,
         **kwargs

--- a/packages/jasmine/src/jasmine_node_test.bzl
+++ b/packages/jasmine/src/jasmine_node_test.bzl
@@ -59,7 +59,9 @@ def jasmine_node_test(
     all_data += [Label("@bazel_tools//tools/bash/runfiles")]
     entry_point = "@bazel/jasmine/src/jasmine_runner.js"
 
-    templated_args = ["$(location :%s_devmode_srcs.MF)" % name]
+    # If the target specified templated_args, pass it through.
+    templated_args = kwargs.pop("templated_args", []) + ["$(location :%s_devmode_srcs.MF)" % name]
+
     if coverage:
         templated_args = templated_args + ["--coverage"]
     else:

--- a/packages/jasmine/test/BUILD.bazel
+++ b/packages/jasmine/test/BUILD.bazel
@@ -71,3 +71,13 @@ jasmine_node_test(
         "@npm//v8-coverage",
     ],
 )
+
+jasmine_node_test(
+    name = "templated_args_test",
+    srcs = ["templated_args_test.js"],
+    jasmine = "@npm//jasmine",
+    templated_args = [
+        "--node_options=--experimental-modules",
+    ],
+    deps = ["//:jasmine_runner"],
+)

--- a/packages/jasmine/test/templated_args_test.js
+++ b/packages/jasmine/test/templated_args_test.js
@@ -1,0 +1,6 @@
+describe('args', () => {
+  it('should pass through templated_args', () => {
+    // without --node_options=--experimental-modules this will fail
+import('../index');
+  });
+});


### PR DESCRIPTION
Currently, it is not possible to specify `templated_args` on a `jasmine_node_test`. This is because the `jasmine_node_test` implementation unconditionally passes its own `templated_args` to the underlying `nodejs_test` rule. It is an error in the loading phase to have a target with duplicated keywords. 

My use case is to pass `--node_options=--experimental-modules` to the underlying `nodejs_binary`, which allows node to load ES modules [natively](https://nodejs.org/api/esm.html).

General support for ES modules in rules_nodejs is a larger topic that calls for more design and discussion, but I think this commit is independently useful. Thoughts? 