### PR TITLE
Add support for --additional_module_roots flag to nodejs_binary node_loader.js

### DIFF
--- a/internal/node/node_loader.js
+++ b/internal/node/node_loader.js
@@ -33,9 +33,29 @@ const DEBUG = false;
  * Ordered by regex length, longest to smallest. 
  * @type {!Array<{module_name: RegExp, module_root: string}>}
  */
-var MODULE_ROOTS = [
-  TEMPLATED_module_roots
-].sort((a, b) => b.module_name.toString().length - a.module_name.toString().length);
+var MODULE_ROOTS = [TEMPLATED_module_roots];
+
+/**
+ * Allow for additional module_roots to be passed in via
+ * a --additional_module_roots that takes a stringified JSON
+ * array as its value
+ */
+const args = process.argv.slice(2);
+for (var i = 0; i < args.length; i++) {
+  if (args[i] === '--additional_module_roots') {
+    try {
+      const additionalModuleRoots = JSON.parse(args[i + 1]) || [];
+      MODULE_ROOTS = MODULE_ROOTS.concat(additionalModuleRoots.map(m => {
+        return {module_name: new RegExp(m.module_name), module_root: m.module_root};
+      }));
+    } catch (e) {
+      throw new Error(`Invalid --additional_module_roots: ${e.toString()}`);
+    }
+  }
+}
+
+MODULE_ROOTS =
+    MODULE_ROOTS.sort((a, b) => b.module_name.toString().length - a.module_name.toString().length);
 
 /**
  * Array of bootstrap modules that need to be loaded before the entry point.

--- a/internal/web_package/assembler_spec.js
+++ b/internal/web_package/assembler_spec.js
@@ -2,16 +2,23 @@ const assembler = require('./assembler');
 const path = require('path');
 const fs = require('fs');
 
+function mkdirp(p) {
+  if (!fs.existsSync(p)) {
+    mkdirp(path.dirname(p));
+    fs.mkdirSync(p);
+  }
+}
+
 describe('assembler', () => {
     const outdir = 'output';
     beforeEach(() => {
         const now = Date.now();
         // prevent test isolation failures by running each spec in a separate dir
         const uniqueDir = path.join(process.env['TEST_TMPDIR'], String(now));
-        fs.mkdirSync(uniqueDir);
+        mkdirp(uniqueDir);
         process.chdir(uniqueDir);
-        fs.mkdirSync('path');
-        fs.mkdirSync('path/to');
+        mkdirp('path');
+        mkdirp('path/to');
         fs.writeFileSync('path/to/thing1.txt', 'some content', {encoding: 'utf-8'});
 
     });


### PR DESCRIPTION
Adds --additional_module_roots flag to nodejs_binary node_loader.js.

prereq for https://github.com/angular/angular/pull/27785.

Needs tests still.