### PR TITLE
Add visible alias for the metadata entry of ts_devserver

### DIFF
--- a/examples/app/BUILD.bazel
+++ b/examples/app/BUILD.bazel
@@ -11,6 +11,8 @@ ts_devserver(
     name = "devserver",
     index_html = "index.html",
     port = 8080,
+    # Expose this to other examples, so we can test visibility of generated manifest file
+    visibility = ["//:__subpackages__"],
     # We'll collect all the devmode JS sources from these TypeScript libraries
     deps = [":app"],
 )

--- a/examples/app/test/BUILD.bazel
+++ b/examples/app/test/BUILD.bazel
@@ -1,0 +1,7 @@
+# Verify that we can do something with the devserver manifest
+genrule(
+    name = "consume_manifest",
+    srcs = ["//:devserver.MF"],
+    outs = [":MANIFEST"],
+    cmd = "cp $< $@",
+)

--- a/packages/typescript/internal/devserver/ts_devserver.bzl
+++ b/packages/typescript/internal/devserver/ts_devserver.bzl
@@ -247,6 +247,13 @@ def ts_devserver_macro(name, data = [], args = [], visibility = None, tags = [],
         **kwargs
     )
 
+    # Expose the manifest file label
+    native.alias(
+        name = "%s.MF" % name,
+        actual = "%s_launcher.MF" % name,
+        visibility = visibility,
+    )
+
     native.sh_binary(
         name = name,
         args = args,


### PR DESCRIPTION
moved from https://github.com/bazelbuild/rules_typescript/pull/439

@achew22 could you help me add to the commit message here an explanation of *why* we make this change?