### PR TITLE
Fix fs.copyFileSync `EACCES: permission denied` failure

### DIFF
--- a/internal/web_package/assembler.js
+++ b/internal/web_package/assembler.js
@@ -70,7 +70,12 @@ function main(params) {
     }
   }
 
-  for (const f of params) {
+  // Remove duplicate files (which may come from this rule) from the
+  // list since fs.copyFileSync may fail with `EACCES: permission denied`
+  // as it will not have permission to overwrite duplicate files that were
+  // copied from within bazel-bin.
+  const files = [...new Set(params)];
+  for (const f of files) {
     copy(f);
   }
   return 0;

--- a/internal/web_package/assembler.js
+++ b/internal/web_package/assembler.js
@@ -74,8 +74,8 @@ function main(params) {
   // list since fs.copyFileSync may fail with `EACCES: permission denied`
   // as it will not have permission to overwrite duplicate files that were
   // copied from within bazel-bin.
-  const files = [...new Set(params)];
-  for (const f of files) {
+  // See https://github.com/bazelbuild/rules_nodejs/pull/546.
+  for (const f of new Set(params)) {
     copy(f);
   }
   return 0;

--- a/internal/web_package/test/BUILD.bazel
+++ b/internal/web_package/test/BUILD.bazel
@@ -1,9 +1,19 @@
-load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
+load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test", "rollup_bundle")
 load("@build_bazel_rules_nodejs//internal/web_package:web_package.bzl", "web_package")
+
+rollup_bundle(
+    name = "bundle",
+    srcs = glob(["*.js"]),
+    entry_point = "internal/web_package/test/script.js",
+)
 
 web_package(
     name = "pkg",
-    assets = ["script.js"],
+    # Intentionally duplicating `bundle.min.js` in assets and data
+    # to test for regression of the issues fixed by
+    # https://github.com/bazelbuild/rules_nodejs/pull/546
+    assets = [":bundle.min.js"],
+    data = [":bundle"],
     index_html = "index.html",
 )
 

--- a/internal/web_package/test/index_golden.html_
+++ b/internal/web_package/test/index_golden.html_
@@ -1,2 +1,2 @@
 <html><head></head><body>
-<script type="text/javascript" src="/script.js?v=123"></script></body></html>
+<script type="text/javascript" src="/bundle.min.js?v=123"></script></body></html>


### PR DESCRIPTION
Showed up in https://github.com/angular/angular/pull/28625 bazel-schematics integration test. It looks like it only happens under Linux.