### PR TITLE
Cleanup srcs/deps/scripts attributes in node_module_library and its usage

### DIFF
--- a/internal/npm_install/node_module_library.bzl
+++ b/internal/npm_install/node_module_library.bzl
@@ -29,11 +29,6 @@ def _node_module_library_impl(ctx):
     # use in rules such as ts_devserver
     scripts = depset(ctx.files.scripts)
 
-    # TODO(gregmagolan): fix deps in generate_build_file.js and remove transitive lookup
-    for src in ctx.attr.srcs:
-        if NodeModuleSources in src:
-            scripts = depset(transitive = [scripts, src[NodeModuleSources].scripts])
-
     # declarations are a subset of sources that are decleration files
     declarations = depset([f for f in ctx.files.srcs if f.path.endswith(".d.ts")])
 

--- a/internal/npm_install/test/golden/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/BUILD.bazel.golden
@@ -3,7 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
 node_module_library(
     name = "node_modules",
-    srcs = [
+    deps = [
         "//node_modules/.bin:.bin__files",
         "//node_modules/ajv:ajv__files",
         "//node_modules/balanced-match:balanced-match__files",

--- a/internal/npm_install/test/golden/node_modules/@angular/core/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/@angular/core/BUILD.bazel.golden
@@ -3,10 +3,8 @@ package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
 node_module_library(
     name = "core__pkg",
-    srcs = [
-        ":core__files",
-    ],
     deps = [
+        "//node_modules/@angular/core:core__files",
         "//node_modules/tslib:tslib__files",
         "//node_modules/rxjs:rxjs__files",
         "//node_modules/zone.js:zone.js__files",

--- a/internal/npm_install/test/golden/node_modules/@gregmagolan/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/@gregmagolan/BUILD.bazel.golden
@@ -3,7 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
 node_module_library(
     name = "@gregmagolan",
-    srcs = [
+    deps = [
         "//node_modules/@gregmagolan/test-a:test-a__files",
         "//node_modules/@gregmagolan/test-b:test-b__files",
     ],

--- a/internal/npm_install/test/golden/node_modules/@gregmagolan/test-a/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/@gregmagolan/test-a/BUILD.bazel.golden
@@ -4,8 +4,8 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
 node_module_library(
     name = "test-a__pkg",
-    srcs = [
-        ":test-a__files",
+    deps = [
+        "//node_modules/@gregmagolan/test-a:test-a__files",
     ],
 )
 node_module_library(

--- a/internal/npm_install/test/golden/node_modules/@gregmagolan/test-b/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/@gregmagolan/test-b/BUILD.bazel.golden
@@ -3,8 +3,8 @@ package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
 node_module_library(
     name = "test-b__pkg",
-    srcs = [
-        ":test-b__files",
+    deps = [
+        "//node_modules/@gregmagolan/test-b:test-b__files",
     ],
 )
 node_module_library(

--- a/internal/npm_install/test/golden/node_modules/ajv/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/ajv/BUILD.bazel.golden
@@ -3,10 +3,8 @@ package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
 node_module_library(
     name = "ajv__pkg",
-    srcs = [
-        ":ajv__files",
-    ],
     deps = [
+        "//node_modules/ajv:ajv__files",
         "//node_modules/co:co__files",
         "//node_modules/fast-deep-equal:fast-deep-equal__files",
         "//node_modules/fast-json-stable-stringify:fast-json-stable-stringify__files",

--- a/internal/npm_install/test/golden/node_modules/jasmine/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/jasmine/BUILD.bazel.golden
@@ -4,10 +4,8 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
 node_module_library(
     name = "jasmine__pkg",
-    srcs = [
-        ":jasmine__files",
-    ],
     deps = [
+        "//node_modules/jasmine:jasmine__files",
         "//node_modules/glob:glob__files",
         "//node_modules/fs.realpath:fs.realpath__files",
         "//node_modules/inflight:inflight__files",

--- a/internal/npm_install/test/golden/node_modules/rxjs/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/rxjs/BUILD.bazel.golden
@@ -3,10 +3,8 @@ package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
 node_module_library(
     name = "rxjs__pkg",
-    srcs = [
-        ":rxjs__files",
-    ],
     deps = [
+        "//node_modules/rxjs:rxjs__files",
         "//node_modules/tslib:tslib__files",
     ],
 )

--- a/internal/npm_install/test/golden/node_modules/unidiff/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/unidiff/BUILD.bazel.golden
@@ -3,10 +3,8 @@ package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
 node_module_library(
     name = "unidiff__pkg",
-    srcs = [
-        ":unidiff__files",
-    ],
     deps = [
+        "//node_modules/unidiff:unidiff__files",
         "//node_modules/diff:diff__files",
     ],
 )

--- a/internal/npm_install/test/golden/node_modules/zone.js/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/zone.js/BUILD.bazel.golden
@@ -3,8 +3,8 @@ package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
 node_module_library(
     name = "zone.js__pkg",
-    srcs = [
-        ":zone.js__files",
+    deps = [
+        "//node_modules/zone.js:zone.js__files",
     ],
 )
 node_module_library(


### PR DESCRIPTION
Generated `__pkg` targets should not use `srcs` and should only specify `__files` targets in `deps` so that `sources_aspect` picks up all `dev_scripts` via `deps` tree which allows the transitive lookup in `node_module_library` to be removed.
