### PR TITLE
Consider all matches in resolveToModuleRoot

### DIFF
--- a/internal/node/node_loader.js
+++ b/internal/node/node_loader.js
@@ -30,9 +30,12 @@ const DEBUG = false;
 /**
  * The module roots as pairs of a RegExp to match the require path, and a
  * module_root to substitute for the require path.
+ * Ordered by regex length, longest to smallest. 
  * @type {!Array<{module_name: RegExp, module_root: string}>}
  */
-var MODULE_ROOTS = [TEMPLATED_module_roots];
+var MODULE_ROOTS = [
+  TEMPLATED_module_roots
+].sort((a, b) => b.module_name.toString().length - a.module_name.toString().length);
 
 /**
  * Array of bootstrap modules that need to be loaded before the entry point.
@@ -59,22 +62,16 @@ function resolveToModuleRoot(path) {
     throw new Error('resolveToModuleRoot missing path: ' + path);
   }
 
-  var match;
-  var lengthOfMatch = 0;
-  for (var i = 0; i < MODULE_ROOTS.length; i++) {
-    var m = MODULE_ROOTS[i];
-    var p = path.replace(m.module_name, m.module_root);
-    // Longest regex wins when multiple match
-    var len = m.module_name.toString().length;
-    if (p !== path && len > lengthOfMatch) {
-      lengthOfMatch = len;
-      match = p;
-    }
+  // We want all possible matches.
+  const orderedMatches = MODULE_ROOTS.filter(m => m.module_name.test(path));
+
+  if (orderedMatches.length === 0) {
+    return null;
+  } else {
+    // Longest regex wins when multiple match, and the list is already ordered by length.
+    const m = orderedMatches[0];
+    return path.replace(m.module_name, m.module_root);
   }
-  if (match) {
-    return match;
-  }
-  return null;
 }
 
 /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Given `'rxjs/ajax/index.js'` as `path`, and the following resolutions:
```
var MODULE_ROOTS = [
  {module_name: /^rxjs\/ajax\/\b/, module_root: 'rxjs/ajax/'},
  {module_name: /^rxjs\/ajax\b/, module_root: 'rxjs/ajax/index.js'},
]
```

The current algorithm would disregard the first match because it left the string unchanged, even though it was the longest regex.

This caused it to return `rxjs/ajax/index.js/index.js` instead of `rxjs/ajax/index.js`.

Followup to https://github.com/bazelbuild/rules_nodejs/pull/474, related to a failure observed in https://github.com/angular/angular/pull/27764.


## What is the new behavior?
`rxjs/ajax/index.js` is returned for the given example.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I couldn't find any tests for this logic. Are there any I should be adding tests to @alexeagle @gregmagolan?
