### PR TITLE
Windows: jasmine_node_test uses nodejs_test_macro

### DIFF
--- a/internal/jasmine_node_test/jasmine_node_test.bzl
+++ b/internal/jasmine_node_test/jasmine_node_test.bzl
@@ -19,7 +19,7 @@ than launching a test in Karma, for example.
 """
 
 load("//internal/common:devmode_js_sources.bzl", "devmode_js_sources")
-load("//internal/node:node.bzl", "nodejs_test")
+load("//internal/node:node.bzl", "nodejs_test_macro")
 
 def jasmine_node_test(
         name,
@@ -59,15 +59,13 @@ def jasmine_node_test(
     all_data = data + srcs + deps
     all_data += [Label("//internal/jasmine_node_test:jasmine_runner.js")]
     all_data += [":%s_devmode_srcs.MF" % name]
-    all_data += [Label("@bazel_tools//tools/bash/runfiles")]
     entry_point = "build_bazel_rules_nodejs/internal/jasmine_node_test/jasmine_runner.js"
 
-    nodejs_test(
+    nodejs_test_macro(
         name = name,
         data = all_data,
         entry_point = entry_point,
         templated_args = ["$(location :%s_devmode_srcs.MF)" % name],
-        testonly = 1,
         expected_exit_code = expected_exit_code,
         tags = tags,
         **kwargs

--- a/internal/npm_package/test/npm_package.spec.js
+++ b/internal/npm_package/test/npm_package.spec.js
@@ -8,7 +8,7 @@ function read(p) {
   // So instead we lookup the sibling file (the primary output of the test rule)
   // and bootstrap the filesystem lookup from there.
   const dir =
-      path.dirname(require.resolve('build_bazel_rules_nodejs/internal/npm_package/test/test.sh'));
+      path.dirname(require.resolve('build_bazel_rules_nodejs/internal/npm_package/test/test'));
   return fs.readFileSync(path.join(dir, 'test_pkg', p), {encoding: 'utf-8'}).trim();
 }
 


### PR DESCRIPTION
Windows: jasmine_node_test uses nodejs_test_macro

Fix the jasmine_node_test() rule on Windows when
tested with Bazel's Windows-native test wrapper
(see https://github.com/bazelbuild/bazel/issues/5508).

jasmine_node_test() now uses nodejs_test_macro()
instead of nodejs_test(). This changes the test's
executable from a Bash script to a native Windows
binary, so the rule can be tested using Bazel's
new Windows-native test wrapper.

The default test wrapper is a Bash script, which
could run shell scripts as subprocesses so it
could test nodejs_test() directly.

The new test wrapper is a native C++ binary that
can only run native Windows binaries. (But it does
not require Bash, see https://github.com/bazelbuild/bazel/issues/5508.)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Test related change


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Tests in `//internal/e2e/fine_grained_deps:*` fail with Bazel 0.25.0rc2 and `--incompatible_windows_native_test_wrapper`. (Flag info: https://github.com/bazelbuild/bazel/issues/6622)

Bazel output:
```
C:\src\rules_nodejs> git rev-parse HEAD
593d47d8e1c77eb6fee6b5a8fe32895be1cbfb01

C:\src\rules_nodejs> c:\src\bazel-releases\0.25.0\rc2\bazel.exe test --incompatible_windows_native_test_wrapper //internal/e2e/fine_grained_deps:*
(...)
INFO: From Testing //internal/e2e/fine_grained_deps:test_npm:
==================== Test output for //internal/e2e/fine_grained_deps:test_npm:
ERROR(tools/test/windows/tw.cc:1250) value: 193 (0x000000c1): CreateProcessW failed (C:\_bazel\o375m4zz\execroot\build_bazel_rules_nodejs\bazel-out\x64_windows-fastbuild\bin\internal\e2e\fine_grained_deps\test_npm.sh)
ERROR(tools/test/windows/tw.cc:1442) Failed to start test process "C:\_bazel\o375m4zz\execroot\build_bazel_rules_nodejs\bazel-out\x64_windows-fastbuild\bin\internal\e2e\fine_grained_deps\test_npm.sh"
================================================================================
```


## What is the new behavior?

Those tests pass now.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

