### PR TITLE
Improve failure message for invalid jasmine_node_test setup

### DIFF
--- a/internal/jasmine_node_test/jasmine_runner.js
+++ b/internal/jasmine_node_test/jasmine_runner.js
@@ -1,6 +1,19 @@
 const fs = require('fs');
-const path = require('path');
-const JasmineRunner = require('jasmine/lib/jasmine');
+let JasmineRunner = null;
+
+try {
+  JasmineRunner = require('jasmine/lib/jasmine');
+} catch (e) {
+  if (e.code && e.code === 'MODULE_NOT_FOUND') {
+    throw new Error('When using the "jasmine_node_test" rule, please make sure that the ' +
+      '"jasmine" node module is available as a runtime dependency (add to "deps").\nRead more: ' +
+      'https://github.com/bazelbuild/rules_nodejs#fine-grained-npm-package-dependencies.');
+  }
+
+  // In case the error is not about finding "jasmine" within the runfiles, just
+  // rethrow the original exception so that it's still possible to debug.
+  throw e;
+}
 
 const UTF8 = {
   encoding: 'utf-8'

--- a/internal/jasmine_node_test/test/BUILD.bazel
+++ b/internal/jasmine_node_test/test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
+load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test", "nodejs_test")
 
 jasmine_node_test(
     name = "underscore_spec_test",
@@ -22,4 +22,13 @@ jasmine_node_test(
     name = "dot_test_test",
     srcs = ["foo.test.js"],
     node_modules = "//internal/test:node_modules",
+)
+
+nodejs_test(
+    name = "no_jasmine_test",
+    entry_point = "build_bazel_rules_nodejs/internal/jasmine_node_test/test/no_jasmine_test.js",
+    data = [
+        "no_jasmine_test.js",
+        "//internal/jasmine_node_test:jasmine_runner.js"
+    ],
 )

--- a/internal/jasmine_node_test/test/no_jasmine_test.js
+++ b/internal/jasmine_node_test/test/no_jasmine_test.js
@@ -1,0 +1,8 @@
+try {
+  require('../jasmine_runner');
+} catch (e) {
+  // Assert that the error message is about jasmine not being available. In case it's a different
+  // exception, just exit with error code **3** (this is the failed tests exit code for Bazel)
+  process.exit(e.message.match(/make sure.*jasmine.*available/) ? 0 : 3)
+}
+


### PR DESCRIPTION
This improves the developer experience if people just use `jasmine_node_test` without adding `jasmine` as an actual runtime dependency. Related to #344 