### PR TITLE
Improve error message in npm_package if a file fails to copy

### DIFF
--- a/internal/npm_package/packager.js
+++ b/internal/npm_package/packager.js
@@ -99,8 +99,13 @@ function main(args) {
   // Don't include external directories in the package, these should be installed
   // by users outside of the package.
   for (dep of depsArg.split(',').filter(s => !!s && !s.startsWith('external/'))) {
-    const content = fs.readFileSync(dep, {encoding: 'utf-8'});
-    write(outPath(dep), content, replacements);
+    try {
+      const content = fs.readFileSync(dep, {encoding: 'utf-8'});
+      write(outPath(dep), content, replacements);
+    } catch (e) {
+      console.error(`Failed to copy ${dep} to ${outPath(dep)}`);
+      throw e;
+    }
   }
 
   // package contents like bazel-bin/baseDir/my/directory/* is


### PR DESCRIPTION
I ran into this exception yesterday and it is helpful to know which file the copy failed on