### PR TITLE
fix(@bazel/typescript): remove unknown rules from generated API doc

### DIFF
--- a/packages/typescript/WORKSPACE
+++ b/packages/typescript/WORKSPACE
@@ -30,11 +30,11 @@ git_repository(
 )
 
 # Needed for stardoc
-# git_repository(
-#     name = "io_bazel",
-#     commit = "1488f91fec238adacbd0517fcee15d8ec0599b8d",
-#     remote = "https://github.com/bazelbuild/bazel.git",
-# )
+git_repository(
+    name = "io_bazel",
+    commit = "1488f91fec238adacbd0517fcee15d8ec0599b8d",
+    remote = "https://github.com/bazelbuild/bazel.git",
+)
 
 # We have a source dependency on build_bazel_rules_typescript
 # so we must repeat its transitive toolchain deps

--- a/packages/typescript/docs/BUILD.bazel
+++ b/packages/typescript/docs/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_test")
 load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
 
 exports_files(["install.md"])
@@ -8,4 +9,13 @@ stardoc(
     input = "//:index.docs.bzl",
     visibility = ["//:__subpackages__"],
     deps = ["//:bzl"],
+)
+
+nodejs_test(
+    name = "test",
+    data = [
+        "docs_test.js",
+        ":index.md",
+    ],
+    entry_point = "npm_bazel_typescript/docs/docs_test.js",
 )

--- a/packages/typescript/docs/docs_test.js
+++ b/packages/typescript/docs/docs_test.js
@@ -1,0 +1,5 @@
+const actual = require('fs').readFileSync(
+    process.env['TEST_SRCDIR'] + '/npm_bazel_typescript/docs/index.md', {encoding: 'utf-8'});
+if (actual.indexOf('<unknown name>') >= 0) {
+  throw new Error('Found <unknown name> in index.md');
+}

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -61,7 +61,7 @@
         }
     },
     "scripts": {
-        "test": "bazel build //...",
+        "test": "bazel test //...",
         "// TODO": "port remaining e2e tests from rules_typescript"
     }
 }


### PR DESCRIPTION
Hopefully this fixes it so npmjs will render the README
