### PR TITLE
Don’t gitignore /internal/npm_install/test/golden/node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ rules_nodejs-*.tar.gz
 /internal/e2e/*/bazel-*
 /internal/npm_install/test/package/*
 node_modules
+!/internal/npm_install/test/golden/node_modules
 examples/vendored_node/node-v10.12.0-linux-x64
 examples/vendored_node/node-v10.12.0-linux-x64.tar.xz
 examples/vendored_node/yarn-v1.10.0

--- a/scripts/clean_all.sh
+++ b/scripts/clean_all.sh
@@ -11,9 +11,7 @@ cd ${RULES_NODEJS_DIR}
 echo_and_run() { echo "+ $@" ; "$@" ; }
 
 echo_and_run rm -rf ./dist
-echo_and_run rm -rf ./node_modules
-echo_and_run rm -rf ./examples/program/node_modules
-echo_and_run rm -rf ./internal/npm_install/test/package/node_modules
+echo_and_run rm -rf `find . -type d -name node_modules -prune -not -path "./internal/npm_install/test/golden/node_modules"`
 
 echo_and_run bazel clean --expunge
 
@@ -30,7 +28,7 @@ ${RULES_NODEJS_DIR}/scripts/clean_packages_all.sh
       if [[ -e 'WORKSPACE' ]] ; then
         printf "\n\nCleaning /internal/e2e/${subDir}\n"
         echo_and_run bazel clean --expunge
-        echo_and_run rm -rf node_modules
+        echo_and_run rm -rf `find . -type d -name node_modules -prune`
       fi
     )
   done

--- a/scripts/clean_e2e.sh
+++ b/scripts/clean_e2e.sh
@@ -19,6 +19,6 @@ for e2eTest in ${E2E_TESTS[@]} ; do
     printf "\n\nCleaning e2e test ${e2eTest}\n"
     ${RULES_NODEJS_DIR}/scripts/unlink_deps.sh
     echo_and_run bazel clean --expunge
-    echo_and_run rm -rf node_modules
+    echo_and_run rm -rf `find . -type d -name node_modules -prune`
   )
 done

--- a/scripts/clean_examples.sh
+++ b/scripts/clean_examples.sh
@@ -19,6 +19,6 @@ for example in ${EXAMPLES[@]} ; do
     printf "\n\nCleaning example ${example}\n"
     ${RULES_NODEJS_DIR}/scripts/unlink_deps.sh
     echo_and_run bazel clean --expunge
-    echo_and_run rm -rf node_modules
+    echo_and_run rm -rf `find . -type d -name node_modules -prune`
   )
 done

--- a/scripts/clean_packages.sh
+++ b/scripts/clean_packages.sh
@@ -19,6 +19,6 @@ for package in ${PACKAGES[@]} ; do
     printf "\n\nCleaning package ${package}\n"
     ${RULES_NODEJS_DIR}/scripts/unlink_deps.sh
     echo_and_run bazel clean --expunge
-    echo_and_run rm -rf node_modules
+    echo_and_run rm -rf `find . -type d -name node_modules -prune`
   )
 done


### PR DESCRIPTION
This fixes a few pain points for local development.

1. golden files like `internal/npm_install/test/golden/node_modules/@angular/core/BUILD.bazel.golden` are git ignored since they are in a `node_modules` folder. This PR fixes that by adding the negate pattern `!/internal/npm_install/test/golden/node_modules` to gitignore.

2. clean scripts now recursively delete *all* node_modules folders in the repo since `.bazelignore` doesn't behave like `.gitignore` and its `node_modules` entry only tells bazel to ignore the root `/node_modules` folder. Each nested folder must be listed explicitly in `.bazelignore`.

Will file an issue about the `.bazelignore` behavior to Bazel about this soon as it will cause issues for all users of nodejs rules that have nested `node_modules` and multiple `package.json` files (especially once https://github.com/bazelbuild/rules_nodejs/pull/704 lands).