### PR TITLE
Allow custom rollup config

### DIFF
--- a/internal/rollup/rollup_bundle.bzl
+++ b/internal/rollup/rollup_bundle.bzl
@@ -111,7 +111,7 @@ def write_rollup_config(ctx, plugins = [], root_dir = None, filename = "_%s.roll
 
     ctx.actions.expand_template(
         output = config,
-        template = ctx.file._rollup_config_tmpl,
+        template = ctx.file.rollup_config_tmpl,
         substitutions = {
             "TMPL_additional_plugins": ",\n".join(plugins),
             "TMPL_banner_file": "\"%s\"" % ctx.file.license_banner.path if ctx.file.license_banner else "undefined",
@@ -196,7 +196,7 @@ def _run_rollup(ctx, sources, config, output, map_output = None):
         outputs += [map_output]
 
     ctx.actions.run(
-        executable = ctx.executable._rollup,
+        executable = ctx.executable.rollup,
         inputs = depset(direct_inputs, transitive = [sources]),
         outputs = outputs,
         arguments = [args],
@@ -594,17 +594,17 @@ ROLLUP_ATTRS = {
         doc = """Other rules that produce JavaScript outputs, such as `ts_library`.""",
         aspects = ROLLUP_DEPS_ASPECTS,
     ),
-    "_no_explore_html": attr.label(
-        default = Label("@build_bazel_rules_nodejs//internal/rollup:no_explore.html"),
-        allow_single_file = True,
-    ),
-    "_rollup": attr.label(
+    "rollup": attr.label(
         executable = True,
         cfg = "host",
         default = Label("@build_bazel_rules_nodejs//internal/rollup:rollup"),
     ),
-    "_rollup_config_tmpl": attr.label(
+    "rollup_config_tmpl": attr.label(
         default = Label("@build_bazel_rules_nodejs//internal/rollup:rollup.config.js"),
+        allow_single_file = True,
+    ),
+    "_no_explore_html": attr.label(
+        default = Label("@build_bazel_rules_nodejs//internal/rollup:no_explore.html"),
         allow_single_file = True,
     ),
     "_source_map_explorer": attr.label(


### PR DESCRIPTION
Hi 👋 

Lately I've been experimenting with Bazel for a React app and would like to use the `rollup_bundle` rule to produce my final bundle.

To get my bundle working correctly I needed to customize some of the config with things like:

* The replace plugin: https://github.com/rollup/rollup/issues/719#issuecomment-227872509
* The commonjs plugin: #483 

I originally started down the path of trying to customize the existing template and rollup process, but because you need to install npm packages for the plugins I found the existing route very limiting and overly complex for trying to add support for all the different plugins & configurations.

Instead, this PR makes the `rollup` & `rollup_config_tmpl` rule attrs non-private so that users wishing to change the way the rollup process works can simply define their own.

I originally looked at #234, but found it super complicated for my needs.  This was a straight forward change that works well for me locally.

For reference, my files for this setup look like this:

**web/BUILD.bazel**
```python
package(default_visibility = ["//visibility:public"])

load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")

exports_files([
    "rollup.config.js",
    "tsconfig.json"
])

nodejs_binary(
    name = "rollup",
    entry_point = "rollup/bin/rollup",
    data = [
        "@npm//rollup",
        "@npm//rollup-plugin-commonjs",
        "@npm//rollup-plugin-includepaths",
        "@npm//rollup-plugin-node-resolve",
        "@npm//rollup-plugin-replace",
    ],
)
```

**web/rollup.config.js**
```javascript
const path = require('path');

import includePaths from 'rollup-plugin-includepaths';
import nodeResolve from 'rollup-plugin-node-resolve';
import commonjs from 'rollup-plugin-commonjs';
import replace from 'rollup-plugin-replace';

// The Bazel rollup rule will write these template vars out before running rollup
const inputs = [TMPL_inputs];
const rootDir = 'TMPL_rootDir';
const nodeModulesRoot = 'TMPL_node_modules_root';

const config = {
  onwarn: (warning) => {
    // warnings should be fatal
    throw new Error(warning.message);
  },
  plugins: [
    // include our Bazel root dir
    includePaths({
      paths: [rootDir],
    }),

    // resolve against our node modules
    nodeResolve({
      customResolveOptions: {
        moduleDirectory: nodeModulesRoot,
      }
    }),

    // support commonjs
    commonjs(),

    // replace NODE_ENV with the appropriate env
    replace({
      'process.env.NODE_ENV': JSON.stringify('production'),
    }),
  ],
  output: {
    format: 'TMPL_output_format',
  }
};

if (inputs.length > 1) {
  // code splitting
  config.experimentalCodeSplitting = true;
  config.experimentalDynamicImport = true;
  config.input = inputs;
  if (process.env.ROLLUP_BUNDLE_FIXED_CHUNK_NAMES) {
    config.output.chunkFileNames = '[name].js';
  }
} else {
  // single bundle
  config.input = inputs[0];
  config.output['name'] = 'TMPL_global_name';
}

export default config;
```

**web/admin/BUILD.bazel**
```python
...

rollup_bundle(
    name = "bundle",
    deps = npm_deps + [
        ":admin",
    ],
    entry_point = "web/admin/index",
    rollup = "//web:rollup",
    rollup_config_tmpl = "//web:rollup.config.js",
)

...
```

If you're OK with this change I can sign the CLA and add tests for it.

These issues can be closed in favor of this one if it lands:

* #483 
* #441 
* #235 
* #234 
* #216 