### PR TITLE
Fix _copy.sh shebang

### DIFF
--- a/internal/copy_repository/_copy.sh
+++ b/internal/copy_repository/_copy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
`/bin/bash` does not exist on all systems. E.g. [NixOS](https://nixos.org/). This patch uses `/usr/bin/env bash` instead, which will pick the correct `bash` from `PATH`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Platform compatibility


## What is the current behavior?
Loading the workspace fails with
```
ERROR: error loading package '': Encountered error while reading extension file 'defs.bzl': no such package '@build_bazel_rules_typescript//': copy_repository failed:
STDOUT:

STDERR:
java.io.IOException: Cannot run program ".../external/build_bazel_rules_typescript/./_copy.sh" (in directory ".../external/build_bazel_rules_typescript"): error=2, No such file or directory
```
Issue Number: N/A


## What is the new behavior?
Loading the workspace works.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No





## Other information

