### PR TITLE
Default runfiles to upwards directory as a last fallback

### DIFF
--- a/internal/node/node_launcher.sh
+++ b/internal/node/node_launcher.sh
@@ -31,7 +31,7 @@ if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/
       export RUNFILES_DIR="$0.runfiles"
     fi
 fi
-if [[ -f "${RUNFILES_DIR:-".."}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+if [[ -f "${RUNFILES_DIR:-..}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
   source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
 elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
   source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \

--- a/internal/node/node_launcher.sh
+++ b/internal/node/node_launcher.sh
@@ -31,7 +31,7 @@ if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/
       export RUNFILES_DIR="$0.runfiles"
     fi
 fi
-if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+if [[ -f "${RUNFILES_DIR:-".."}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
   source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
 elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
   source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \

--- a/internal/node/node_launcher.sh
+++ b/internal/node/node_launcher.sh
@@ -29,9 +29,11 @@ if [[ ! -d "${RUNFILES_DIR:-/dev/null}" && ! -f "${RUNFILES_MANIFEST_FILE:-/dev/
       export RUNFILES_MANIFEST_FILE="$0.runfiles/MANIFEST"
     elif [[ -f "$0.runfiles/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
       export RUNFILES_DIR="$0.runfiles"
+    else
+      export RUNFILES_DIR=".."
     fi
 fi
-if [[ -f "${RUNFILES_DIR:-..}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+if [[ -f "${RUNFILES_DIR:-/dev/null}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
   source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
 elif [[ -f "${RUNFILES_MANIFEST_FILE:-/dev/null}" ]]; then
   source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " \


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
When wanting to run the nodejs_binary in a custom `sh_binary`, to have some custom setup or run multiple commands for integration tests for example, one just sees the error message `ERROR: cannot find @bazel_tools//tools/bash/runfiles:runfiles.bash` when executing the binary and it is not really obvious as to why the bash runfiles can not be found.

After digging further it turns out one has to explicitely set the `RUNFILES` env variable to `..` and I wonder if it is not possible to make this use-case work out of the box as this is what we expected.

simple BUILD file example to illustrate the wrapping:
```
nodejs_binary(
    name = "app", 
    entry_point = "__main__/app.js",
    data = ["app.js", "@npm//somedep"],
)

sh_binary(
    name = "app",
    srcs = ["my_script.sh"],
    data = [":app"],
)
```


## What is the new behavior?

Defaulting RUNFILES to `..` if neither `RUNFILES_MANIFEST_FILE` nor `RUNFILES_DIR` can be set in any other way.


## Does this PR introduce a breaking change?

I would expect this to not break any existing usages, as it only adds one further case to try for the runfiles dir. And if it is still not there it will still fail.

