### PR TITLE
WIP: Allow for overriding jasmineCore in bootstrap of jasmine_node_test via global.jasmineCore

### DIFF
--- a/internal/jasmine_node_test/jasmine_runner.js
+++ b/internal/jasmine_node_test/jasmine_runner.js
@@ -37,7 +37,18 @@ function main(args) {
   // Remove the manifest, some tested code may process the argv.
   process.argv.splice(2, 1)[0];
 
-  const jrunner = new JasmineRunner();
+  // Initialize jasmine with the jasmineCore in options so that if
+  // global.jasmineCore is set then that jasmineCore will be used.
+  // This is so that a bootstrap script provide a patched version of
+  // jasmineCore if necessary. For example:
+  // ```
+  // const jasmineCore = require('jasmine-core');
+  // const patchedJasmine = jasmineCore.boot(jasmineCore);
+  // ...patch jasmine here...
+  // jasmineCore.boot = function() { return patchedJasmine; };
+  // global.jasmineCore = jasmineCore;
+  // ```
+  const jrunner = new JasmineRunner({jasmineCore: global.jasmineCore});
   fs.readFileSync(manifest, UTF8)
       .split('\n')
       .filter(l => l.length > 0)


### PR DESCRIPTION
This solves an issue that came up in the angular/flex-layout jasmine_node_test bootstrap script where an `afterEach` that was being called was not taking effect in jasmine.

The solution was to add step 6 to the bootstrap script in flex-layout and this PR picks that up so that the patched jasmineCore is used in jasmine_node_test:

```
// This hack is needed to get jasmine, node and zone working inside bazel.
// 1) we load `jasmine-core` which contains the ENV: it, describe etc...
const jasmineCore: any = require('jasmine-core');
// 2) We create an instance of `jasmine` ENV.
const patchedJasmine = jasmineCore.boot(jasmineCore);
// 3) Save the `jasmine` into global so that `zone.js/dist/jasmine-patch.js` can get a hold of it to
// patch it.
(global as any)['jasmine'] = patchedJasmine;
// 4) Change the `jasmine-core` to make sure that all subsequent jasmine's have the same ENV,
// otherwise the patch will not work.
//    This is needed since Bazel creates a new instance of jasmine and it's ENV and we want to make
//    sure it gets the same one.
jasmineCore.boot = function() {
  return patchedJasmine;
};
// 5) Patch jasmine ENV with code which understands ProxyZone.
import 'zone.js/dist/jasmine-patch.js';
// 6) Save the patched `jasmineCore` into global so that
// `@build_bazel_rules_nodejs//internal/jasmine_node_test/jasmine_runner.js` can get a hold of it
(global as any)['jasmineCore'] = jasmineCore;
```