### PR TITLE
Make test sharding work with jasmine focusing

### DIFF
--- a/packages/jasmine/src/jasmine_runner.js
+++ b/packages/jasmine/src/jasmine_runner.js
@@ -93,30 +93,20 @@ function main(args) {
     process.exit(exitCode);
   });
 
-  // Re-do logic from jrunner.execute() here so that
-  // we can control which specs are executed below
-  jrunner.loadRequires();
-  jrunner.loadHelpers();
-  if (!jrunner.defaultReporterConfigured) {
-    jrunner.configureDefaultReporter({showColors: jrunner.showingColors});
-  }
-  jrunner.loadSpecs();
-  jrunner.addReporter(jrunner.completionReporter);
-
-  const allSpecs = getAllSpecs(jasmine.getEnv());
   if (TOTAL_SHARDS) {
     // Partition the specs among the shards.
     // This ensures that the specs are evenly divided over the shards.
     // Also it keeps specs in the same order and prefers to keep specs grouped together.
     // This way, common beforeEach/beforeAll setup steps aren't repeated as much over different
     // shards.
+    const allSpecs = getAllSpecs(jasmine.getEnv());
     const start = allSpecs.length * SHARD_INDEX / TOTAL_SHARDS;
     const end = allSpecs.length * (SHARD_INDEX + 1) / TOTAL_SHARDS;
-    jasmine.getEnv().execute(allSpecs.slice(start, end));
-  } else {
-    jasmine.getEnv().execute(allSpecs);
+    const enabledSpecs = allSpecs.slice(start, end);
+    jasmine.getEnv().configure({specFilter: (s) => enabledSpecs.includes(s.id)});
   }
 
+  jrunner.execute();
   return 0;
 }
 

--- a/packages/jasmine/test/BUILD.bazel
+++ b/packages/jasmine/test/BUILD.bazel
@@ -30,3 +30,13 @@ jasmine_node_test(
     jasmine = "@npm//jasmine",
     shard_count = 3,
 )
+
+jasmine_node_test(
+    name = "filtering_test",
+    srcs = ["filtering_test.js"],
+    jasmine = "@npm//jasmine",
+    # Only run this test when explicitly included in the target patterns
+    # It will fail because usage of `fit` and `fdescribe` cause Jasmine
+    # to return a 'incomplete' status
+    tags = ["manual"],
+)

--- a/packages/jasmine/test/filtering_test.js
+++ b/packages/jasmine/test/filtering_test.js
@@ -1,0 +1,15 @@
+describe('filtering', () => {
+  describe('exclusions', () => {
+    xit('should not run this one', () => {
+      fail('Ran an excluded (xit) test');
+    });
+  });
+  describe('focusing', () => {
+    fit('should run this one', () => {
+      expect(true).toBeTruthy();
+    });
+    it('should not run this one', () => {
+      fail('ran a test that was not focused');
+    });
+  });
+});


### PR DESCRIPTION
Instead of manually passing the specs, use the built-in filtering mechanism
