### PR TITLE
Symlink yarn lock file if exclude_packages is empty.

### DIFF
--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -166,7 +166,8 @@ cd "{root}" && "{npm}" {npm_args}
         else:
             repository_ctx.symlink(
                 repository_ctx.attr.package_lock_json,
-                repository_ctx.path("package-lock.json"))
+                repository_ctx.path("package-lock.json"),
+            )
 
     _add_package_json(repository_ctx)
     _add_data_dependencies(repository_ctx)
@@ -236,7 +237,8 @@ def _yarn_install_impl(repository_ctx):
         else:
             repository_ctx.symlink(
                 repository_ctx.attr.yarn_lock,
-                repository_ctx.path("yarn.lock"))
+                repository_ctx.path("yarn.lock"),
+            )
 
     _add_package_json(repository_ctx)
     _add_data_dependencies(repository_ctx)

--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -155,13 +155,18 @@ cd "{root}" && "{npm}" {npm_args}
         )
 
     if repository_ctx.attr.package_lock_json:
-        # Copy the file over instead of using a symlink since the lock file
-        # will be modified if there are excluded_packages
-        repository_ctx.template(
-            "package-lock.json",
-            repository_ctx.path(repository_ctx.attr.package_lock_json),
-            {},
-        )
+        if repository_ctx.attr.exclude_packages:
+            # Copy the file over instead of using a symlink since the lock file
+            # will be modified if there are excluded_packages
+            repository_ctx.template(
+                "package-lock.json",
+                repository_ctx.path(repository_ctx.attr.package_lock_json),
+                {},
+            )
+        else:
+            repository_ctx.symlink(
+                repository_ctx.attr.package_lock_json,
+                repository_ctx.path("package-lock.json"))
 
     _add_package_json(repository_ctx)
     _add_data_dependencies(repository_ctx)
@@ -220,13 +225,18 @@ def _yarn_install_impl(repository_ctx):
     yarn = get_yarn_label(repository_ctx)
 
     if repository_ctx.attr.yarn_lock:
-        # Copy the file over instead of using a symlink since the lock file
-        # will be modified if there are excluded_packages
-        repository_ctx.template(
-            "yarn.lock",
-            repository_ctx.path(repository_ctx.attr.yarn_lock),
-            {},
-        )
+        if repository_ctx.attr.exclude_packages:
+            # Copy the file over instead of using a symlink since the lock file
+            # will be modified if there are excluded_packages
+            repository_ctx.template(
+                "yarn.lock",
+                repository_ctx.path(repository_ctx.attr.yarn_lock),
+                {},
+            )
+        else:
+            repository_ctx.symlink(
+                repository_ctx.attr.yarn_lock,
+                repository_ctx.path("yarn.lock"))
 
     _add_package_json(repository_ctx)
     _add_data_dependencies(repository_ctx)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the past rules_nodejs would symlink `yarn.lock` which was nice because I could just update a package in the `package.json` file, then do `bazel run` and my `yarn.lock` would be updated automatically. At some point this behaviour was broken.

Issue Number: N/A


## What is the new behavior?
If `exclude_packages` are empty I see no reason for the copy to take place and it would be nice to have a way to get the previous behaviour back that I kind of got to rely on.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

