### PR TITLE
Rollup bundle rule does not resolve external source maps

### DIFF
--- a/internal/rollup/rollup_bundle.bzl
+++ b/internal/rollup/rollup_bundle.bzl
@@ -170,7 +170,9 @@ def _filter_js_inputs(all_inputs):
     return [
         f
         for f in all_inputs
-        if f.path.endswith(".js") or f.path.endswith(".json")
+        # We also need to include ".map" files as these can be read by
+        # the "rollup-plugin-sourcemaps" plugin.
+        if f.path.endswith(".js") or f.path.endswith(".json") or f.path.endswith(".map")
     ]
 
 def _run_rollup(ctx, sources, config, output, map_output = None):


### PR DESCRIPTION
In order to support external source-maps, the `rollup-plugin-sourcemaps` module has
been added to the rollup configuration. Unfortunately this currently only has an effect
on Windows as the sandbox is not available and the plugin can read the referenced
external `.map` files.

When running in the Bazel sandbox or within RBE, these map files can't be read
by the plugin because the `.map` files are omitted from the `run_rollup` action
inputs. This causes inconsistent behavior and makes the sourcemaps plugin a no-op
right now.