### PR TITLE
Fix @bazel/typescript homepage URL

### DIFF
--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -7,7 +7,7 @@
         "typescript",
         "bazel"
     ],
-    "homepage": "https://github.com/bazelbuild/rules_nodejs/packages/typescript",
+    "homepage": "https://github.com/bazelbuild/rules_nodejs/tree/master/packages/typescript",
     "main": "./internal/tsc_wrapped/index.js",
     "typings": "./internal/tsc_wrapped/index.d.ts",
     "bin": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

`package.json` metadata change

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Clicking on `Homepage` from [npm](https://www.npmjs.com/package/@bazel/typescript) takes you to a 404 page on GitHub.

Issue Number: N/A

## What is the new behavior?

Clicking on `Homepage` from [npm](https://www.npmjs.com/package/@bazel/typescript) takes you to the `typescript` package directory on GitHub.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

