### PR TITLE
make node_repositories optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ npm_install(
 )
 ```
 
+> If you don't need to pass any arguments to `node_repositories`,
+  you can skip calling that function. `yarn_install` and `npm_install` will do it by default.
+
 #### yarn_install vs. npm_install
 
 `yarn_install` is the preferred rule for setting up Bazel-managed dependencies for a number of reasons:

--- a/README.md
+++ b/README.md
@@ -17,9 +17,114 @@ so this repo can be thought of as "JavaScript rules for Bazel" as well.
 Generated documentation for using each rule is at:
 https://bazelbuild.github.io/rules_nodejs/
 
-## Installation
+## Quickstart
 
-First, install a current bazel distribution, following the [bazel instructions].
+This is the most common workflow to get started.
+See sections below for details and alternative methods.
+
+1. Add dependencies
+
+    ```sh
+    $ yarn add -D @bazel/bazel @bazel/ibazel @bazel/buildifier
+    ```
+
+    or if you prefer `npm`,
+
+    ```sh
+    $ npm install --save-dev @bazel/bazel @bazel/ibazel @bazel/buildifier
+    ```
+
+2. Create a file called `WORKSPACE` in the root of your repo, containing
+
+    ```python
+    load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+    http_archive(
+        name = "build_bazel_rules_nodejs",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.18.6/rules_nodejs-0.18.6.tar.gz"],
+        sha256 = "1416d03823fed624b49a0abbd9979f7c63bbedfd37890ddecedd2fe25cccebc6",
+    )
+
+    load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")
+    yarn_install(
+        name = "npm",
+        package_json = "//:package.json",
+        yarn_lock = "//:yarn.lock",
+    )
+    ```
+
+    or if you used `npm`:
+
+    ```python
+    load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+    http_archive(
+        name = "build_bazel_rules_nodejs",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.18.6/rules_nodejs-0.18.6.tar.gz"],
+        sha256 = "1416d03823fed624b49a0abbd9979f7c63bbedfd37890ddecedd2fe25cccebc6",
+    )
+
+    load("@build_bazel_rules_nodejs//:defs.bzl", "npm_install")
+    npm_install(
+        name = "npm",
+        package_json = "//:package.json",
+        package_lock_json = "//:package-lock.json",
+    )
+    ```
+
+3. In your `package.json`, find the `"scripts"` section, or create one.
+
+    ```json
+    "scripts": {
+        "build": "bazel build //...",
+        "test": "ibazel test //..."
+    }
+    ```
+
+4. Test that you can do an initial build. It will report that no targets were found yet.
+
+    ```sh
+    $ yarn build
+    ```
+
+    or 
+
+    ```sh
+    $ npm run build
+    ```
+
+## Adding Build Targets
+
+Consult the documentation at http://bazel.build for details.
+
+Create a file called `BUILD.bazel` and invoke some rules to create targets.
+
+Some of the available rules are:
+
+| Rule | Description    |
+| -------| ------|
+| [nodejs_binary]  | Allows you to run an application by giving the entry point. The entry point can come from an external dependency installed by the package manager, or it can be a `.js` file from a package built by Bazel. |
+| [nodejs_test]    | The same as `nodejs_binary`, but instead of calling it with `bazel run`, you call it with `bazel test`. The test passes if the program exits with a zero exit code. |
+| [jasmine_node_test] | Allows you to write a test that executes in NodeJS using the [Jasmine] test framework. |
+| [rollup_bundle] | Runs the Rollup and Uglify toolchain to produce a single JavaScript bundle from multiple JavaScript sources. |
+| [npm_package] | Creates a package format ready to publish to npm. Can also do the publishing. |
+| [ts_library] | Compiles TypeScript code into JavaScript |
+| [karma_web_test] | Runs tests in a browser using the [Karma] test runner |
+
+[nodejs_binary]: https://bazelbuild.github.io/rules_nodejs/node/node.html#nodejs_binary
+[nodejs_test]: https://bazelbuild.github.io/rules_nodejs/node/node.html#nodejs_test
+[jasmine_node_test]: https://www.npmjs.com/package/@bazel/jasmine
+[Jasmine]: https://jasmine.github.io/
+[rollup_bundle]: https://bazelbuild.github.io/rules_nodejs/rollup/rollup_bundle.html#rollup_bundle
+[npm_package]: https://bazelbuild.github.io/rules_nodejs/npm_package/npm_package.html#npm_package
+[ts_library]: https://www.npmjs.com/package/@bazel/typescript
+[Karma]: https://karma-runner.github.io/latest/index.html
+[karma_web_test]: https://www.npmjs.com/package/@bazel/karma
+
+## Custom installation
+
+First, you need Bazel.
+We recommend fetching it from npm to keep your frontend workflow similar.
+
+> You could install a current bazel distribution, following the [bazel instructions].
 
 Next, create a `WORKSPACE` file in your project root (or edit the existing one)
 containing:
@@ -390,23 +495,6 @@ Note: the arguments passed to `bazel run` after `--` are forwarded to the execut
 
 ## Usage
 
-The complete API documentation is at https://bazelbuild.github.io/rules_nodejs/
-
-A few examples of rules contained in this repository:
-
-The `nodejs_binary` rule allows you to run an application by giving the entry point.
-The entry point can come from an external dependency installed by the package manager,
-or it can be a `.js` file from a package built by Bazel.
-
-`nodejs_test` is the same as nodejs_binary, but instead of calling it with `bazel run`,
-you call it with `bazel test`. The test passes if the program exits with a zero exit code.
-
-The `jasmine_node_test` rule allows you to write a test that executes in NodeJS.
-
-`rollup_bundle` runs the Rollup and Uglify toolchain to produce a single JavaScript bundle.
-
-`npm_package` packages up a library to publish to npm.
-
 ### Running a program from npm
 
 The `nodejs_binary` rule lets you run a program with Node.js.
@@ -461,11 +549,7 @@ See the `examples/program` directory in this repository.
 
 ### Testing
 
-The `jasmine_node_test` rule can be used to run unit tests in NodeJS, using the Jasmine framework.
-Targets declared with this rule can be run with `bazel test`.
-See https://bazelbuild.github.io/rules_nodejs/jasmine_node_test/jasmine_node_test.html
-
-The `examples/program/index.spec.js` file illustrates this. Another usage is in https://github.com/angular/tsickle/blob/master/test/BUILD
+The `examples/program/index.spec.js` file illustrates testing. Another usage is in https://github.com/angular/tsickle/blob/master/test/BUILD
 
 ### Stamping
 
@@ -500,20 +584,6 @@ Ideally, `rollup_bundle` and `npm_package` should honor the `--stamp` argument t
 See https://www.kchodorow.com/blog/2017/03/27/stamping-your-builds/ for more background.
 
 [bazel_stamp_vars in Angular]: https://github.com/angular/angular/blob/master/tools/bazel_stamp_vars.sh
-
-### Bundling/optimizing
-
-A `rollup_bundle` rule produces several bundle files.
-See https://bazelbuild.github.io/rules_nodejs/rollup/rollup_bundle.html
-
-> Note: we expect other bundling rules will follow later, such as Closure compiler and Webpack.
-
-### Publishing to npm
-
-The `npm_package` rule is used to create a package to publish to external users who do not use Bazel.
-See https://bazelbuild.github.io/rules_nodejs/npm_package/npm_package.html
-
-> For those downstream dependencies that use Bazel, they can simply write BUILD files to consume your library.
 
 # Scope of the project
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -37,8 +37,6 @@ nodejs_binary = _nodejs_binary
 nodejs_test = _nodejs_test
 node_repositories = _node_repositories
 jasmine_node_test = _jasmine_node_test
-npm_install = _npm_install
-yarn_install = _yarn_install
 rollup_bundle = _rollup_bundle
 npm_package = _npm_package
 history_server = _history_server
@@ -61,3 +59,13 @@ def node_modules_filegroup(packages, patterns = [], **kwargs):
         ]] + patterns),
         **kwargs
     )
+
+def npm_install(**kwargs):
+    # Just in case the user didn't install nodejs, do it now
+    _node_repositories()
+    _npm_install(**kwargs)
+
+def yarn_install(**kwargs):
+    # Just in case the user didn't install nodejs, do it now
+    _node_repositories()
+    _yarn_install(**kwargs)

--- a/examples/bazel_managed_deps/WORKSPACE
+++ b/examples/bazel_managed_deps/WORKSPACE
@@ -8,10 +8,7 @@ local_repository(
     path = "../../bazel-bin/local_testing_package",
 )
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
-
-# Install node, npm, and yarn
-node_repositories()
+load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")
 
 # This runs yarn install, then our generate_build_file.js to create BUILD files
 # inside the resulting node_modules directory.

--- a/examples/define_var/WORKSPACE
+++ b/examples/define_var/WORKSPACE
@@ -6,9 +6,7 @@ local_repository(
     path = "../../bazel-bin/local_testing_package",
 )
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
-
-node_repositories()
+load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")
 
 yarn_install(
     name = "npm",

--- a/examples/parcel/WORKSPACE
+++ b/examples/parcel/WORKSPACE
@@ -8,9 +8,7 @@ local_repository(
     path = "../../bazel-bin/local_testing_package",
 )
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
-
-node_repositories()
+load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")
 
 yarn_install(
     name = "npm",

--- a/examples/webapp/WORKSPACE
+++ b/examples/webapp/WORKSPACE
@@ -8,9 +8,7 @@ local_repository(
     path = "../../bazel-bin/local_testing_package",
 )
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")
-
-node_repositories()
+load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")
 
 yarn_install(
     name = "npm",

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -543,7 +543,8 @@ def node_repositories(
     # 0.21.0: repository_ctx.report_progress API
     check_bazel_version("0.21.0")
 
-    _nodejs_repo(
+    _maybe(
+        _nodejs_repo,
         name = "nodejs",
         package_json = package_json,
         node_version = node_version,
@@ -557,12 +558,14 @@ def node_repositories(
         preserve_symlinks = preserve_symlinks,
     )
 
-    _yarn_repo(
+    _maybe(
+        _yarn_repo,
         name = "yarn",
         package_json = package_json,
     )
 
-    yarn_install(
+    _maybe(
+        yarn_install,
         name = "build_bazel_rules_nodejs_npm_install_deps",
         package_json = "@build_bazel_rules_nodejs//internal/npm_install:package.json",
         yarn_lock = "@build_bazel_rules_nodejs//internal/npm_install:yarn.lock",
@@ -570,26 +573,34 @@ def node_repositories(
         prod_only = True,
     )
 
-    yarn_install(
+    _maybe(
+        yarn_install,
         name = "build_bazel_rules_nodejs_rollup_deps",
         package_json = "@build_bazel_rules_nodejs//internal/rollup:package.json",
         yarn_lock = "@build_bazel_rules_nodejs//internal/rollup:yarn.lock",
     )
 
-    yarn_install(
+    _maybe(
+        yarn_install,
         name = "history-server_runtime_deps",
         package_json = "@build_bazel_rules_nodejs//internal/history-server:package.json",
         yarn_lock = "@build_bazel_rules_nodejs//internal/history-server:yarn.lock",
     )
 
-    yarn_install(
+    _maybe(
+        yarn_install,
         name = "http-server_runtime_deps",
         package_json = "@build_bazel_rules_nodejs//internal/http-server:package.json",
         yarn_lock = "@build_bazel_rules_nodejs//internal/http-server:yarn.lock",
     )
 
-    yarn_install(
+    _maybe(
+        yarn_install,
         name = "build_bazel_rules_nodejs_web_package_deps",
         package_json = "@build_bazel_rules_nodejs//internal/web_package:package.json",
         yarn_lock = "@build_bazel_rules_nodejs//internal/web_package:yarn.lock",
     )
+
+def _maybe(repo_rule, name, **kwargs):
+    if name not in native.existing_rules():
+        repo_rule(name = name, **kwargs)


### PR DESCRIPTION
The common WORKSPACE pattern is to pass no arguments to it, and use yarn_install or npm_install
We can make the trivial WORKSPACE file shorter.