### PR TITLE
ci: make sure the CI checks for unformatted files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
 
       # Run the Buildifier linter to check our Bazel rules.
       - run: 'yarn bazel:format -mode=check ||
-              (echo "BUILD files not formatted. Please run 'yarn bazel:lint'" ; exit 1)'
+              (echo "BUILD files not formatted. Please run ''yarn bazel:lint''" ; exit 1)'
 
   # Overlaps with testing we do on BuildKite. This is still here because:
   # - BuildKite doesn't have a public results UI; failures here let contributors fix their changes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,14 @@ jobs:
 
       - run: yarn install
 
-      # Run the Buildifier linter to check our Bazel rules.
-      - run: 'yarn bazel:format -mode=check ||
-              (echo "BUILD files not formatted. Please run ''yarn bazel:lint''" ; exit 1)'
+      # Run the Buildifier to check our Bazel rules for format issues.
+      - run: 'yarn bazel:format --mode=check ||
+              (echo "BUILD files not formatted. Please run ''yarn bazel:format --mode=fix''" ; exit 1)'
+
+      # Run the Buildifier to check our Bazel rules for lint issues.
+      # Note: The `--lint=warn` will auto fixe (re-write) the affected files. 
+      - run: 'yarn bazel:format --lint=warn ||
+              (echo "BUILD files contain unresolved lint errors. Please fix manually the remaining errors." ; exit 1)'
 
   # Overlaps with testing we do on BuildKite. This is still here because:
   # - BuildKite doesn't have a public results UI; failures here let contributors fix their changes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,16 +64,9 @@ jobs:
 
       - run: yarn install
 
-      # Run the skylark linter to check our Bazel rules
-      # Note, this is not yet enforced, because
-      # - buildifier doesn't exit non-zero in the presence of lint warnings: https://github.com/bazelbuild/buildtools/issues/470
-      # - false positive for rule docstrings: https://github.com/bazelbuild/buildtools/issues/471
-      - run: 'yarn bazel:lint ||
-              (echo -e "\n.bzl files have lint errors. Please run ''yarn bazel:lint-fix''"; exit 1)'
-
-      # Enforce that BUILD files are formatted.
+      # Run the Buildifier linter to check our Bazel rules.
       - run: 'yarn bazel:format -mode=check ||
-              (echo "BUILD files not formatted. Please run ''yarn bazel:format''" ; exit 1)'
+              (echo "BUILD files not formatted. Please run 'yarn bazel:lint'" ; exit 1)'
 
   # Overlaps with testing we do on BuildKite. This is still here because:
   # - BuildKite doesn't have a public results UI; failures here let contributors fix their changes


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

The CI currently check and auto-fix the unformatted BUILD files.


## What is the new behavior?

We make sure that the CI only checks and failes on unformatted BUILD files.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

