### PR TITLE
Default to quiet=True for yarn_install and npm_install now that Bazel outputs progress

### DIFF
--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -76,7 +76,7 @@ COMMON_ATTRIBUTES = dict(dict(), **{
         doc = "Don't install devDependencies",
     ),
     "quiet": attr.bool(
-        default = False,
+        default = True,
         doc = "If stdout and stderr should be printed to the terminal.",
     ),
 })


### PR DESCRIPTION
As of Bazel 0.20.0 progress is reported for repository rules such as yarn_install and npm_install so feedback is on by default for these rules which can take some time to complete.

Quiet defaulting to false was intended as a stop-gap measure while Bazel was working on the above change.

Reference: https://github.com/bazelbuild/rules_nodejs/pull/427#issuecomment-440277731