### PR TITLE
Don't load the deprecated jasmine_node_test from other rules.

### DIFF
--- a/internal/rollup/BUILD.bazel
+++ b/internal/rollup/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//:defs.bzl", "jasmine_node_test", "nodejs_binary")
+load("//:defs.bzl", "nodejs_binary")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -86,6 +86,12 @@ nodejs_binary(
     visibility = ["//visibility:public"],
 )
 
+# BEGIN-INTERNAL
+# TODO: switch to npm_bazel_jasmine
+# buildozer: disable=load-on-top
+# buildozer: disable=out-of-order-load
+load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
+
 jasmine_node_test(
     name = "test",
     srcs = glob(["*.spec.js"]),
@@ -104,6 +110,7 @@ jasmine_node_test(
     ],
 )
 
+# END-INTERNAL
 filegroup(
     name = "package_contents",
     srcs = glob(

--- a/internal/web_package/BUILD.bazel
+++ b/internal/web_package/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test", "nodejs_binary")
+load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -36,6 +36,12 @@ nodejs_binary(
     install_source_map_support = False,
 )
 
+# BEGIN-INTERNAL
+# TODO: switch to npm_bazel_jasmine
+# buildozer: disable=load-on-top
+# buildozer: disable=same-origin-load
+load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
+
 jasmine_node_test(
     name = "injector_test",
     srcs = ["injector_spec.js"],
@@ -57,6 +63,7 @@ jasmine_node_test(
     ],
 )
 
+# END-INTERNAL
 filegroup(
     name = "package_contents",
     srcs = glob(


### PR DESCRIPTION
This prints extra warnings in users builds that they can't fix (and the warnings don't even indicate what file has the dependency)
