### PR TITLE
fix: local workspace path not always properly determined

### DIFF
--- a/internal/e2e/node/BUILD.bazel
+++ b/internal/e2e/node/BUILD.bazel
@@ -26,7 +26,10 @@ jasmine_node_test(
         ":data_resolution_lib",
         ":module_resolution_lib",
     ],
-    data = ["data/data.json"],
+    data = [
+        "data/data.json",
+        ":genfile-runfile",
+    ],
     node_modules = "//internal/test:node_modules",
     deps = ["//internal/e2e/node/lib1"],
 )
@@ -43,4 +46,14 @@ genrule(
     srcs = ["data_resolution.spec.js"],
     outs = ["data_resolution_built.spec.js"],
     cmd = "cp $< $@",
+)
+
+# This genrule creates a file that alphabetically comes before any source file in this
+# package. This genfile can be then set up as runfile to verify that the "node_loader.js"
+# properly determines the local workspace path without incorrectly using the genfile as base
+# for the local workspace path. See: https://github.com/bazelbuild/rules_nodejs/issues/352
+genrule(
+    name = "genfile-runfile",
+    outs = ["#LEADING.txt"],
+    cmd = "touch $@",
 )

--- a/internal/e2e/node/data_resolution.spec.js
+++ b/internal/e2e/node/data_resolution.spec.js
@@ -30,7 +30,7 @@ describe('node data resolution', () => {
     const thisFilePath = __filename;
     const relativePathFromDataToThisFile = path.join('../', path.basename(thisFilePath));
     const joinedPathFromDataToThisFile = path.join(path.dirname(resolvedRelativeDataPath), 
-      relativePathFromDataToThisFile)
+      relativePathFromDataToThisFile);
     
     const resolvedPathFromDataToThisFile = require.resolve(joinedPathFromDataToThisFile);
     expect(resolvedPathFromDataToThisFile).toEqual(thisFilePath);


### PR DESCRIPTION
Since there can be also runfiles which refer to the current `USER_WORKSPACE`, but actually resolve to the bazel output instead of to the actual local workspace, it can happen that the `node_loader` determines a wrong path to the local workspace.

We can safely fix this by just ensuring that the runfile, which potentially resolves to the local workspace, does not refer to the bazel-bin or bazel-genfiles directory (those paths are templated)

Fixes #352.

cc. @alexeagle 