### PR TITLE
Fix jasmine_runner.js so that an already initialized jasmine will be used

### DIFF
--- a/internal/e2e/jasmine/BUILD.bazel
+++ b/internal/e2e/jasmine/BUILD.bazel
@@ -2,8 +2,8 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 
 jasmine_node_test(
     name = "shared_env_test",
+    srcs = ["jasmine_shared_env_test.spec.js"],
     bootstrap = ["build_bazel_rules_nodejs/internal/e2e/jasmine/jasmine_shared_env_bootstrap.js"],
     data = ["jasmine_shared_env_bootstrap.js"],
-    srcs = ["jasmine_shared_env_test.spec.js"],
     node_modules = "//internal/test:node_modules",
 )

--- a/internal/e2e/jasmine/BUILD.bazel
+++ b/internal/e2e/jasmine/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
+
+jasmine_node_test(
+    name = "shared_env_test",
+    bootstrap = ["build_bazel_rules_nodejs/internal/e2e/jasmine/jasmine_shared_env_bootstrap.js"],
+    data = ["jasmine_shared_env_bootstrap.js"],
+    srcs = ["jasmine_shared_env_test.spec.js"],
+    node_modules = "//internal/test:node_modules",
+)

--- a/internal/e2e/jasmine/jasmine_shared_env_bootstrap.js
+++ b/internal/e2e/jasmine/jasmine_shared_env_bootstrap.js
@@ -1,0 +1,21 @@
+global.foobar = 1;
+
+require('zone.js/dist/zone-node.js');
+require('zone.js/dist/long-stack-trace-zone.js');
+require('zone.js/dist/proxy.js');
+require('zone.js/dist/sync-test.js');
+require('zone.js/dist/async-test.js');
+require('zone.js/dist/fake-async-test.js');
+require('zone.js/dist/task-tracking.js');
+
+// This hack is needed to get jasmine, node and zone working inside bazel.
+// Initialize jasmine by calling jasmineCore boot. This will initialize
+// global.jasmine so that it can be patched by zone.js jasmine-patch.js.
+const jasmineCore = require('jasmine-core');
+jasmineCore.boot(jasmineCore);
+
+// Test that a bootstrap afterEach() is preserved in the jasmine tests
+afterEach(() => global.foobar++);
+
+// Test that the jasmine zone patch is preserved in the jasmine tests
+require('zone.js/dist/jasmine-patch.js');

--- a/internal/e2e/jasmine/jasmine_shared_env_test.spec.js
+++ b/internal/e2e/jasmine/jasmine_shared_env_test.spec.js
@@ -1,0 +1,14 @@
+describe('jasmine_shared_env_test', () => {
+  it('global.foobar should be 1', () => {
+    expect(global.foobar).toBe(1);
+  });
+  it('afterEach should have run and global.foobar should now be 2', () => {
+    expect(global.foobar).toBe(2);
+  });
+  it('afterEach should have run and global.foobar should now be 3', () => {
+    expect(global.foobar).toBe(3);
+  });
+  it('should have the jasmine zone patch applies', () => {
+    expect(global.jasmine['__zone_patch__']).toBe(true);
+  })
+});

--- a/internal/test/package.json
+++ b/internal/test/package.json
@@ -13,7 +13,8 @@
     "rollup-plugin-node-resolve": "3.0.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup": "0.60.1",
-    "unidiff": "^0.0.4"
+    "unidiff": "^0.0.4",
+    "zone.js": "0.8.29"
   },
   "dependencies": {}
 }

--- a/internal/test/yarn.lock
+++ b/internal/test/yarn.lock
@@ -435,3 +435,8 @@ urix@^0.1.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+zone.js@0.8.29:
+  version "0.8.29"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.29.tgz#8dce92aa0dd553b50bc5bfbb90af9986ad845a12"
+  integrity sha512-mla2acNCMkWXBD+c+yeUrBUrzOxYMNFdQ6FGfigGGtEVBPJx07BQeJekjt9DmH1FtZek4E9rE1eRR9qQpxACOQ==


### PR DESCRIPTION
Replaces #497 and fixes issue found in https://github.com/angular/flex-layout/pull/964.

A jasmine_node_test bootstrap script now only needs the following lines and jasmine_runner will share the initialized jasmine:

```
const jasmineCore: any = require('jasmine-core');
jasmineCore.boot(jasmineCore);
```

`jasmineCore.boot(jasmineCore)` will initialize `global.jasmine`. For reference, the current bootstrap looks like: https://github.com/angular/angular/blob/master/tools/testing/init_node_no_angular_spec.ts

If using zone.js, call `jasmine-patch.js` after `boot()` to patch `global.jasmine`:

```
import 'zone.js/dist/jasmine-patch.js';
```

Now if the bootstrap script modifies the jasmine env with something like this:

```
afterEach(() => testBedInstance.resetTestingModule());
```

jasmine_runner.js will persist that configuration as it will used the initialized jasmine. With the current code, jasmine_runner will not persist the configuration (or the zone patch).