### PR TITLE
Fix release archive npm_package rule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,6 +21,9 @@ npm_package(
         "defs.bzl",
         "package.bzl",
     ],
+    # Don't replace the default 0.0.0-PLACEHOLDER for this npm_package since
+    # we are packaging up the packager itself and this replacement will break it
+    replace_with_version = "",
     deps = [
         "//third_party/github.com/bazelbuild/bazel-skylib:package_contents",
         "//third_party/github.com/buffer-from:package_contents",
@@ -40,9 +43,6 @@ npm_package(
         "//internal/web_package:package_contents",
         "//tools:package_contents",
     ],
-    # Don't replace the default 0.0.0-PLACEHOLDER for this npm_package since
-    # we are packaging up the packager itself and this replacement will break it
-    replace_with_version = "",
 )
 
 npm_package(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -40,6 +40,9 @@ npm_package(
         "//internal/web_package:package_contents",
         "//tools:package_contents",
     ],
+    # Don't replace the default 0.0.0-PLACEHOLDER for this npm_package since
+    # we are packaging up the packager itself and this replacement will break it
+    replace_with_version = "",
 )
 
 npm_package(
@@ -48,6 +51,9 @@ npm_package(
     # The WORKSPACE file isn't in the distribution, but is required for local_repository
     srcs = ["WORKSPACE"],
     packages = [":rules_nodejs_package"],
+    # Don't replace the default 0.0.0-PLACEHOLDER for this npm_package since
+    # we are packaging up the packager itself and this replacement will break it
+    replace_with_version = "",
 )
 
 # This artifact is published to GitHub along with each release

--- a/internal/npm_package/npm_package.bzl
+++ b/internal/npm_package/npm_package.bzl
@@ -52,6 +52,7 @@ def create_package(ctx, deps_sources, nested_packages):
     args.add_joined([p.path for p in nested_packages], join_with = ",", omit_if_empty = False)
     args.add(ctx.attr.replacements)
     args.add_all([ctx.outputs.pack.path, ctx.outputs.publish.path])
+    args.add(ctx.attr.replace_with_version)
     args.add(ctx.version_file.path if ctx.version_file else "")
 
     inputs = ctx.files.srcs + deps_sources + nested_packages + [ctx.file._run_npm_template]
@@ -115,10 +116,12 @@ NPM_PACKAGE_ATTRS = {
         allow_files = True,
     ),
     "replacements": attr.string_dict(
-        doc = """Key-value pairs which are replaced in all the files while building the package.
-        Note that the special value 0.0.0-PLACEHOLDER is always replaced with the version stamp data.
-        See the section on stamping in the README.
-        """,
+        doc = """Key-value pairs which are replaced in all the files while building the package.""",
+    ),
+    "replace_with_version": attr.string(
+        doc = """If set this value is replaced with the version stamp data.
+        See the section on stamping in the README.""",
+        default = "0.0.0-PLACEHOLDER",
     ),
     "deps": attr.label_list(
         doc = """Other targets which produce files that should be included in the package, such as `rollup_bundle`""",

--- a/internal/npm_package/npm_package.bzl
+++ b/internal/npm_package/npm_package.bzl
@@ -115,13 +115,13 @@ NPM_PACKAGE_ATTRS = {
         doc = """Other npm_package rules whose content is copied into this package.""",
         allow_files = True,
     ),
-    "replacements": attr.string_dict(
-        doc = """Key-value pairs which are replaced in all the files while building the package.""",
-    ),
     "replace_with_version": attr.string(
         doc = """If set this value is replaced with the version stamp data.
         See the section on stamping in the README.""",
         default = "0.0.0-PLACEHOLDER",
+    ),
+    "replacements": attr.string_dict(
+        doc = """Key-value pairs which are replaced in all the files while building the package.""",
     ),
     "deps": attr.label_list(
         doc = """Other targets which produce files that should be included in the package, such as `rollup_bundle`""",

--- a/internal/npm_package/test/npm_package.spec.js
+++ b/internal/npm_package/test/npm_package.spec.js
@@ -28,4 +28,7 @@ describe('npm_package srcs', () => {
   it('copies data dependencies', () => {
     expect(read('data.json')).toEqual('[]');
   });
+  it('replaced 0.0.0-PLACEHOLDER', () => {
+    expect(read('package.json').version).not.toEqual('0.0.0-PLACEHOLDER');
+  });
 });


### PR DESCRIPTION
Disables the 0.0.0-PLACEHOLDER replacement for the archive package since it re-writes the npm_package rule and breaks it.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

