### PR TITLE
Set --network-timeout option in yarn_install

### DIFF
--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -196,6 +196,8 @@ def _yarn_install_impl(repository_ctx):
     "network",
     "--cwd",
     repository_ctx.path(""),
+    "--network-timeout",
+    str(repository_ctx.attr.timeout*1000), # in ms
   ]
 
   if repository_ctx.attr.prod_only:


### PR DESCRIPTION
This should mitigate yarn install timeouts on slow networks. I've seen timeouts while running a Windows VM on OSX and yarn install timeouts have been seen on occasion in CircleCI.

Note: default --network-timeout option in yarn is 30s