### PR TITLE
Fix jasmine & jasmine-core requires in jasmine_runner.js

### DIFF
--- a/packages/jasmine/BUILD.bazel
+++ b/packages/jasmine/BUILD.bazel
@@ -61,6 +61,9 @@ npm_package(
 
 js_library(
     name = "jasmine_runner",
-    srcs = ["src/jasmine_runner.js"],
+    srcs = [
+        "index.js",
+        "src/jasmine_runner.js",
+    ],
     module_name = "@bazel/jasmine",
 )

--- a/packages/jasmine/index.js
+++ b/packages/jasmine/index.js
@@ -1,24 +1,4 @@
-// Try unhoisted location of `jasmine-core` which is a transitive dep of `jasmine`.
-// Try this first so that we don't accidentally fall through to the user's
-// `jasmine-core`. This file will be under `node_modules/@bazel/jasmine/index.js`.
-// `jasmine` is a direct dependency of `@bazel/jasmine` so
-// require `jasmine` will get the correct version of `jasmine`, however,
-// `jasmine-core` is a transitive dep of `jasmine` so we need to look in the
-// unhoisted location first to guarantee we will get the correct `jasmine-core`
-// which our version of `jasmine` depends on.
-let jasmineCore;
-try {
-  // Look under `node_modules/@bazel/jasmine/node_modules/jasmine/node_modules/jasmine-core`
-  jasmineCore = require('jasmine/node_modules/jasmine-core');
-} catch (e) {
-  if (e.code !== 'MODULE_NOT_FOUND') {
-    // rethrow other errors
-    throw e;
-  }
-  // Look under `node_modules/@bazel/jasmine/node_modules/jasmine-core` and
-  // falls back to `node_modules/jasmine-core` if not found there.
-  jasmineCore = require('jasmine-core');
-}
+const jasmineCore = require('jasmine-core');
 
 // a boot function for use in user bootstrap code:
 // require('@bazel/jasmine').boot()

--- a/packages/jasmine/src/jasmine_runner.js
+++ b/packages/jasmine/src/jasmine_runner.js
@@ -1,24 +1,16 @@
 const fs = require('fs');
 const path = require('path');
+const bazelJasmine = require('@bazel/jasmine');
+
+const JasmineRunner = bazelJasmine.jasmine;
 
 let jasmineCore = null
-let JasmineRunner = require('jasmine/lib/jasmine');
 if (global.jasmine) {
   // global.jasmine has been initialized which means a bootstrap script
   // has already required `jasmine-core` and called jasmineCore.boot()
   jasmineCore = global.jasmineCore;
   if (!jasmineCore) {
-    try {
-      // Try unhoisted jasmine-core first so that we don't
-      // need an @npm//jasmine-core dep in the unhoisted case.
-      jasmineCore = require('jasmine/node_modules/jasmine-core');
-    } catch (e) {
-      if (e.code !== 'MODULE_NOT_FOUND') {
-        // rethrow other errors
-        throw e;
-      }
-      jasmineCore = require('jasmine-core');
-    }
+    jasmineCore = bazelJasmine.jasmineCore;
   }
   // Override the jasmineCore boot function so that the jasmine
   // runner gets the already initialize jasmine and its shared environment


### PR DESCRIPTION
Fix for https://github.com/bazelbuild/rules_nodejs/issues/632.

Ensure `jasmine-core` version required by jasmine_runner corresponds to the `jasmine` version that `@bazel/jasmine` depends on.

In the future we may want to allow user to override the version of jasmine used by `jasmine_node_test`. @devversion pointed out that this is not currently possible as the `jasmine` attribute is now meant to point to a user's `@bazel/jasmine` npm dep and not their `jasmine` dep.