### PR TITLE
don't include external/ directory in npm_package

### DIFF
--- a/internal/npm_package/packager.js
+++ b/internal/npm_package/packager.js
@@ -96,7 +96,9 @@ function main(args) {
   }
 
   // deps like bazel-bin/baseDir/my/path is copied to outDir/my/path
-  for (dep of depsArg.split(',').filter(s => !!s)) {
+  // Don't include external directories in the package, these should be installed
+  // by users outside of the package.
+  for (dep of depsArg.split(',').filter(s => !!s && !s.startsWith('external/'))) {
     const content = fs.readFileSync(dep, {encoding: 'utf-8'});
     write(outPath(dep), content, replacements);
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "homepage": "https://github.com/bazelbuild/rules_nodejs",
     "license": "Apache-2.0",
     "devDependencies": {
+        "@bazel/bazel": "^0.21.0",
         "@bazel/buildifier": "^0.20.0",
         "clang-format": "1.2.2",
         "husky": "^0.14.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,30 @@
 # yarn lockfile v1
 
 
+"@bazel/bazel-darwin_x64@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@bazel/bazel-darwin_x64/-/bazel-darwin_x64-0.21.0.tgz#db033b6880294ed274489d3bce4a36c77dbf5a7a"
+  integrity sha512-9lI9SFHUm50ufJHD/5gOdJeuaI/hdGji5d0ezYWJdJK55tj4VhcatkJumjYD6yp1nPNnU038AZ7JvkPcTgt7OA==
+
+"@bazel/bazel-linux_x64@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@bazel/bazel-linux_x64/-/bazel-linux_x64-0.21.0.tgz#d9ba05ff405c52d09878ecfb89872bda2fda418e"
+  integrity sha512-CyOblC7pMIMaXwkQazo/jz2ipmIkxngmVCTzjNKGO9GiZK71L4X/B8Simy3tFhDHZFxso2HkvJTiY1UJozFyZw==
+
+"@bazel/bazel-win32_x64@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@bazel/bazel-win32_x64/-/bazel-win32_x64-0.21.0.tgz#f2f40f40b862f368d8596b4f69152640bd15e2ed"
+  integrity sha512-ELNF4ddUCnd1Qx9359tJ5DenlVK0e5Yoe7PVv+qWNQKSCjguh8jtRy9IlzGZHjn8tFMSnTQjYYY0DgW1W1sbSA==
+
+"@bazel/bazel@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@bazel/bazel/-/bazel-0.21.0.tgz#8582f225a70d8edff26bd89efad5550c4fc17140"
+  integrity sha512-XeT0omRhtUMSzX0Gjme2ECnWtHRPD2Gak7/ewfpGs0pw1IaCvVy/ilaqr6u5g0Kr8SI8KevP7ezKrejXXpJwbQ==
+  optionalDependencies:
+    "@bazel/bazel-darwin_x64" "0.21.0"
+    "@bazel/bazel-linux_x64" "0.21.0"
+    "@bazel/bazel-win32_x64" "0.21.0"
+
 "@bazel/buildifier-darwin_x64@0.20.0":
   version "0.20.0"
   resolved "https://registry.yarnpkg.com/@bazel/buildifier-darwin_x64/-/buildifier-darwin_x64-0.20.0.tgz#1aeceb5a1a57a62eef6415377dbe95091781a7d4"


### PR DESCRIPTION
I can't think of a reason why someone would want this directory in the package. It's only possible when your npm_package rule is declared in the root package anyway. But we should think a bit more about whether there's a case for vendoring your external deps this way, or whether some other files you publish might have references into the external/ directory?