### PR TITLE
fix yarn_install and npm_install after changed packages

### DIFF
--- a/internal/copy_repository/copy_repository.bzl
+++ b/internal/copy_repository/copy_repository.bzl
@@ -35,6 +35,10 @@ def _copy_repository_impl(rctx):
 copy_repository = repository_rule(
     implementation = _copy_repository_impl,
     attrs = {
+        "lock_file": attr.label(
+            allow_single_file = True,
+            doc = "Though unused, this attribute is necessary to cause this rule to be re-executed anytime the node_modules changes.",
+        ),
         "marker_file": attr.label(allow_single_file = True),
     },
 )

--- a/internal/npm_install/generate_build_file.js
+++ b/internal/npm_install/generate_build_file.js
@@ -53,6 +53,7 @@ package(default_visibility = ["//visibility:public"])
 const args = process.argv.slice(2);
 const WORKSPACE = args[0];
 const INCLUDED_FILES = args[1] ? args[1].split(',') : [];
+const LOCK_FILE_LABEL = args[2];
 
 if (require.main === module) {
   main();
@@ -326,6 +327,8 @@ def _maybe(repo_rule, name, **kwargs):
         copy_repository,
         name = "${bwName}",
         marker_file = "@${WORKSPACE}//_workspaces/${bwName}:_bazel_workspace_marker",
+        # Ensure that changes to the node_modules cause the copy to re-execute
+        lock_file = "@${WORKSPACE}${LOCK_FILE_LABEL}",
     )
 `;
 

--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -81,11 +81,11 @@ COMMON_ATTRIBUTES = dict(dict(), **{
     ),
 })
 
-def _create_build_file(repository_ctx, node):
+def _create_build_file(repository_ctx, node, lock_file):
     repository_ctx.report_progress("Processing node_modules: installing Bazel packages and generating BUILD files")
     if repository_ctx.attr.manual_build_file_contents:
         repository_ctx.file("manual_build_file_contents", repository_ctx.attr.manual_build_file_contents)
-    result = repository_ctx.execute([node, "generate_build_file.js", repository_ctx.attr.name, ",".join(repository_ctx.attr.included_files)])
+    result = repository_ctx.execute([node, "generate_build_file.js", repository_ctx.attr.name, ",".join(repository_ctx.attr.included_files), str(lock_file)])
     if result.return_code:
         fail("node failed: \nSTDOUT:\n%s\nSTDERR:\n%s" % (result.stdout, result.stderr))
 
@@ -207,7 +207,7 @@ cd "{root}" && "{npm}" {npm_args}
     if result.return_code:
         fail("remove_npm_absolute_paths failed: %s (%s)" % (result.stdout, result.stderr))
 
-    _create_build_file(repository_ctx, node)
+    _create_build_file(repository_ctx, node, repository_ctx.attr.package_lock_json)
 
 npm_install = repository_rule(
     attrs = dict(COMMON_ATTRIBUTES, **{
@@ -284,7 +284,7 @@ def _yarn_install_impl(repository_ctx):
     if result.return_code:
         fail("yarn_install failed: %s (%s)" % (result.stdout, result.stderr))
 
-    _create_build_file(repository_ctx, node)
+    _create_build_file(repository_ctx, node, repository_ctx.attr.yarn_lock)
 
 yarn_install = repository_rule(
     attrs = dict(COMMON_ATTRIBUTES, **{


### PR DESCRIPTION
Previously it did not re-copy the package contents, so the bazel workspace would be stale
