### PR TITLE
Fix for #652: Running "bazel run @nodejs//:yarn" twice fails with unlink error

### DIFF
--- a/internal/npm_install/test/package/delete_build_files.js
+++ b/internal/npm_install/test/package/delete_build_files.js
@@ -19,5 +19,7 @@ const files = [
 ];
 
 for (const file of files) {
-  fs.unlinkSync(file);
+  if (fs.existsSync(file)) {
+    fs.unlinkSync(file);
+  }
 }


### PR DESCRIPTION
Fixes #652 