### PR TITLE
Update scripts to unlink deps in package.json for nested workspaces after builds & tests to reduce local changes

### DIFF
--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -31,5 +31,8 @@ for package in ${PACKAGES[@]} ; do
     readonly BAZEL_BIN=$(bazel info bazel-bin)
     echo_and_run cp -R "${BAZEL_BIN}/npm_package" ${DEST_DIR}
     chmod -R u+w ${DEST_DIR}
+
+    # Unlink deps to undo local changes
+    ${RULES_NODEJS_DIR}/scripts/unlink_deps.sh
   )
 done

--- a/scripts/link_deps.sh
+++ b/scripts/link_deps.sh
@@ -6,6 +6,7 @@ set -eu -o pipefail
 # -o pipefail: causes a pipeline to produce a failure return code if any command errors
 
 readonly RULES_NODEJS_DIR=$(cd $(dirname "$0")/..; pwd)
+readonly RELATIVE_DIR=$(pwd | cut -c 2- | cut -c ${#RULES_NODEJS_DIR}-)
 
 echo_and_run() { echo "+ $@" ; "$@" ; }
 
@@ -20,6 +21,7 @@ sedi () {
   sed "${sedi[@]}" "$@"
 }
 
+# Unlink first incase they are already linked
 ${RULES_NODEJS_DIR}/scripts/unlink_deps.sh
 
 DEPS=()
@@ -43,6 +45,8 @@ done
 if [[ ${DEPS:-} ]] ; then
   ${RULES_NODEJS_DIR}/scripts/check_deps.sh ${DEPS[@]}
 fi
+
+echo "Linking deps in ${RELATIVE_DIR}"
 
 for package in ${PACKAGES[@]:-} ; do
   # Find name of dist dir (the postfix $RANDOM changes each time it is re-generated)

--- a/scripts/publish_release.sh
+++ b/scripts/publish_release.sh
@@ -24,4 +24,5 @@ for pkg in ${PACKAGES[@]} ; do (
     cd packages/$pkg
     ${RULES_NODEJS_DIR}/scripts/link_deps.sh
     echo_and_run ../../node_modules/.bin/bazel --output_base=$TMP run  --workspace_status_command=../../scripts/current_version.sh //:npm_package.${NPM_COMMAND}
+    ${RULES_NODEJS_DIR}/scripts/unlink_deps.sh
 ) done

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -19,5 +19,6 @@ for e2eTest in ${E2E_TESTS[@]} ; do
     printf "\n\nRunning e2e test ${e2eTest}\n"
     ${RULES_NODEJS_DIR}/scripts/link_deps.sh
     echo_and_run yarn test
+    ${RULES_NODEJS_DIR}/scripts/unlink_deps.sh
   )
 done

--- a/scripts/test_examples.sh
+++ b/scripts/test_examples.sh
@@ -17,7 +17,7 @@ for example in ${EXAMPLES[@]} ; do
   (
     # Test example
     if [[ ${example} == "vendored_node" && ${KERNEL_NAME} != Linux* ]] ; then
-      echo "Skipping vendored_node test as it only runs on Linux while we are executing on ${KERNEL_NAME}"
+      printf "\n\nSkipping vendored_node test as it only runs on Linux while we are executing on ${KERNEL_NAME}\n"
     else
       cd "${EXAMPLES_DIR}/${example}"
       printf "\n\nRunning example ${example}\n"
@@ -26,6 +26,7 @@ for example in ${EXAMPLES[@]} ; do
       if grep -q "\"e2e\":" package.json; then
         echo_and_run yarn e2e
       fi
+      ${RULES_NODEJS_DIR}/scripts/unlink_deps.sh
     fi
   )
 done

--- a/scripts/test_legacy_e2e.sh
+++ b/scripts/test_legacy_e2e.sh
@@ -19,5 +19,6 @@ for e2eTest in ${E2E_TESTS[@]} ; do
     printf "\n\nRunning legacy e2e test ${e2eTest}\n"
     ${RULES_NODEJS_DIR}/scripts/link_deps.sh
     echo_and_run yarn test
+    ${RULES_NODEJS_DIR}/scripts/unlink_deps.sh
   )
 done

--- a/scripts/test_packages.sh
+++ b/scripts/test_packages.sh
@@ -19,5 +19,6 @@ for package in ${PACKAGES[@]} ; do
     printf "\n\nTesting package ${package}\n"
     ${RULES_NODEJS_DIR}/scripts/link_deps.sh
     echo_and_run yarn test
+    ${RULES_NODEJS_DIR}/scripts/unlink_deps.sh
   )
 done

--- a/scripts/unlink_all_deps.sh
+++ b/scripts/unlink_all_deps.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+# -e: exits if a command fails
+# -u: errors if an variable is referenced before being set
+# -o pipefail: causes a pipeline to produce a failure return code if any command errors
+
+readonly RULES_NODEJS_DIR=$(cd $(dirname "$0")/..; pwd)
+cd ${RULES_NODEJS_DIR}
+
+for rootDir in packages examples e2e internal/e2e ; do
+  (
+    cd ${rootDir}
+    for subDir in $(ls) ; do
+      [[ -d "${subDir}" ]] || continue
+      (
+        cd ${subDir}
+        if [[ -e 'package.json' ]] ; then
+          ${RULES_NODEJS_DIR}/scripts/unlink_deps.sh
+        fi
+      )
+    done
+  )
+done

--- a/scripts/unlink_deps.sh
+++ b/scripts/unlink_deps.sh
@@ -6,6 +6,7 @@ set -eu -o pipefail
 # -o pipefail: causes a pipeline to produce a failure return code if any command errors
 
 readonly RULES_NODEJS_DIR=$(cd $(dirname "$0")/..; pwd)
+readonly RELATIVE_DIR=$(pwd | cut -c 2- | cut -c ${#RULES_NODEJS_DIR}-)
 
 echo_and_run() { echo "+ $@" ; "$@" ; }
 
@@ -19,6 +20,8 @@ sedi () {
 
   sed "${sedi[@]}" "$@"
 }
+
+echo "Unlinking deps in ${RELATIVE_DIR}"
 
 # Replaces "file://..." with absolute path to generated npm package under /dist/npm_bazel_foobar$RANDOM
 # back to "bazel://@npm_bazel_foobar//:npm_package"


### PR DESCRIPTION
Should mitigate accidentally committing locally modified package.json files with absolute `file://` entries.