### PR TITLE
Fix @bazel/jasmine jasmineCore re-export so that jasmine-core transitive dep of jasmine transitive-dep is always used

### DIFF
--- a/packages/jasmine/index.js
+++ b/packages/jasmine/index.js
@@ -1,4 +1,15 @@
-const jasmineCore = require('jasmine-core');
+const path = require('path');
+const fs = require('fs');
+
+// We want the jasmine-core version that is a transitive dependency of jasmine, however,
+// jasmine does not provide a re-export of its jasmine-core so we need resolve jasmine-core
+// from jasmine/node_modules/jasmine-core if it exists but from the base path of the jasmine
+// that @bazel/jasmine depends on which is path.dirname(require.resolve('jasmine/package.json'))
+const jasmineDir = path.dirname(require.resolve(path.posix.join('jasmine', 'package.json')));
+const jasmineCore =
+    fs.existsSync(path.posix.join(jasmineDir, 'node_modules', 'jasmine-core', 'package.json')) ?
+    require(path.posix.join(jasmineDir, 'node_modules', 'jasmine-core')) :
+    require('jasmine-core');
 
 // a boot function for use in user bootstrap code:
 // require('@bazel/jasmine').boot()


### PR DESCRIPTION
Ran into yet another corner case for re-exporting the correct `jasmine-core` from `@bazel/jasmine` npm package here: https://github.com/angular/angular/pull/29913. I think I've thought it through fully now and this will always get the right version of `jasmine-core`