### PR TITLE
Rename NodeModuleSources to NodeModulesSourcesInfo per naming convention

### DIFF
--- a/internal/common/node_module_info.bzl
+++ b/internal/common/node_module_info.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""NodeModuleInfo & NodeModuleSources providers and apsect to collect node_modules from deps.
+"""NodeModuleInfo & NodeModuleSourcesInfo providers and apsect to collect node_modules from deps.
 """
 
 # NodeModuleInfo provider is only provided by targets that are npm dependencies by the
@@ -35,12 +35,11 @@ NodeModuleInfo = provider(
     },
 )
 
-# NodeModuleSources provider is provided by targets that are npm dependencies by the
+# NodeModuleSourcesInfo provider is provided by targets that are npm dependencies by the
 # `node_module_library` rule as well as other targets that have direct or transitive deps on
 # `node_module_library` targets via the `collect_node_modules_aspect` below.
 # TODO: rename to NodeModuleSourcesInfo so name doesn't trigger name-conventions warning
-# buildozer: disable=name-conventions
-NodeModuleSources = provider(
+NodeModuleSourcesInfo = provider(
     doc = "Provides sources for npm dependencies installed with yarn_install and npm_install rules",
     fields = {
         "scripts": "Source files that are javascript named-UMD or named-AMD modules for use in rules such as ts_devserver",
@@ -52,19 +51,19 @@ NodeModuleSources = provider(
 def _collect_node_modules_aspect_impl(target, ctx):
     nm_wksp = None
 
-    if NodeModuleSources in target:
+    if NodeModuleSourcesInfo in target:
         return []
 
     if hasattr(ctx.rule.attr, "deps"):
         sources = depset()
         for dep in ctx.rule.attr.deps:
-            if NodeModuleSources in dep:
-                if nm_wksp and dep[NodeModuleSources].workspace != nm_wksp:
-                    fail("All npm dependencies need to come from a single workspace. Found '%s' and '%s'." % (nm_wksp, dep[NodeModuleSources].workspace))
-                nm_wksp = dep[NodeModuleSources].workspace
-                sources = depset(transitive = [dep[NodeModuleSources].sources, sources])
+            if NodeModuleSourcesInfo in dep:
+                if nm_wksp and dep[NodeModuleSourcesInfo].workspace != nm_wksp:
+                    fail("All npm dependencies need to come from a single workspace. Found '%s' and '%s'." % (nm_wksp, dep[NodeModuleSourcesInfo].workspace))
+                nm_wksp = dep[NodeModuleSourcesInfo].workspace
+                sources = depset(transitive = [dep[NodeModuleSourcesInfo].sources, sources])
         if sources:
-            return [NodeModuleSources(sources = sources, workspace = nm_wksp)]
+            return [NodeModuleSourcesInfo(sources = sources, workspace = nm_wksp)]
 
     return []
 

--- a/internal/common/sources_aspect.bzl
+++ b/internal/common/sources_aspect.bzl
@@ -15,7 +15,7 @@
 """Aspect to collect es5 js sources and scripts from deps.
 """
 
-load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleInfo", "NodeModuleSources")
+load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleInfo", "NodeModuleSourcesInfo")
 
 def _sources_aspect_impl(target, ctx):
     # TODO(kyliau): node_sources here is a misnomer because it implies that
@@ -33,8 +33,8 @@ def _sources_aspect_impl(target, ctx):
     # get TypeScript outputs.
     if hasattr(target, "typescript"):
         node_sources = depset(transitive = [node_sources, target.typescript.es5_sources])
-    elif NodeModuleSources in target:
-        dev_scripts = depset(transitive = [dev_scripts, target[NodeModuleSources].scripts])
+    elif NodeModuleSourcesInfo in target:
+        dev_scripts = depset(transitive = [dev_scripts, target[NodeModuleSourcesInfo].scripts])
     elif hasattr(target, "files") and not NodeModuleInfo in target:
         # Sources from npm fine grained deps should not be included
         node_sources = depset(

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -20,7 +20,7 @@ They support module mapping: any targets in the transitive dependencies with
 a `module_name` attribute can be `require`d by that name.
 """
 
-load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleSources", "collect_node_modules_aspect")
+load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleSourcesInfo", "collect_node_modules_aspect")
 load("//internal/common:expand_into_runfiles.bzl", "expand_location_into_runfiles")
 load("//internal/common:module_mappings.bzl", "module_mappings_runtime_aspect")
 load("//internal/common:sources_aspect.bzl", "sources_aspect")
@@ -55,8 +55,8 @@ def _compute_node_modules_root(ctx):
             "node_modules",
         ] if f])
     for d in ctx.attr.data:
-        if NodeModuleSources in d:
-            possible_root = "/".join([d[NodeModuleSources].workspace, "node_modules"])
+        if NodeModuleSourcesInfo in d:
+            possible_root = "/".join([d[NodeModuleSourcesInfo].workspace, "node_modules"])
             if not node_modules_root:
                 node_modules_root = possible_root
             elif node_modules_root != possible_root:
@@ -116,10 +116,10 @@ def _nodejs_binary_impl(ctx):
     node_modules = depset(ctx.files.node_modules)
 
     # Also include files from npm fine grained deps as inputs.
-    # These deps are identified by the NodeModuleSources provider.
+    # These deps are identified by the NodeModuleSourcesInfo provider.
     for d in ctx.attr.data:
-        if NodeModuleSources in d:
-            node_modules = depset(transitive = [node_modules, d[NodeModuleSources].sources])
+        if NodeModuleSourcesInfo in d:
+            node_modules = depset(transitive = [node_modules, d[NodeModuleSourcesInfo].sources])
 
     # Using a depset will allow us to avoid flattening files and sources
     # inside this loop. This should reduce the performances hits,

--- a/internal/npm_install/node_module_library.bzl
+++ b/internal/npm_install/node_module_library.bzl
@@ -15,7 +15,7 @@
 """Contains the node_module_library which is used by yarn_install & npm_install.
 """
 
-load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleInfo", "NodeModuleSources")
+load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleInfo", "NodeModuleSourcesInfo")
 
 def _node_module_library_impl(ctx):
     workspace = ctx.label.workspace_root.split("/")[1] if ctx.label.workspace_root else ctx.workspace_name
@@ -23,8 +23,8 @@ def _node_module_library_impl(ctx):
 
     scripts = depset()
     for src in ctx.attr.srcs:
-        if NodeModuleSources in src:
-            scripts = depset(transitive = [scripts, src[NodeModuleSources].scripts])
+        if NodeModuleSourcesInfo in src:
+            scripts = depset(transitive = [scripts, src[NodeModuleSourcesInfo].scripts])
     scripts = depset(ctx.files.scripts, transitive = [scripts])
 
     return [
@@ -34,7 +34,7 @@ def _node_module_library_impl(ctx):
         NodeModuleInfo(
             workspace = workspace,
         ),
-        NodeModuleSources(
+        NodeModuleSourcesInfo(
             sources = sources,
             scripts = scripts,
             workspace = workspace,

--- a/internal/rollup/rollup_bundle.bzl
+++ b/internal/rollup/rollup_bundle.bzl
@@ -18,7 +18,7 @@ The versions of Rollup and terser are controlled by the Bazel toolchain.
 You do not need to install them into your project.
 """
 
-load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleSources", "collect_node_modules_aspect")
+load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleSourcesInfo", "collect_node_modules_aspect")
 load("//internal/common:collect_es6_sources.bzl", _collect_es2015_sources = "collect_es6_sources")
 load("//internal/common:module_mappings.bzl", "get_module_mappings")
 
@@ -64,8 +64,8 @@ def _compute_node_modules_root(ctx):
             "node_modules",
         ] if f])
     for d in ctx.attr.deps:
-        if NodeModuleSources in d:
-            possible_root = "/".join(["external", d[NodeModuleSources].workspace, "node_modules"])
+        if NodeModuleSourcesInfo in d:
+            possible_root = "/".join(["external", d[NodeModuleSourcesInfo].workspace, "node_modules"])
             if not node_modules_root:
                 node_modules_root = possible_root
             elif node_modules_root != possible_root:
@@ -197,11 +197,11 @@ def _run_rollup(ctx, sources, config, output, map_output = None):
     direct_inputs += _filter_js_inputs(ctx.files.node_modules)
 
     # Also include files from npm fine grained deps as inputs.
-    # These deps are identified by the NodeModuleSources provider.
+    # These deps are identified by the NodeModuleSourcesInfo provider.
     for d in ctx.attr.deps:
-        if NodeModuleSources in d:
+        if NodeModuleSourcesInfo in d:
             # Note: we can't avoid calling .to_list() on sources
-            direct_inputs += _filter_js_inputs(d[NodeModuleSources].sources.to_list())
+            direct_inputs += _filter_js_inputs(d[NodeModuleSourcesInfo].sources.to_list())
 
     if ctx.file.license_banner:
         direct_inputs += [ctx.file.license_banner]

--- a/packages/typescript/internal/build_defs.bzl
+++ b/packages/typescript/internal/build_defs.bzl
@@ -14,7 +14,7 @@
 
 "TypeScript compilation"
 
-load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleInfo", "NodeModuleSources", "collect_node_modules_aspect")
+load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleInfo", "NodeModuleSourcesInfo", "collect_node_modules_aspect")
 
 # pylint: disable=unused-argument
 # pylint: disable=missing-docstring
@@ -55,8 +55,8 @@ def _compute_node_modules_root(ctx):
             "node_modules",
         ] if f])
     for d in ctx.attr.deps:
-        if NodeModuleSources in d:
-            possible_root = "/".join(["external", d[NodeModuleSources].workspace, "node_modules"])
+        if NodeModuleSourcesInfo in d:
+            possible_root = "/".join(["external", d[NodeModuleSourcesInfo].workspace, "node_modules"])
             if not node_modules_root:
                 node_modules_root = possible_root
             elif node_modules_root != possible_root:
@@ -102,11 +102,11 @@ def _compile_action(ctx, inputs, outputs, tsconfig_file, node_opts, description 
     action_inputs.extend(_filter_ts_inputs(ctx.files.node_modules))
 
     # Also include files from npm fine grained deps as action_inputs.
-    # These deps are identified by the NodeModuleSources provider.
+    # These deps are identified by the NodeModuleSourcesInfo provider.
     for d in ctx.attr.deps:
-        if NodeModuleSources in d:
+        if NodeModuleSourcesInfo in d:
             # Note: we can't avoid calling .to_list() on sources
-            action_inputs.extend(_filter_ts_inputs(d[NodeModuleSources].sources.to_list()))
+            action_inputs.extend(_filter_ts_inputs(d[NodeModuleSourcesInfo].sources.to_list()))
 
     if ctx.file.tsconfig:
         action_inputs.append(ctx.file.tsconfig)


### PR DESCRIPTION
BREAKING CHANGE:

Although this name is an internal detail and is not used anywhere outside of this repository, since we publish multiple packages this change will still mean that an older @bazel/typescript npm package will not work with the next release of build_bazel_rules_nodejs and vice-versa.

Next release should be a minor bump with this.

There are some other breaking changes that would be good to get in all at once if we are going to bump the minor:

* remove COMPAT_VERSION & maybe VERSION as well from npm published workspaces; with the peer deps convention we don't really need version checks anymore
* remove `defs.bzl` from published npm packages since `index.bzl` is standard
* remove deprecated `preserve_symlinks` option
* make package_lock_json mandatory
* remove `jasmine_node_test` from `build_bazel_rules_nodejs`
* remove deprecated `internal/collect_es6_sources.bzl`
* remove deprecated `internal/node.bzl`

Also this but it could be a stretch so probably better to think this one through more since it will be a harder one for users to upgrade from:

* remove deprecated `node_modules` attributes (nodejs_binary, nodejs_test, rollup_bundle)? with the addition of the `node_module_library()` rule, we could make `//:node_modules` work within deps/data instead of having a separate `node_modules` attributes.
