### PR TITLE
fix(rollup_bundle): add resolve({..., browser:true})

### DIFF
--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -165,8 +165,12 @@ const config = {
   },
   plugins: [TMPL_additional_plugins].concat([
     {resolveId: resolveBazel},
-    nodeResolve(
-        {jsnext: true, module: true, customResolveOptions: {moduleDirectory: nodeModulesRoot}}),
+    nodeResolve({
+      jsnext: true,
+      module: true,
+      browser: true,
+      customResolveOptions: {moduleDirectory: nodeModulesRoot}
+    }),
     {resolveId: notResolved},
     sourcemaps(),
   ])


### PR DESCRIPTION
This is useful for bundling zone.js and other npm packages that contains
the browser field in the package.json