### PR TITLE
[feat] support named exports in rollup_bundle

### DIFF
--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -189,7 +189,9 @@ const config = {
       // with the amd plugin.
       include: /\.ngfactory\.js$/i,
     }),
-    commonjs(),
+    commonjs({
+      namedExports: TMPL_named_exports,
+    }),
     {
       name: 'notResolved',
       resolveId: notResolved,

--- a/internal/rollup/rollup.config.spec.js
+++ b/internal/rollup/rollup.config.spec.js
@@ -6,6 +6,13 @@ TMPL_module_mappings = {
   '@bar/baz': 'path/to/bar/baz_lib',
 };
 
+TMPL_named_exports = {
+  'external/node_modules/foo/foo.js': [
+    'symbol1',
+    'symbol2',
+  ],
+}
+
 const rootDir = 'bazel-bin/path/to/a.esm5';
 TMPL_additional_plugins = [];
 TMPL_banner_file = '';
@@ -72,7 +79,7 @@ describe('rollup config', () => {
     expect(doResolve(`other${sep}thing`))
         .toEqual(`${baseDir}/bazel-bin/path/to/a.esm5/external/other_wksp/path/to/other_lib/thing`);
     expect(doResolve(`@bar${sep}baz${sep}foo`))
-      .toEqual(`${baseDir}/bazel-bin/path/to/a.esm5/path/to/bar/baz_lib/foo`);        
+      .toEqual(`${baseDir}/bazel-bin/path/to/a.esm5/path/to/bar/baz_lib/foo`);
   });
 
   it('should find paths in any root', () => {

--- a/internal/rollup/rollup_bundle.bzl
+++ b/internal/rollup/rollup_bundle.bzl
@@ -133,6 +133,7 @@ def write_rollup_config(ctx, plugins = [], root_dir = None, filename = "_%s.roll
             "TMPL_inputs": ",".join(["\"%s\"" % e for e in entry_points]),
             "TMPL_is_default_node_modules": "true" if is_default_node_modules else "false",
             "TMPL_module_mappings": str(mappings),
+            "TMPL_named_exports": str(ctx.attr.named_exports),
             "TMPL_node_modules_root": node_modules_root,
             "TMPL_output_format": output_format,
             "TMPL_rootDir": root_dir,
@@ -628,6 +629,12 @@ ROLLUP_ATTRS = {
         Note that you can replace a version placeholder in the license file, by using
         the special version `0.0.0-PLACEHOLDER`. See the section on stamping in the README.""",
         allow_single_file = [".txt"],
+    ),
+    "named_exports": attr.string_list_dict(
+        doc = """A dict of symbols informing rollup of objects exported by
+        modules that do not conform to commonjs, amd, or umd formats.
+        """,
+        default = {},
     ),
     "node_modules": attr.label(
         doc = """Dependencies from npm that provide some modules that must be


### PR DESCRIPTION
    Overview:
    
        This commit enables the `rollup_bundle` rule to include packages
        whose exported symbols cannot be recognized by the `rollup` program.
    
        Some js packages such as `sprintf.js` are not packaged in a format
        recognizable by the `rollup` program.  In those cases, the
        `rollup-plugin-commonjs` plugin supplies a configuration flag,
        `namedExports`, that can be used to specify named exports.
    
        Typical usages of the `namedExports` flag can be found here:
                https://github.com/rollup/rollup-plugin-commonjs
    
    Usage:
    
        With this commit, in a typical use case with Bazel, one would write:
    
        ```bzl
    
        ROLLUP_BUNDLE_NAMED_EXPORTS = {
            # Note the leading 'external/npm/node_modules'.  This full path is
            # what is recognized by Bazel's module resolution logic.
            'external/npm/node_modules/sprintf-js/src/sprintf.js': [
                'sprintf',
                'vsprintf',
            ],
            'external/npm/node_modules/railroad-diagrams/railroad-diagrams.js': [
                'Choice',
                'Comment',
                'ComplexDiagram',
                'Diagram',
                'NonTerminal',
                'OneOrMore',
                'Optional',
                'Sequence',
                'Skip',
                'Terminal',
                'ZeroOrMore',
            ],
        }
    
        rollup_bundle(
            name = 'bundle',
            deps = [ ... ],
            entry_point = 'logi/src/ui/debug/main.prod',
            globals = { ... },
            named_exports = ROLLUP_BUNDLE_NAMED_EXPORTS,
        )
        ```
