### PR TITLE
Add jasmine-core dependency to @bazel/jasmine since it is required in its index

### DIFF
--- a/packages/jasmine/package.json
+++ b/packages/jasmine/package.json
@@ -18,6 +18,7 @@
     "main": "index.js",
     "dependencies": {
         "jasmine": "~3.3.1",
+        "jasmine-core": "~3.3.0",
         "v8-coverage": "1.0.8"
     },
     "bazelWorkspaces": {


### PR DESCRIPTION
Ran into yet another corner case for re-exporting the correct `jasmine-core` from `@bazel/jasmine` npm package here: angular/angular#29913. A direct dependency on `jasmine-core` from `@bazel/jasmine` instead of relying on the transitive dep via `jasmine` would fix the issue.

For reference the case is. `@bazel/jasmine`dep on jasmine is hoisted to the root node_modules so its under `node_modules/jasmine` but root package.json has a conflicting dep on `jasmine-core` so its location is `node_modules/jasmine/node_modules/jasmine-core`.

Replaces #697.