### PR TITLE
Always replace 0.0.0-PLACEHOLDER even if there's no stamp info

### DIFF
--- a/internal/npm_package/packager.js
+++ b/internal/npm_package/packager.js
@@ -47,21 +47,24 @@ function main(args) {
     // Strip content between BEGIN-INTERNAL / END-INTERNAL comments
     [/(#|\/\/)\s+BEGIN-INTERNAL[\w\W]+END-INTERNAL/g, ''],
   ];
+  let version = '0.0.0';
   if (stampFile) {
     // The stamp file is expected to look like
     // BUILD_SCM_HASH 83c699db39cfd74526cdf9bebb75aa6f122908bb
     // BUILD_SCM_LOCAL_CHANGES true
     // BUILD_SCM_VERSION 6.0.0-beta.6+12.sha-83c699d.with-local-changes
     // BUILD_TIMESTAMP 1520021990506
+    //
+    // We want version to be the 6.0.0-beta... part
     const versionTag = fs.readFileSync(stampFile, {encoding: 'utf-8'})
                            .split('\n')
                            .find(s => s.startsWith('BUILD_SCM_VERSION'));
     // Don't assume BUILD_SCM_VERSION exists
     if (versionTag) {
-      const version = versionTag.split(' ')[1].trim();
-      replacements.push([/0.0.0-PLACEHOLDER/g, version]);
+      version = versionTag.split(' ')[1].trim();
     }
   }
+  replacements.push([/0.0.0-PLACEHOLDER/g, version]);
   const rawReplacements = JSON.parse(replacementsArg);
   for (let key of Object.keys(rawReplacements)) {
     replacements.push([new RegExp(key, 'g'), rawReplacements[key]])


### PR DESCRIPTION
This makes it easier to test that the replacement happens in ng_package without having to stamp the artifacts