### PR TITLE
rollup_bundle: stop --silent rollup to let it report all build errors

### DIFF
--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -154,8 +154,6 @@ const inputs = [TMPL_inputs];
 const enableCodeSplitting = inputs.length > 1;
 
 const config = {
-  resolveBazel,
-  banner,
   onwarn: ({loc, frame, message}) => {
     // Always fail on warnings, assuming we don't know which are harmless.
     // We can add exclusions here based on warning.code, if we discover some
@@ -192,5 +190,7 @@ else {
     name: 'TMPL_global_name',
   };
 }
+
+config.output.banner = banner;
 
 module.exports = config;

--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -156,11 +156,14 @@ const enableCodeSplitting = inputs.length > 1;
 const config = {
   resolveBazel,
   banner,
-  onwarn: (warning) => {
+  onwarn: ({loc, frame, message}) => {
     // Always fail on warnings, assuming we don't know which are harmless.
     // We can add exclusions here based on warning.code, if we discover some
     // types of warning should always be ignored under bazel.
-    throw new Error(warning.message);
+    if (loc) {
+      throw new Error(`${loc.file} (${loc.line}:${loc.column}) ${message}`);
+    }
+    throw new Error(message);
   },
   plugins: [TMPL_additional_plugins].concat([
     {resolveId: resolveBazel},

--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -174,7 +174,6 @@ const config = {
 
 if (enableCodeSplitting) {
   config.experimentalCodeSplitting = true;
-  config.experimentalDynamicImport = true;
   config.input = inputs;
   config.output = {
     format: 'TMPL_output_format',

--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -164,10 +164,10 @@ const config = {
     throw new Error(message);
   },
   plugins: [TMPL_additional_plugins].concat([
-    {resolveId: resolveBazel},
+    {name: 'bazel-resolve', resolveId: resolveBazel},
     nodeResolve(
         {jsnext: true, module: true, customResolveOptions: {moduleDirectory: nodeModulesRoot}}),
-    {resolveId: notResolved},
+    {name: 'bazel-not-resolved', resolveId: notResolved},
     sourcemaps(),
   ])
 }
@@ -191,8 +191,5 @@ else {
 }
 
 config.output.banner = banner;
-
-// export resolveBazel for testing without triggering unknown config error.
-config.plugins.resolveBazel = resolveBazel;
 
 module.exports = config;

--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -192,4 +192,7 @@ else {
 
 config.output.banner = banner;
 
+// export resolveBazel for testing without triggering unknown config error.
+config.plugins.resolveBazel = resolveBazel;
+
 module.exports = config;

--- a/internal/rollup/rollup.config.spec.js
+++ b/internal/rollup/rollup.config.spec.js
@@ -33,7 +33,7 @@ const resolve =
 const rollupConfig = require('./rollup.config');
 
 function doResolve(importee, importer) {
-  const resolved = rollupConfig.resolveBazel(importee, importer, baseDir, resolve, rootDir);
+  const resolved = rollupConfig.plugins.resolveBazel(importee, importer, baseDir, resolve, rootDir);
   if (resolved) {
     return resolved.replace(/\\/g, '/');
   } else {
@@ -72,7 +72,7 @@ describe('rollup config', () => {
     expect(doResolve(`other${sep}thing`))
         .toEqual(`${baseDir}/bazel-bin/path/to/a.esm5/external/other_wksp/path/to/other_lib/thing`);
     expect(doResolve(`@bar${sep}baz${sep}foo`))
-      .toEqual(`${baseDir}/bazel-bin/path/to/a.esm5/path/to/bar/baz_lib/foo`);        
+        .toEqual(`${baseDir}/bazel-bin/path/to/a.esm5/path/to/bar/baz_lib/foo`);
   });
 
   it('should find paths in any root', () => {

--- a/internal/rollup/rollup.config.spec.js
+++ b/internal/rollup/rollup.config.spec.js
@@ -31,9 +31,10 @@ const resolve =
     }
 
 const rollupConfig = require('./rollup.config');
+const resolveBazel = rollupConfig.plugins.find(({name}) => name === 'bazel-resolve').resolveId;
 
 function doResolve(importee, importer) {
-  const resolved = rollupConfig.plugins.resolveBazel(importee, importer, baseDir, resolve, rootDir);
+  const resolved = resolveBazel(importee, importer, baseDir, resolve, rootDir);
   if (resolved) {
     return resolved.replace(/\\/g, '/');
   } else {

--- a/internal/rollup/rollup_bundle.bzl
+++ b/internal/rollup/rollup_bundle.bzl
@@ -169,7 +169,10 @@ def _run_rollup(ctx, sources, config, output, map_output = None):
 
     # We will produce errors as needed. Anything else is spammy: a well-behaved
     # bazel rule prints nothing on success.
-    args.add("--silent")
+    #
+    # TODO(https://github.com/rollup/rollup/issues/2582): Uncomment the following
+    # line once rollup stops reporting build errors with onwarn.
+    # args.add("--silent")
 
     if ctx.attr.globals:
         args.add("--external")


### PR DESCRIPTION
This CL removes `--silent` flag when running `rollup` to let it report all the warnings and errors (due to rollup/rollup#2582) during the build. The warning message now contains location info when available.

As a result of this change, some config errors are found and fixed as well:

- set banner with `config.output.banner` instead of `config.banner` as the latter is deprecated in rollup/rollup@ffe4e5b.
- removed `config.experimentalDynamicImport` as rollup/rollup@4d4ec4c made it default and removed it.
- stop exporting `resolveBazel` in `config` to avoid triggering unknown config error, and let the test to find it in plug-in list by name.

Updates #447 
