### PR TITLE
feat(rollup): provide sourcemaps for all output types

### DIFF
--- a/internal/e2e/rollup/BUILD.bazel
+++ b/internal/e2e/rollup/BUILD.bazel
@@ -18,7 +18,7 @@ rollup_bundle(
 
 jasmine_node_test(
     name = "test",
-    srcs = glob(["*.spec.js"]),
+    srcs = ["rollup.spec.js"],
     configuration_env_vars = ["UPDATE_GOLDEN"],
     data = glob([
         "*_golden.js_",
@@ -33,5 +33,50 @@ jasmine_node_test(
         "//internal/e2e:check_lib",
         "@npm//jasmine",
         "@npm//unidiff",
+    ],
+)
+
+filegroup(
+    name = "bundle-outputgroups-cjs",
+    srcs = [":bundle"],
+    output_group = "cjs",
+)
+
+filegroup(
+    name = "bundle-outputgroups-umd",
+    srcs = [":bundle"],
+    output_group = "umd",
+)
+
+filegroup(
+    name = "bundle-outputgroups-es2015",
+    srcs = [":bundle"],
+    output_group = "es2015",
+)
+
+filegroup(
+    name = "bundle-outputgroups-es5_min",
+    srcs = [":bundle"],
+    output_group = "es5_min",
+)
+
+filegroup(
+    name = "bundle-outputgroups-es5_min_debug",
+    srcs = [":bundle"],
+    output_group = "es5_min_debug",
+)
+
+jasmine_node_test(
+    name = "test-outputgroups",
+    srcs = ["outputgroups.spec.js"],
+    data = [
+        ":bundle-outputgroups-cjs",
+        ":bundle-outputgroups-es2015",
+        ":bundle-outputgroups-es5_min",
+        ":bundle-outputgroups-es5_min_debug",
+        ":bundle-outputgroups-umd",
+    ],
+    deps = [
+        "@npm//jasmine",
     ],
 )

--- a/internal/e2e/rollup/outputgroups.spec.js
+++ b/internal/e2e/rollup/outputgroups.spec.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+
+function checkExists(name) {
+  if (!fs.existsSync(require.resolve(path.join(__dirname, name)))) {
+    fail(`Output ${name} does not exist.`);
+  }
+}
+
+// TODO: the right assertions are to load up the source-map library
+// and assert that the sourcemap actually maps back to the sources
+
+describe('outputgroups', () => {
+  it('should produce a es2015 sourcemap', () => {
+    checkExists('bundle.es2015.js');
+    checkExists('bundle.es2015.js.map');
+  });
+  it('should produce a es5_min sourcemap', () => {
+    checkExists('bundle.min.js');
+    checkExists('bundle.min.js.map');
+  });
+  it('should produce a es5_min_debug sourcemap', () => {
+    checkExists('bundle.min_debug.js');
+    checkExists('bundle.min_debug.js.map');
+  });
+  it('should produce a cjs sourcemap', () => {
+    checkExists('bundle.cjs.js');
+    checkExists('bundle.cjs.js.map');
+  });
+  it('should produce a umd sourcemap', () => {
+    checkExists('bundle.umd.js');
+    checkExists('bundle.umd.js.map');
+  });
+});

--- a/internal/e2e/rollup_code_splitting/BUILD.bazel
+++ b/internal/e2e/rollup_code_splitting/BUILD.bazel
@@ -13,7 +13,10 @@ rollup_bundle(
 
 jasmine_node_test(
     name = "test",
-    srcs = glob(["*.spec.js"]),
+    srcs = [
+        "additional_entry.spec.js",
+        "main1.spec.js",
+    ],
     data = glob([
         "*_golden.js_",
     ]) + [
@@ -24,5 +27,36 @@ jasmine_node_test(
         "//internal/e2e:check_lib",
         "@npm//jasmine",
         "@npm//unidiff",
+    ],
+)
+
+filegroup(
+    name = "bundle-outputgroups-es2015",
+    srcs = [":bundle"],
+    output_group = "es2015",
+)
+
+filegroup(
+    name = "bundle-outputgroups-es5_min",
+    srcs = [":bundle"],
+    output_group = "es5_min",
+)
+
+filegroup(
+    name = "bundle-outputgroups-es5_min_debug",
+    srcs = [":bundle"],
+    output_group = "es5_min_debug",
+)
+
+jasmine_node_test(
+    name = "test-outputgroups",
+    srcs = ["outputgroups.spec.js"],
+    data = [
+        ":bundle-outputgroups-es2015",
+        ":bundle-outputgroups-es5_min",
+        ":bundle-outputgroups-es5_min_debug",
+    ],
+    deps = [
+        "@npm//jasmine",
     ],
 )

--- a/internal/e2e/rollup_code_splitting/outputgroups.spec.js
+++ b/internal/e2e/rollup_code_splitting/outputgroups.spec.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+
+function checkExists(name) {
+  if (!fs.existsSync(require.resolve(path.join(__dirname, name)))) {
+    fail(`Output ${name} does not exist.`);
+  }
+}
+
+// TODO: the right assertions are to load up the source-map library
+// and assert that the sourcemap actually maps back to the sources
+
+describe('outputgroups', () => {
+  it('should produce a es2015 sourcemap', () => {
+    checkExists('bundle.es2015.js');
+    checkExists('bundle_chunks_es2015/additional_entry.js');
+    checkExists('bundle_chunks_es2015/additional_entry.js.map');
+    checkExists('bundle_chunks_es2015/main1.js');
+    checkExists('bundle_chunks_es2015/main1.js.map');
+  });
+  it('should produce a es5_min sourcemap', () => {
+    checkExists('bundle.min.js');
+    checkExists('bundle_chunks_min/additional_entry.js');
+    checkExists('bundle_chunks_min/additional_entry.js.map');
+    checkExists('bundle_chunks_min/main1.js');
+    checkExists('bundle_chunks_min/main1.js.map');
+  });
+  it('should produce a es5_min_debug sourcemap', () => {
+    checkExists('bundle.min_debug.js');
+    checkExists('bundle_chunks_min_debug/additional_entry.js');
+    checkExists('bundle_chunks_min_debug/additional_entry.js.map');
+    checkExists('bundle_chunks_min_debug/main1.js');
+    checkExists('bundle_chunks_min_debug/main1.js.map');
+  });
+});


### PR DESCRIPTION
~~This adds sourcemap targets output groups for all the output formats.~~

Today there's the default target which outputs the es5 bundle.js and bundle.js.map. Then there's sub-targets such as `.es2015.js`, `.umd.js` etc. There's also `.js` which is the same as the default target but without the `.map`. But there's no way to easily fetch the .js+map of only the es2015 bundle.

~~This adds a `.js.map` target alongside every `.js` target.~~
This adds an output-group for each bundle type. The tests show an example of `filegroup`s consuming these output-groups.