### PR TITLE
Fix web_package injector nomodule issue when no matching ESModule script

### DIFF
--- a/examples/app/BUILD.bazel
+++ b/examples/app/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_nodejs//:defs.bzl", "http_server", "rollup_bundle")
+load("@build_bazel_rules_nodejs//internal/web_package:web_package.bzl", "web_package")
 load("@npm_bazel_typescript//:index.bzl", "ts_config", "ts_devserver", "ts_library")
 
 ts_library(
@@ -8,11 +9,8 @@ ts_library(
 
 ts_devserver(
     name = "devserver",
+    index_html = "index.html",
     port = 8080,
-    # This is the path we'll request from the browser, see index.html
-    serving_path = "/bundle.min.js",
-    # The devserver can serve our static files too
-    static_files = ["index.html"],
     # We'll collect all the devmode JS sources from these TypeScript libraries
     deps = [":app"],
 )
@@ -23,13 +21,22 @@ rollup_bundle(
     deps = [":app"],
 )
 
+web_package(
+    name = "package",
+    assets = [
+        # For differential loading, we supply both an ESModule entry point and an es5 entry point
+        # The injector will put two complimentary script tags in the index.html
+        ":bundle.min.js",
+        ":bundle.min.es2015.js",
+    ],
+    index_html = "index.html",
+)
+
 http_server(
     name = "prodserver",
-    data = [
-        "index.html",
-        ":bundle",
-    ],
+    data = [":package"],
     templated_args = [
+        "package",
         "-p",
         "8080",
     ],

--- a/examples/app/index.html
+++ b/examples/app/index.html
@@ -10,12 +10,5 @@
     <title>ts_devserver example</title>
   </head>
   <body>
-    <!--
-      For development mode, this script will be bundled on-the-fly by
-      the devserver, based on the latest JS files built by Bazel.
-      For production, you should be able to use the same index.html file, but
-      this JS resource would be served from a static file.
-    -->
-    <script src="/bundle.min.js"></script>
   </body>
 </html>

--- a/internal/web_package/injector_spec.js
+++ b/internal/web_package/injector_spec.js
@@ -21,7 +21,7 @@ describe('HTML injector', () => {
   it('should inject script tag', () => {
     expect(injector.main([outFile, inFile, '--assets', 'path/to/my.js'], read, write, () => 123)).toBe(0);
     expect(output).toBe(
-        '<html><head></head><body><script nomodule="" src="/path/to/my.js?v=123"></script></body></html>');
+        '<html><head></head><body><script src="/path/to/my.js?v=123"></script></body></html>');
   });
 
   it('should allow the "module js" extension', () => {
@@ -31,12 +31,20 @@ describe('HTML injector', () => {
         '<html><head></head><body><script type="module" src="/path/to/my.mjs?v=123"></script></body></html>');
   });
 
+  it('should allow the ".es2015.js" extension', () => {
+    expect(injector.main(
+               [outFile, inFile, '--assets', 'path/to/my.es2015.js'], read, write, () => 123))
+        .toBe(0);
+    expect(output).toBe(
+        '<html><head></head><body><script type="module" src="/path/to/my.es2015.js?v=123"></script></body></html>');
+  });
+
   it('should strip longest prefix', () => {
     expect(injector.main([outFile, inFile, 
       'path', 'path/to',
       '--assets', 'path/to/my.js'], read, write, () => 123)).toBe(0);
     expect(output).toBe(
-        '<html><head></head><body><script nomodule="" src="/my.js?v=123"></script></body></html>');
+        '<html><head></head><body><script src="/my.js?v=123"></script></body></html>');
   });
 
   it('should strip external workspaces', () => {
@@ -44,7 +52,7 @@ describe('HTML injector', () => {
       'npm/node_modules/zone.js/dist',
       '--assets', 'external/npm/node_modules/zone.js/dist/zone.min.js'], read, write, () => 123)).toBe(0);
     expect(output).toBe(
-        '<html><head></head><body><script nomodule="" src="/zone.min.js?v=123"></script></body></html>');
+        '<html><head></head><body><script src="/zone.min.js?v=123"></script></body></html>');
     
   });
 

--- a/internal/web_package/test/index_golden.html_
+++ b/internal/web_package/test/index_golden.html_
@@ -1,2 +1,2 @@
 <html><head></head><body>
-<script nomodule="" src="/bundle.min.js?v=123"></script></body></html>
+<script src="/bundle.min.js?v=123"></script></body></html>


### PR DESCRIPTION
Fixes regression from https://github.com/bazelbuild/rules_nodejs/pull/610 in web_package injector.js (which is also used by ts_devserver) where an non-ESModule script is tagged with `nomodule` when there is no matching ESModule script with `type="module"`. This causes the script not to load in a modern ESModule browser.