### PR TITLE
Return typescript legacy provider from node_modules_library with the …

### DIFF
--- a/internal/common/sources_aspect.bzl
+++ b/internal/common/sources_aspect.bzl
@@ -33,14 +33,15 @@ def _sources_aspect_impl(target, ctx):
     # get TypeScript outputs.
     if hasattr(target, "typescript"):
         node_sources = depset(transitive = [node_sources, target.typescript.es5_sources])
-    elif NodeModuleSources in target:
-        dev_scripts = depset(transitive = [dev_scripts, target[NodeModuleSources].scripts])
     elif hasattr(target, "files") and not NodeModuleInfo in target:
         # Sources from npm fine grained deps should not be included
         node_sources = depset(
             [f for f in target.files if f.path.endswith(".js")],
             transitive = [node_sources],
         )
+
+    if NodeModuleSources in target:
+        dev_scripts = depset(target[NodeModuleSources].scripts)
 
     if hasattr(ctx.rule.attr, "deps"):
         for dep in ctx.rule.attr.deps:

--- a/packages/typescript/internal/build_defs.bzl
+++ b/packages/typescript/internal/build_defs.bzl
@@ -14,7 +14,7 @@
 
 "TypeScript compilation"
 
-load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleInfo", "NodeModuleSources", "collect_node_modules_aspect")
+load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleSources", "collect_node_modules_aspect")
 
 # pylint: disable=unused-argument
 # pylint: disable=missing-docstring
@@ -252,13 +252,10 @@ def _ts_library_impl(ctx):
     ts_providers = compile_ts(
         ctx,
         is_library = True,
-        # Filter out the node_modules from deps passed to TypeScript compiler
-        # since they don't have the required providers.
-        # They were added to the action inputs for tsc_wrapped already.
-        # strict_deps checking currently skips node_modules.
+        # Strict_deps checking currently skips node_modules.
         # TODO(alexeagle): turn on strict deps checking when we have a real
         # provider for JS/DTS inputs to ts_library.
-        deps = [d for d in ctx.attr.deps if not NodeModuleInfo in d],
+        deps = ctx.attr.deps,
         compile_action = _compile_action,
         devmode_compile_action = _devmode_compile_action,
         tsc_wrapped_tsconfig = tsc_wrapped_tsconfig,


### PR DESCRIPTION
…npm package's typescript declaration files.

Fixes https://github.com/bazelbuild/rules_typescript/issues/381 -- `.d.ts` files from npm deps now show up in generated tsconfig file:

```
"allowedStrictDeps": ["external/npm/node_modules/source-map/source-map.d.ts", "test/things.ts"]
```

Once released & pushed downstream the following change will need to be made in `ng_module.bzl` in angular/angular:
```
- deps = [d for d in ctx.attr.deps if not NodeModuleInfo in d],
+ deps = ctx.attr.deps,
```
in order to fix this for `ng_module` as well