### PR TITLE
Increase `npm/yarn install` timeout and add new arg for `--network-timeout`

### DIFF
--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -198,9 +198,9 @@ cd "{root}" && "{npm}" {npm_args}
 npm_install = repository_rule(
     attrs = dict(COMMON_ATTRIBUTES, **{
         "timeout": attr.int(
-            default = 600,
+            default = 3600,
             doc = """Maximum duration of the command "npm install" in seconds
-            (default is 600 seconds).""",
+            (default is 3600 seconds).""",
         ),
         "package_lock_json": attr.label(
             allow_single_file = True,
@@ -239,7 +239,7 @@ def _yarn_install_impl(repository_ctx):
         "--cwd",
         repository_ctx.path(""),
         "--network-timeout",
-        str(repository_ctx.attr.timeout * 1000),  # in ms
+        str(repository_ctx.attr.network_timeout * 1000),  # in ms
     ]
 
     if repository_ctx.attr.prod_only:
@@ -271,9 +271,14 @@ def _yarn_install_impl(repository_ctx):
 yarn_install = repository_rule(
     attrs = dict(COMMON_ATTRIBUTES, **{
         "timeout": attr.int(
-            default = 600,
-            doc = """Maximum duration of the command "yarn" in seconds.
-            (default is 600 seconds).""",
+            default = 3600,
+            doc = """Maximum duration of the command "yarn install" in seconds
+            (default is 3600 seconds).""",
+        ),
+        "network_timeout": attr.int(
+            default = 300,
+            doc = """Maximum duration of a network request made by yarn in seconds
+            (default is 300 seconds).""",
         ),
         "use_global_yarn_cache": attr.bool(
             default = True,


### PR DESCRIPTION
## PR Checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
- [x] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)


## What is the current behavior?
Previously, the `timeout` arg was used for both the `repository_ctx.execute()` timeout and the yarn's `--network-timeout`. Yet, in some cases the default 10mins timeout is not enough for the `npm/yarn install` job to complete (e.g. on CI VM with slow network connection). Additionally, it makes little sense to set the per-request network timeout and the overall command timeout (which potentially involves multiple network requests) to the same value.


## What is the new behavior?
This PR introduces a new arg for `yarn_install()` to set `--network-timeout` (defaulting to 5mins) and increases the default `timeout` value to 60mins (from 10mins).


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Not sure


## Other information
Run into this while investigating buildkite failures related to angular/angular#27508.