### PR TITLE
feat: add ability to set jasmine seed as env variable

### DIFF
--- a/packages/jasmine/src/jasmine_node_test.bzl
+++ b/packages/jasmine/src/jasmine_node_test.bzl
@@ -30,6 +30,7 @@ def jasmine_node_test(
         tags = [],
         jasmine = Label("@npm//@bazel/jasmine"),
         coverage = False,
+        seed = None,
         **kwargs):
     """Runs tests in NodeJS using the Jasmine test runner.
 
@@ -44,6 +45,7 @@ def jasmine_node_test(
       tags: bazel tags applied to test
       jasmine: a label providing the jasmine dependency
       coverage: Enables code coverage collection and reporting
+      seed: Override the randomized jasmine seed with a specific seed
       **kwargs: remaining arguments are passed to the test rule
     """
     devmode_js_sources(
@@ -64,6 +66,9 @@ def jasmine_node_test(
         templated_args = templated_args + ["--coverage"]
     else:
         templated_args = templated_args + ["--nocoverage"]
+
+    if seed:
+        templated_args = templated_args + ["--seed ", str(seed)]
 
     nodejs_test(
         name = name,

--- a/packages/jasmine/src/jasmine_node_test.bzl
+++ b/packages/jasmine/src/jasmine_node_test.bzl
@@ -31,6 +31,7 @@ def jasmine_node_test(
         jasmine = Label("@npm//@bazel/jasmine"),
         coverage = False,
         seed = None,
+        randomize = True,
         **kwargs):
     """Runs tests in NodeJS using the Jasmine test runner.
 
@@ -45,7 +46,8 @@ def jasmine_node_test(
       tags: bazel tags applied to test
       jasmine: a label providing the jasmine dependency
       coverage: Enables code coverage collection and reporting
-      seed: Override the randomized jasmine seed with a specific seed
+      seed: Override the randomize jasmine seed with a specific seed
+      randomize: Whether or not to randomize the test sequence (supercedes the `seed` arg)
       **kwargs: remaining arguments are passed to the test rule
     """
     devmode_js_sources(
@@ -67,8 +69,13 @@ def jasmine_node_test(
     else:
         templated_args = templated_args + ["--nocoverage"]
 
-    if seed:
-        templated_args = templated_args + ["--seed ", str(seed)]
+    if randomize:
+        if seed:
+            templated_args = templated_args + ["--randomize-seed", str(seed)]
+        else:
+            templated_args = templated_args + ["--randomize"]
+    else:
+        templated_args = templated_args + ["--norandomize"]
 
     nodejs_test(
         name = name,

--- a/packages/jasmine/src/jasmine_runner.js
+++ b/packages/jasmine/src/jasmine_runner.js
@@ -63,8 +63,17 @@ function main(args) {
   // second is always a flag to enable coverage or not
   const coverageArg = args[1];
   const enableCoverage = coverageArg === '--coverage';
-  // third arg is an optional seed
-  const seed = args[2] === '--seed' ? args[3] : null;
+
+  let randomize = true;
+  let seed = null;
+  switch (args[2]) {
+    case '--norandomize':
+      randomize = false;
+      break;
+    case '--randomize-seed':
+      seed = args[3];
+      break;
+  }
 
   // Remove the manifest, some tested code may process the argv.
   // Also remove the --coverage flag
@@ -197,11 +206,15 @@ function main(args) {
     }
   }
 
-  if (seed) {
-    // Display that the seed has been overridden in bright green.
-    console.log(`\u001b[32mJasmine seed override: ${seed}\u001b[39m`);
-    const env = jasmine.getEnv();
-    env.seed(seed);
+  const env = jasmine.getEnv();
+  if (randomize) {
+    if (seed != null) {
+      console.log(`Jasmine seed override: ${seed}`);
+      env.seed(seed);
+    }
+  } else {
+    console.log('Jasmine tests will be executed in order of declaration');
+    env.randomizeTests(false);
   }
 
   jrunner.execute();


### PR DESCRIPTION
- Uses environment variable `JASMINE_SEED` to allow users to lock the randomization seed down for deterministic tests
- Adds documentation on how to use `JASMINE_SEED` environment variable
