### PR TITLE
Fix windows node_loader  resolution bug in resolveManifestDirectory()

### DIFF
--- a/internal/node/node_loader.js
+++ b/internal/node/node_loader.js
@@ -234,7 +234,7 @@ function resolveManifestFile(res) {
 }
 
 function resolveManifestDirectory(res) {
-  const pkgfile = runfilesManifest[`${res}/package.json`];
+  const pkgfile = runfilesManifest[path.posix.join(res, 'package.json')];
   if (pkgfile) {
     try {
       const pkg = JSON.parse(fs.readFileSync(pkgfile, 'UTF-8'));
@@ -257,7 +257,7 @@ function resolveManifestDirectory(res) {
     } catch (e) {
     }
   }
-  return resolveManifestFile(`${res}/index`)
+  return resolveManifestFile(path.posix.join(res, 'index'));
 }
 
 function resolveRunfiles(parent, ...pathSegments) {


### PR DESCRIPTION
Fixes Windows node_loader resolution bug that came up in https://github.com/bazelbuild/rules_typescript/pull/374.