### PR TITLE
fix(bazel): export getNativeBinary()

### DIFF
--- a/packages/bazel/index.js
+++ b/packages/bazel/index.js
@@ -9,7 +9,7 @@ const spawnSync = require('child_process').spawnSync;
 const warnGlobalInstall = `
   *** WARNING
     The Bazel binary is being run from a global install.
-    
+
     This means the version may not match the one used in your project.
     We recommend installing the @bazel/bazel package locally in your project.
   ***
@@ -53,8 +53,14 @@ function getNativeBinary() {
   return path.resolve(path.dirname(nativePackage), binary);
 }
 
-/** Starts a new synchronous child process that runs Bazel with the specified arguments. */
-const bazelProcess = spawnSync(getNativeBinary(), process.argv.slice(2), {stdio: 'inherit'});
+if (require.main === module) {
+  /** Starts a new synchronous child process that runs Bazel with the specified arguments. */
+  const bazelProcess = spawnSync(getNativeBinary(), process.argv.slice(2), {stdio: 'inherit'});
 
-// Ensure that this wrapper script exits with the same exit code as the child process.
-process.exit(bazelProcess.status);
+  // Ensure that this wrapper script exits with the same exit code as the child process.
+  process.exit(bazelProcess.status);
+}
+
+module.exports = {
+  getNativeBinary,
+};


### PR DESCRIPTION
`@bazel/bazel` should export getNativeBinary() method so that downstream
consumers can locate the actual Bazel binary and spawn a process using
custom options. If loaded as script the code should continue to work as before.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

