### PR TITLE
No --types for rollup_bundle tsc downleveling...

### DIFF
--- a/internal/rollup/rollup_bundle.bzl
+++ b/internal/rollup/rollup_bundle.bzl
@@ -224,7 +224,15 @@ def _run_rollup(ctx, sources, config, output, map_output = None):
 
 def _run_tsc(ctx, input, output):
     args = ctx.actions.args()
+
+    # No types needed since we are just downleveling.
+    # `--types` proceeded by another config argument means an empty types array
+    # for the command line parser.
+    # See https://github.com/Microsoft/TypeScript/issues/18581#issuecomment-330700612
+    args.add("--types")
+    args.add("--skipLibCheck")
     args.add_all(["--target", "es5"])
+    args.add_all(["--lib", "es2015,dom"])
     args.add("--allowJS")
     args.add(input.path)
     args.add_all(["--outFile", output.path])

--- a/internal/rollup/tsc-directory.js
+++ b/internal/rollup/tsc-directory.js
@@ -48,8 +48,11 @@ function runTsc(inputDir, outputDir, projectFile) {
 
   const tsConfig = {
     'compilerOptions': {
+      // no types needed since we are just downleveling
+      'types': [],
+      'skipLibCheck': true,
       'target': 'es5',
-      'lib': ['es6'],
+      'lib': ['es2015', 'dom'],
       'allowJs': true,
       'outDir': outputBasename,
     },


### PR DESCRIPTION
& make --libs consistent between tsc and tsc-directory.

This fixes an issue observed where types files could break downleveling action if they used higher level language constructs
