### PR TITLE
fix(npm_package): deps should allow files

### DIFF
--- a/internal/npm_package/npm_package.bzl
+++ b/internal/npm_package/npm_package.bzl
@@ -88,9 +88,14 @@ def _npm_package(ctx):
             deps_sources,
             # Collect whatever is in the "data"
             dep.data_runfiles.files,
-            # For JavaScript-producing rules, gather up the devmode Node.js sources
-            dep.node_sources,
         ]
+
+        if hasattr(dep, "node_sources"):
+            # For JavaScript-producing rules, gather up the devmode Node.js sources
+            transitive.append(dep.node_sources)
+        else:
+            # For standalone Output File Targets (aspects not invoked on these)
+            transitive.append(dep.files)
 
         # ts_library doesn't include .d.ts outputs in the runfiles
         # see comment in rules_typescript/internal/common/compilation.bzl
@@ -133,6 +138,7 @@ NPM_PACKAGE_ATTRS = {
     "deps": attr.label_list(
         doc = """Other targets which produce files that should be included in the package, such as `rollup_bundle`""",
         aspects = [sources_aspect],
+        allow_files = True,
     ),
     "_packager": attr.label(
         default = Label("//internal/npm_package:packager"),

--- a/internal/npm_package/packager.js
+++ b/internal/npm_package/packager.js
@@ -86,6 +86,10 @@ function main(args) {
 
   // src like baseDir/my/path is just copied to outDir/my/path
   for (src of srcsArg.split(',').filter(s => !!s)) {
+    if (!src.startsWith(baseDir)) {
+      throw new Error(`${src} in 'srcs' does not reside in the base directory, ` +
+        `generated file should belong in 'deps' instead.`);
+    }
     copyWithReplace(src, path.join(outDir, path.relative(baseDir, src)), replacements);
   }
 

--- a/internal/npm_package/test/BUILD.bazel
+++ b/internal/npm_package/test/BUILD.bazel
@@ -31,6 +31,7 @@ npm_package(
     packages = [":dependent_pkg"],
     replacements = {"replace_me": "replaced"},
     deps = [
+        ":bundle.min.js",
         ":produces_files",
         ":ts_library",
     ],
@@ -41,4 +42,10 @@ jasmine_node_test(
     srcs = ["npm_package.spec.js"],
     data = [":test_pkg"],
     deps = ["@npm//jasmine"],
+)
+
+genrule(
+    name = "bundle",
+    outs = ["bundle.min.js"],
+    cmd = "echo -n 'bundle content' > $@",
 )

--- a/internal/npm_package/test/npm_package.spec.js
+++ b/internal/npm_package/test/npm_package.spec.js
@@ -31,6 +31,9 @@ describe('npm_package srcs', () => {
   it('replaced 0.0.0-PLACEHOLDER', () => {
     expect(read('package.json').version).not.toEqual('0.0.0-PLACEHOLDER');
   });
+  it('copies files from deps', () => {
+    expect(read('bundle.min.js')).toBe('bundle content');
+  });
   it('vendors external workspaces',
      () => {
          // TODO(alexeagle): there isn't a way to test this yet, because the npm_package under test


### PR DESCRIPTION
**BREAKING CHANGE**: npm_package now throws for any files in `srcs` which
do not reside in the same package as the target.

The `deps` attr of `npm_package` should allow files.
A common use case would be named output of other rules, such as
`rollup_bundle`. In which case, user should be able to add
`bundle.umd.js` from `rollup_bundle` to the `deps` of `npm_package`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

