### PR TITLE
Update to bazel_skylib 0.5.0

### DIFF
--- a/internal/e2e/node_loader_no_preserve_symlinks/WORKSPACE
+++ b/internal/e2e/node_loader_no_preserve_symlinks/WORKSPACE
@@ -1,16 +1,13 @@
 workspace(name = "node_loader_e2e_no_preserve_symlinks")
 
-http_archive(
-    name = "bazel_skylib",
-    url = "https://github.com/bazelbuild/bazel-skylib/archive/0.3.1.zip",
-    strip_prefix = "bazel-skylib-0.3.1",
-    sha256 = "95518adafc9a2b656667bbf517a952e54ce7f350779d0dd95133db4eb5c27fb1",
-)
-
 local_repository(
     name = "build_bazel_rules_nodejs",
     path = "../../..",
 )
+
+load("@build_bazel_rules_nodejs//:package.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
 

--- a/internal/e2e/node_loader_preserve_symlinks/WORKSPACE
+++ b/internal/e2e/node_loader_preserve_symlinks/WORKSPACE
@@ -1,16 +1,13 @@
 workspace(name = "node_loader_e2e_preserve_symlinks")
 
-http_archive(
-    name = "bazel_skylib",
-    url = "https://github.com/bazelbuild/bazel-skylib/archive/0.3.1.zip",
-    strip_prefix = "bazel-skylib-0.3.1",
-    sha256 = "95518adafc9a2b656667bbf517a952e54ce7f350779d0dd95133db4eb5c27fb1",
-)
-
 local_repository(
     name = "build_bazel_rules_nodejs",
     path = "../../..",
 )
+
+load("@build_bazel_rules_nodejs//:package.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
 

--- a/package.bzl
+++ b/package.bzl
@@ -58,9 +58,9 @@ def rules_nodejs_dependencies():
     _maybe(
         http_archive,
         name = "bazel_skylib",
-        url = "https://github.com/bazelbuild/bazel-skylib/archive/0.3.1.zip",
-        strip_prefix = "bazel-skylib-0.3.1",
-        sha256 = "95518adafc9a2b656667bbf517a952e54ce7f350779d0dd95133db4eb5c27fb1",
+        url = "https://github.com/bazelbuild/bazel-skylib/archive/0.5.0.zip",
+        strip_prefix = "bazel-skylib-0.5.0",
+        sha256 = "ca4e3b8e4da9266c3a9101c8f4704fe2e20eb5625b2a6a7d2d7d45e3dd4efffd",
     )
 
     # Needed for Remote Build Execution


### PR DESCRIPTION
Version 0.3.1 doesn't work with rules_typescript... rules_typescript currently installs 0.5.0 as the dep:

```
    ###############################################
    # Repeat the dependencies of rules_nodejs here!
    # We can't load() from rules_nodejs yet, because we've only just fetched it.
    # But we also don't want to make users load and call the rules_nodejs_dependencies
    # function because we can do that for them, mostly hiding the transitive dependency.
    _maybe(
        http_archive,
        name = "bazel_skylib",
        url = "https://github.com/bazelbuild/bazel-skylib/archive/0.5.0.zip",
        strip_prefix = "bazel-skylib-0.5.0",
        sha256 = "ca4e3b8e4da9266c3a9101c8f4704fe2e20eb5625b2a6a7d2d7d45e3dd4efffd",
    )
```