### PR TITLE
[feat] support config json file in jasmine_node_test

### DIFF
--- a/internal/jasmine_node_test/jasmine_runner.js
+++ b/internal/jasmine_node_test/jasmine_runner.js
@@ -63,6 +63,9 @@ function main(args) {
   process.argv.splice(2, 1)[0];
 
   const jrunner = new JasmineRunner({jasmineCore: jasmineCore});
+  if (args.length == 2) {
+    jrunner.loadConfigFile(args[1])
+  }
   fs.readFileSync(manifest, UTF8)
       .split('\n')
       .filter(l => l.length > 0)

--- a/packages/jasmine/src/BUILD
+++ b/packages/jasmine/src/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = 'jasmine_runner',
+    srcs = ['jasmine_runner.js'],
+    visibility = ['//visibility:public'],
+)

--- a/packages/jasmine/src/jasmine_runner.js
+++ b/packages/jasmine/src/jasmine_runner.js
@@ -69,6 +69,9 @@ function main(args) {
   const cwd = process.cwd()
 
   const jrunner = new JasmineRunner({jasmineCore: jasmineCore});
+  if (args.length == 3) {
+    jrunner.loadConfigFile(args[2]);
+  }
   const allFiles = fs.readFileSync(manifest, UTF8)
                        .split('\n')
                        .filter(l => l.length > 0)


### PR DESCRIPTION
This commit enables the `jasmine_node_test` rule to be configured on a
per-test basis through jasmine's configuration file.

The demanding situation for me was to turn off randomnization (default
to on in Bazel) to guarantee some test results.  This would incur adding
the following attribute to jasmine's configuration file:
    ```json
    {
        "random": false
    }
    ```
