### PR TITLE
Set use_default_shell_env in rollup example

### DIFF
--- a/examples/rollup/rollup.bzl
+++ b/examples/rollup/rollup.bzl
@@ -27,6 +27,7 @@ def _rollup(ctx):
       inputs = ctx.files.srcs,
       executable = ctx.executable.rollup,
       outputs = [ctx.outputs.bundle],
+      use_default_shell_env = True,
       arguments = args,
   )
   return [DefaultInfo()]


### PR DESCRIPTION
The `rollup` command needs `grep`, `cut`, `dirname` and other commands
to be available under the hood. But we can't rely on that to be true
without `use_default_shell_env = True`. That's because without this
flag, shell scripts use Bash's default `PATH` (since `/usr/bin/env -`
clears the entire environment). That default `PATH` will be different
on different platforms, and is not guaranteed to contain all the shell
commands this script expects to be able to call. Indeed, on NixOS the
default `PATH` for Bash is `/no-such-path`.

If turning on `use_default_shell_env` makes your nervous, it
shouldn't. According to https://github.com/bazelbuild/bazel/pull/6263,
`--experimental_strict_action_env` will become the default in Bazel
v0.20. This means that the default env will be restricted, standard
and small. (So this shouldn't hurt hermeticity - actually it should
help it.)