### PR TITLE
Build/link deps for publish release

### DIFF
--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -22,5 +22,6 @@ echo_and_run() { echo "+ $@" ; "$@" ; }
 for pkg in ${PACKAGES[@]} ; do (
     printf "\n\nBuilding & ${NPM_COMMAND}ing package ${pkg} //:npm_package\n"
     cd packages/$pkg
+    ${RULES_NODEJS_DIR}/scripts/link_deps.sh
     echo_and_run ../../node_modules/.bin/bazel --output_base=$TMP run  --workspace_status_command=../../scripts/current_version.sh //:npm_package.${NPM_COMMAND}
 ) done


### PR DESCRIPTION
link_deps.sh script will replace the `"@bazel/foobar": "bazel://@npm_bazel_foobar//:npm_package"` lines in the packages package.json files.

Note: the replacement absolute path `file://` lines in the package.json are cleaned up for the published packages in COMMON_REPLACEMENTS:

```
COMMON_REPLACEMENTS = {
    ...
    # Cleanup up package.json @bazel/foobar package deps for published packages:
    # "@bazel/foobar": "file:///..." => "@bazel/foobar": "0.0.0-PLACEHOLDER"
    "\"@bazel/([a-zA-Z_-]+)\":\\s+\"(file|bazel)[^\"]+\"": "\"@bazel/$1\": \"0.0.0-PLACEHOLDER\"",
}
```

They are replace with `"@bazel/foobar": "0.0.0-PLACEHOLDER"` which then gets replaced with the current version.