### PR TITLE
Remove spammy log in node_loader.js when require.resolve() throws

### DIFF
--- a/internal/node/node_loader.js
+++ b/internal/node/node_loader.js
@@ -344,16 +344,11 @@ module.constructor._resolveFilename = function(request, parent) {
   const moduleRoot = resolveToModuleRoot(request);
   if (moduleRoot) {
     const moduleRootInRunfiles = resolveRunfiles(undefined, moduleRoot);
-    try {
-      const filename = module.constructor._findPath(moduleRootInRunfiles, []);
-      if (!filename) {
-        throw new Error(`No file ${request} found in module root ${moduleRoot}`);
-      }
-      return filename;
-    } catch (e) {
-      console.error(`Failed to findPath for ${moduleRootInRunfiles}`);
-      throw e;
+    const filename = module.constructor._findPath(moduleRootInRunfiles, []);
+    if (!filename) {
+      throw new Error(`No file ${request} found in module root ${moduleRoot}`);
     }
+    return filename;
   }
 
   // Built-in modules, relative, absolute imports and npm dependencies


### PR DESCRIPTION
This removed logged is spammy if a require.resolve() call is expected to fail like this karma code in rules_typescript:

```
try {
  // attempt to resolve in @bazel/karma nested node_modules first
  return require.resolve(f.replace(/^NODE_MODULES\//, '@bazel/karma/node_modules/'));
} catch (e) {
  // if that failed then attempt to resolve in root node_modules
  return require.resolve(f.replace(/^NODE_MODULES\//, ''));
}
```

The following logs show up in all karma test logs:

```
Failed to findPath for /private/var/tmp/_bazel_greg/837d12dda6835e241d9d3083438c6bb6/sandbox/darwin-sandbox/1/execroot/build_bazel_rules_typescript/bazel-out/darwin-fastbuild/bin/examples/testing/testing_chromium-local.runfiles/build_bazel_rules_typescript/internal/karma/node_modules/requirejs/require.js
Failed to findPath for /private/var/tmp/_bazel_greg/837d12dda6835e241d9d3083438c6bb6/sandbox/darwin-sandbox/1/execroot/build_bazel_rules_typescript/bazel-out/darwin-fastbuild/bin/examples/testing/testing_chromium-local.runfiles/build_bazel_rules_typescript/internal/karma/node_modules/karma-requirejs/lib/adapter.js
```

The code throws when this happens so it should be up to the calling code to catch the error or not or to log or not.