### PR TITLE
Allow Bazel to create symlinks

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,13 +1,6 @@
 # Print test logs for failed tests
 test --test_output=errors
 
-# Don't create symlinks like bazel-out in the project.
-# These cause VSCode to traverse a massive tree, opening file handles and
-# eventually a surprising failure with auto-discovery of the C++ toolchain in
-# MacOS High Sierra.
-# See https://github.com/bazelbuild/bazel/issues/4603
-build --symlink_prefix=/
-
 # Mock versoning command to test the --stamp behavior
 build --workspace_status_command="echo BUILD_SCM_VERSION 1.2.3"
 


### PR DESCRIPTION
Now that https://github.com/bazelbuild/bazel/issues/4603 is resolved, it's convenient to have them again