### PR TITLE
Fix npm_package to support multiple BEGIN-INTERNAL/END-INTERNAL blocks in a file

### DIFF
--- a/internal/npm_package/packager.js
+++ b/internal/npm_package/packager.js
@@ -45,7 +45,7 @@ function main(args) {
 
   const replacements = [
     // Strip content between BEGIN-INTERNAL / END-INTERNAL comments
-    [/(#|\/\/)\s+BEGIN-INTERNAL[\w\W]+END-INTERNAL/g, ''],
+    [/(#|\/\/)\s+BEGIN-INTERNAL[\w\W]+?END-INTERNAL/g, ''],
   ];
   let version = '0.0.0';
   if (stampFile) {


### PR DESCRIPTION
Adding a non-greedy qualifier to the wildcard between BEGIN-INTERNAL & END-INTERNAL fixes https://github.com/bazelbuild/rules_nodejs/issues/516