### PR TITLE
Add check_bazel_version_range function

### DIFF
--- a/internal/common/check_bazel_version.bzl
+++ b/internal/common/check_bazel_version.bzl
@@ -19,7 +19,7 @@ as the continuous integration, so they don't trip over incompatibilities with
 rules used in the project.
 """
 
-load(":check_version.bzl", "check_version")
+load(":check_version.bzl", "check_version", "check_version_range")
 
 # From https://github.com/tensorflow/tensorflow/blob/5541ef4fbba56cf8930198373162dd3119e6ee70/tensorflow/workspace.bzl#L44
 
@@ -53,5 +53,46 @@ def check_bazel_version(minimum_bazel_version, message = ""):
         fail("\nCurrent Bazel version is {}, expected at least {}\n{}".format(
             native.bazel_version,
             minimum_bazel_version,
+            message,
+        ))
+
+# Check that a bazel version being used is in the version range.
+# Args:
+#   minimum_bazel_version in the form "<major>.<minor>.<patch>"
+#   maximum_bazel_version in the form "<major>.<minor>.<patch>"
+def check_bazel_version_range(minimum_bazel_version, maximum_bazel_version, message = ""):
+    """
+    Verify the users Bazel version is in the version range.
+
+    This should be called from the `WORKSPACE` file so that the build fails as
+    early as possible. For example:
+
+    ```
+    # in WORKSPACE:
+    load("@build_bazel_rules_nodejs//:defs.bzl", "check_bazel_version_range")
+    check_bazel_version_range("0.11.0", "0.22.0")
+    ```
+
+    Args:
+      minimum_bazel_version: a string indicating the minimum version
+      maximum_bazel_version: a string indicating the maximum version
+      message: optional string to print to your users, could be used to help them update
+    """
+    if "bazel_version" not in dir(native):
+        fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" %
+             minimum_bazel_version)
+    elif not native.bazel_version:
+        print("\nCurrent Bazel is not a release version, cannot check for " +
+              "compatibility.")
+        print("Make sure that you are running at least Bazel %s.\n" % minimum_bazel_version)
+    elif not check_version_range(
+        native.bazel_version,
+        minimum_bazel_version,
+        maximum_bazel_version,
+    ):
+        fail("\nCurrent Bazel version is {}, expected >= {} and <= {}\n{}".format(
+            native.bazel_version,
+            minimum_bazel_version,
+            maximum_bazel_version,
             message,
         ))

--- a/internal/common/check_version.bzl
+++ b/internal/common/check_version.bzl
@@ -60,3 +60,21 @@ def check_version(current_version, minimum_version):
       True if current_version is greater or equal to the minimum_version, False otherwise
     """
     return parse_version(current_version) >= parse_version(minimum_version)
+
+def check_version_range(current_version, minimum_version, maximum_version):
+    """
+    Verify that a version string >= minimum version and <= maximum version.
+
+    The format handled for the version strings is "<major>.<minor>.<patch>-<date> <commit>"
+
+    Args:
+      current_version: a string indicating the version to check
+      minimum_version: a string indicating the minimum version
+      maximum_version: a string indicating the maximum version
+
+    Returns:
+      True if current_version >= minimum_version and <= maximum_version,
+      False otherwise.
+    """
+    return (parse_version(current_version) >= parse_version(minimum_version) and
+            parse_version(current_version) <= parse_version(maximum_version))

--- a/internal/common/check_version_test.py
+++ b/internal/common/check_version_test.py
@@ -24,6 +24,18 @@ class CheckVersionTest(unittest.TestCase):
     result = self.globals['check_version']('1.2.2', '1.2.3')
     self.assertIs(result, False)
 
+  def testVersionRangeWithin(self):
+    result = self.globals['check_version_range']('1.2.2', '1.2.1', '1.2.3')
+    self.assertIs(result, True)
+
+  def testVersionOutOfLowRange(self):
+    result = self.globals['check_version_range']('1.2.0', '1.2.1', '1.2.3')
+    self.assertIs(result, False)
+
+  def testVersionOutOfHighRange(self):
+    result = self.globals['check_version_range']('1.2.4', '1.2.1', '1.2.3')
+    self.assertIs(result, False)
+
   def testNotAlphaComparison(self):
     result = self.globals['check_version']('1.12.3', '1.2.1')
     self.assertIs(result, True)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Before this change, there is no way to check the bazel version falls into a range.  Bazel has been having quite a few breaking changes and a minimum version check (bazel_check_version) is no longer enough.

Issue Number: N/A


## What is the new behavior?
bazel_check_version_range provides the function to check the bazel version is in a range, not just a minimum version.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

