### PR TITLE
Structural changes for npm strict deps support

### DIFF
--- a/e2e/typescript_2.7/BUILD.bazel
+++ b/e2e/typescript_2.7/BUILD.bazel
@@ -29,6 +29,7 @@ ts_library(
         "@npm//@bazel/typescript",
         "@npm//@types/jasmine",
         "@npm//@types/node",
+        "@npm//typescript",
     ],
 )
 

--- a/e2e/typescript_2.8/BUILD.bazel
+++ b/e2e/typescript_2.8/BUILD.bazel
@@ -29,6 +29,7 @@ ts_library(
         "@npm//@bazel/typescript",
         "@npm//@types/jasmine",
         "@npm//@types/node",
+        "@npm//typescript",
     ],
 )
 

--- a/e2e/typescript_2.9/BUILD.bazel
+++ b/e2e/typescript_2.9/BUILD.bazel
@@ -29,6 +29,7 @@ ts_library(
         "@npm//@bazel/typescript",
         "@npm//@types/jasmine",
         "@npm//@types/node",
+        "@npm//typescript",
     ],
 )
 

--- a/e2e/typescript_3.0/BUILD.bazel
+++ b/e2e/typescript_3.0/BUILD.bazel
@@ -29,6 +29,7 @@ ts_library(
         "@npm//@bazel/typescript",
         "@npm//@types/jasmine",
         "@npm//@types/node",
+        "@npm//typescript",
     ],
 )
 

--- a/e2e/typescript_3.1/BUILD.bazel
+++ b/e2e/typescript_3.1/BUILD.bazel
@@ -42,6 +42,7 @@ ts_library(
         "@npm//@bazel/typescript",
         "@npm//@types/jasmine",
         "@npm//@types/node",
+        "@npm//typescript",
     ],
 )
 

--- a/internal/npm_install/test/golden/@angular/core/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/@angular/core/BUILD.bazel.golden
@@ -9,6 +9,10 @@ alias(
   actual = "//node_modules/@angular/core:core__files"
 )
 alias(
+  name = "core__contents",
+  actual = "//node_modules/@angular/core:core__contents"
+)
+alias(
   name = "core__typings",
   actual = "//node_modules/@angular/core:core__typings"
 )

--- a/internal/npm_install/test/golden/@gregmagolan/test-a/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/@gregmagolan/test-a/BUILD.bazel.golden
@@ -9,6 +9,10 @@ alias(
   actual = "//node_modules/@gregmagolan/test-a:test-a__files"
 )
 alias(
+  name = "test-a__contents",
+  actual = "//node_modules/@gregmagolan/test-a:test-a__contents"
+)
+alias(
   name = "test-a__typings",
   actual = "//node_modules/@gregmagolan/test-a:test-a__typings"
 )

--- a/internal/npm_install/test/golden/@gregmagolan/test-b/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/@gregmagolan/test-b/BUILD.bazel.golden
@@ -9,6 +9,10 @@ alias(
   actual = "//node_modules/@gregmagolan/test-b:test-b__files"
 )
 alias(
+  name = "test-b__contents",
+  actual = "//node_modules/@gregmagolan/test-b:test-b__contents"
+)
+alias(
   name = "test-b__typings",
   actual = "//node_modules/@gregmagolan/test-b:test-b__typings"
 )

--- a/internal/npm_install/test/golden/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/BUILD.bazel.golden
@@ -3,7 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
 node_module_library(
     name = "node_modules",
-    deps = [
+    srcs = [
         "//node_modules/.bin:.bin__files",
         "//node_modules/ajv:ajv__files",
         "//node_modules/balanced-match:balanced-match__files",
@@ -31,5 +31,34 @@ node_module_library(
         "//node_modules/@angular/core:core__files",
         "//node_modules/@gregmagolan/test-a:test-a__files",
         "//node_modules/@gregmagolan/test-b:test-b__files",
+    ],
+    deps = [
+        "//node_modules/.bin:.bin__contents",
+        "//node_modules/ajv:ajv__contents",
+        "//node_modules/balanced-match:balanced-match__contents",
+        "//node_modules/brace-expansion:brace-expansion__contents",
+        "//node_modules/co:co__contents",
+        "//node_modules/concat-map:concat-map__contents",
+        "//node_modules/diff:diff__contents",
+        "//node_modules/fast-deep-equal:fast-deep-equal__contents",
+        "//node_modules/fast-json-stable-stringify:fast-json-stable-stringify__contents",
+        "//node_modules/fs.realpath:fs.realpath__contents",
+        "//node_modules/glob:glob__contents",
+        "//node_modules/inflight:inflight__contents",
+        "//node_modules/inherits:inherits__contents",
+        "//node_modules/jasmine:jasmine__contents",
+        "//node_modules/jasmine-core:jasmine-core__contents",
+        "//node_modules/json-schema-traverse:json-schema-traverse__contents",
+        "//node_modules/minimatch:minimatch__contents",
+        "//node_modules/once:once__contents",
+        "//node_modules/path-is-absolute:path-is-absolute__contents",
+        "//node_modules/rxjs:rxjs__contents",
+        "//node_modules/tslib:tslib__contents",
+        "//node_modules/unidiff:unidiff__contents",
+        "//node_modules/wrappy:wrappy__contents",
+        "//node_modules/zone.js:zone.js__contents",
+        "//node_modules/@angular/core:core__contents",
+        "//node_modules/@gregmagolan/test-a:test-a__contents",
+        "//node_modules/@gregmagolan/test-b:test-b__contents",
     ],
 )

--- a/internal/npm_install/test/golden/ajv/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/ajv/BUILD.bazel.golden
@@ -9,6 +9,10 @@ alias(
   actual = "//node_modules/ajv:ajv__files"
 )
 alias(
+  name = "ajv__contents",
+  actual = "//node_modules/ajv:ajv__contents"
+)
+alias(
   name = "ajv__typings",
   actual = "//node_modules/ajv:ajv__typings"
 )

--- a/internal/npm_install/test/golden/jasmine/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/jasmine/BUILD.bazel.golden
@@ -9,6 +9,10 @@ alias(
   actual = "//node_modules/jasmine:jasmine__files"
 )
 alias(
+  name = "jasmine__contents",
+  actual = "//node_modules/jasmine:jasmine__contents"
+)
+alias(
   name = "jasmine__typings",
   actual = "//node_modules/jasmine:jasmine__typings"
 )

--- a/internal/npm_install/test/golden/node_modules/@angular/core/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/@angular/core/BUILD.bazel.golden
@@ -1,16 +1,7 @@
 
 package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
-node_module_library(
-    name = "core__pkg",
-    deps = [
-        "//node_modules/@angular/core:core__files",
-        "//node_modules/tslib:tslib__files",
-        "//node_modules/rxjs:rxjs__files",
-        "//node_modules/zone.js:zone.js__files",
-    ],
-)
-node_module_library(
+filegroup(
     name = "core__files",
     srcs = [
         ":README.md",
@@ -625,6 +616,20 @@ node_module_library(
         ":testing/testing.d.ts",
         ":testing/testing.metadata.json",
     ],
+)
+node_module_library(
+    name = "core__pkg",
+    srcs = [":core__files"],
+    deps = [
+        "//node_modules/@angular/core:core__contents",
+        "//node_modules/tslib:tslib__contents",
+        "//node_modules/rxjs:rxjs__contents",
+        "//node_modules/zone.js:zone.js__contents",
+    ],
+)
+node_module_library(
+    name = "core__contents",
+    srcs = [":core__files"],
     scripts = [
         ":bundles/core-testing.umd.js",
         ":bundles/core.umd.js",

--- a/internal/npm_install/test/golden/node_modules/@gregmagolan/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/@gregmagolan/BUILD.bazel.golden
@@ -3,8 +3,12 @@ package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
 node_module_library(
     name = "@gregmagolan",
-    deps = [
+    srcs = [
         "//node_modules/@gregmagolan/test-a:test-a__files",
         "//node_modules/@gregmagolan/test-b:test-b__files",
+    ],
+    deps = [
+        "//node_modules/@gregmagolan/test-a:test-a__contents",
+        "//node_modules/@gregmagolan/test-b:test-b__contents",
     ],
 )

--- a/internal/npm_install/test/golden/node_modules/@gregmagolan/test-a/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/@gregmagolan/test-a/BUILD.bazel.golden
@@ -2,19 +2,24 @@
 package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
-node_module_library(
-    name = "test-a__pkg",
-    deps = [
-        "//node_modules/@gregmagolan/test-a:test-a__files",
-    ],
-)
-node_module_library(
+filegroup(
     name = "test-a__files",
     srcs = [
         ":@bin/test.js",
         ":main.js",
         ":package.json",
     ],
+)
+node_module_library(
+    name = "test-a__pkg",
+    srcs = [":test-a__files"],
+    deps = [
+        "//node_modules/@gregmagolan/test-a:test-a__contents",
+    ],
+)
+node_module_library(
+    name = "test-a__contents",
+    srcs = [":test-a__files"],
 )
 node_module_library(
     name = "test-a__typings",

--- a/internal/npm_install/test/golden/node_modules/@gregmagolan/test-b/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/@gregmagolan/test-b/BUILD.bazel.golden
@@ -1,13 +1,7 @@
 
 package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
-node_module_library(
-    name = "test-b__pkg",
-    deps = [
-        "//node_modules/@gregmagolan/test-b:test-b__files",
-    ],
-)
-node_module_library(
+filegroup(
     name = "test-b__files",
     srcs = [
         ":main.js",
@@ -15,6 +9,17 @@ node_module_library(
         ":node_modules/@gregmagolan/test-a/package.json",
         ":package.json",
     ],
+)
+node_module_library(
+    name = "test-b__pkg",
+    srcs = [":test-b__files"],
+    deps = [
+        "//node_modules/@gregmagolan/test-b:test-b__contents",
+    ],
+)
+node_module_library(
+    name = "test-b__contents",
+    srcs = [":test-b__files"],
 )
 node_module_library(
     name = "test-b__typings",

--- a/internal/npm_install/test/golden/node_modules/ajv/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/ajv/BUILD.bazel.golden
@@ -1,17 +1,7 @@
 
 package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
-node_module_library(
-    name = "ajv__pkg",
-    deps = [
-        "//node_modules/ajv:ajv__files",
-        "//node_modules/co:co__files",
-        "//node_modules/fast-deep-equal:fast-deep-equal__files",
-        "//node_modules/fast-json-stable-stringify:fast-json-stable-stringify__files",
-        "//node_modules/json-schema-traverse:json-schema-traverse__files",
-    ],
-)
-node_module_library(
+filegroup(
     name = "ajv__files",
     srcs = [
         ":.tonic_example.js",
@@ -103,6 +93,21 @@ node_module_library(
         ":scripts/prepare-tests",
         ":scripts/travis-gh-pages",
     ],
+)
+node_module_library(
+    name = "ajv__pkg",
+    srcs = [":ajv__files"],
+    deps = [
+        "//node_modules/ajv:ajv__contents",
+        "//node_modules/co:co__contents",
+        "//node_modules/fast-deep-equal:fast-deep-equal__contents",
+        "//node_modules/fast-json-stable-stringify:fast-json-stable-stringify__contents",
+        "//node_modules/json-schema-traverse:json-schema-traverse__contents",
+    ],
+)
+node_module_library(
+    name = "ajv__contents",
+    srcs = [":ajv__files"],
 )
 node_module_library(
     name = "ajv__typings",

--- a/internal/npm_install/test/golden/node_modules/jasmine/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/jasmine/BUILD.bazel.golden
@@ -2,25 +2,7 @@
 package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
-node_module_library(
-    name = "jasmine__pkg",
-    deps = [
-        "//node_modules/jasmine:jasmine__files",
-        "//node_modules/glob:glob__files",
-        "//node_modules/fs.realpath:fs.realpath__files",
-        "//node_modules/inflight:inflight__files",
-        "//node_modules/once:once__files",
-        "//node_modules/wrappy:wrappy__files",
-        "//node_modules/inherits:inherits__files",
-        "//node_modules/minimatch:minimatch__files",
-        "//node_modules/brace-expansion:brace-expansion__files",
-        "//node_modules/balanced-match:balanced-match__files",
-        "//node_modules/concat-map:concat-map__files",
-        "//node_modules/path-is-absolute:path-is-absolute__files",
-        "//node_modules/jasmine-core:jasmine-core__files",
-    ],
-)
-node_module_library(
+filegroup(
     name = "jasmine__files",
     srcs = [
         ":.editorconfig",
@@ -38,6 +20,29 @@ node_module_library(
         ":package.json",
         ":tasks/jasmine.js",
     ],
+)
+node_module_library(
+    name = "jasmine__pkg",
+    srcs = [":jasmine__files"],
+    deps = [
+        "//node_modules/jasmine:jasmine__contents",
+        "//node_modules/glob:glob__contents",
+        "//node_modules/fs.realpath:fs.realpath__contents",
+        "//node_modules/inflight:inflight__contents",
+        "//node_modules/once:once__contents",
+        "//node_modules/wrappy:wrappy__contents",
+        "//node_modules/inherits:inherits__contents",
+        "//node_modules/minimatch:minimatch__contents",
+        "//node_modules/brace-expansion:brace-expansion__contents",
+        "//node_modules/balanced-match:balanced-match__contents",
+        "//node_modules/concat-map:concat-map__contents",
+        "//node_modules/path-is-absolute:path-is-absolute__contents",
+        "//node_modules/jasmine-core:jasmine-core__contents",
+    ],
+)
+node_module_library(
+    name = "jasmine__contents",
+    srcs = [":jasmine__files"],
 )
 node_module_library(
     name = "jasmine__typings",

--- a/internal/npm_install/test/golden/node_modules/rxjs/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/rxjs/BUILD.bazel.golden
@@ -1,14 +1,7 @@
 
 package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
-node_module_library(
-    name = "rxjs__pkg",
-    deps = [
-        "//node_modules/rxjs:rxjs__files",
-        "//node_modules/tslib:tslib__files",
-    ],
-)
-node_module_library(
+filegroup(
     name = "rxjs__files",
     srcs = [
         ":AsyncSubject.d.ts",
@@ -3569,6 +3562,18 @@ node_module_library(
         ":webSocket/index.js.map",
         ":webSocket/package.json",
     ],
+)
+node_module_library(
+    name = "rxjs__pkg",
+    srcs = [":rxjs__files"],
+    deps = [
+        "//node_modules/rxjs:rxjs__contents",
+        "//node_modules/tslib:tslib__contents",
+    ],
+)
+node_module_library(
+    name = "rxjs__contents",
+    srcs = [":rxjs__files"],
 )
 node_module_library(
     name = "rxjs__typings",

--- a/internal/npm_install/test/golden/node_modules/unidiff/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/unidiff/BUILD.bazel.golden
@@ -1,14 +1,7 @@
 
 package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
-node_module_library(
-    name = "unidiff__pkg",
-    deps = [
-        "//node_modules/unidiff:unidiff__files",
-        "//node_modules/diff:diff__files",
-    ],
-)
-node_module_library(
+filegroup(
     name = "unidiff__files",
     srcs = [
         ":.npmignore",
@@ -22,6 +15,18 @@ node_module_library(
         ":test/test_unidiff.js",
         ":unidiff.js",
     ],
+)
+node_module_library(
+    name = "unidiff__pkg",
+    srcs = [":unidiff__files"],
+    deps = [
+        "//node_modules/unidiff:unidiff__contents",
+        "//node_modules/diff:diff__contents",
+    ],
+)
+node_module_library(
+    name = "unidiff__contents",
+    srcs = [":unidiff__files"],
 )
 node_module_library(
     name = "unidiff__typings",

--- a/internal/npm_install/test/golden/node_modules/zone.js/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/zone.js/BUILD.bazel.golden
@@ -1,13 +1,7 @@
 
 package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//internal/npm_install:node_module_library.bzl", "node_module_library")
-node_module_library(
-    name = "zone.js__pkg",
-    deps = [
-        "//node_modules/zone.js:zone.js__files",
-    ],
-)
-node_module_library(
+filegroup(
     name = "zone.js__files",
     srcs = [
         ":CHANGELOG.md",
@@ -139,6 +133,17 @@ node_module_library(
         ":lib/zone.ts",
         ":package.json",
     ],
+)
+node_module_library(
+    name = "zone.js__pkg",
+    srcs = [":zone.js__files"],
+    deps = [
+        "//node_modules/zone.js:zone.js__contents",
+    ],
+)
+node_module_library(
+    name = "zone.js__contents",
+    srcs = [":zone.js__files"],
 )
 node_module_library(
     name = "zone.js__typings",

--- a/internal/npm_install/test/golden/rxjs/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/rxjs/BUILD.bazel.golden
@@ -9,6 +9,10 @@ alias(
   actual = "//node_modules/rxjs:rxjs__files"
 )
 alias(
+  name = "rxjs__contents",
+  actual = "//node_modules/rxjs:rxjs__contents"
+)
+alias(
   name = "rxjs__typings",
   actual = "//node_modules/rxjs:rxjs__typings"
 )

--- a/internal/npm_install/test/golden/unidiff/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/unidiff/BUILD.bazel.golden
@@ -9,6 +9,10 @@ alias(
   actual = "//node_modules/unidiff:unidiff__files"
 )
 alias(
+  name = "unidiff__contents",
+  actual = "//node_modules/unidiff:unidiff__contents"
+)
+alias(
   name = "unidiff__typings",
   actual = "//node_modules/unidiff:unidiff__typings"
 )

--- a/internal/npm_install/test/golden/zone.js/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/zone.js/BUILD.bazel.golden
@@ -9,6 +9,10 @@ alias(
   actual = "//node_modules/zone.js:zone.js__files"
 )
 alias(
+  name = "zone.js__contents",
+  actual = "//node_modules/zone.js:zone.js__contents"
+)
+alias(
   name = "zone.js__typings",
   actual = "//node_modules/zone.js:zone.js__typings"
 )

--- a/packages/typescript/internal/build_defs.bzl
+++ b/packages/typescript/internal/build_defs.bzl
@@ -252,9 +252,6 @@ def _ts_library_impl(ctx):
     ts_providers = compile_ts(
         ctx,
         is_library = True,
-        # Strict_deps checking currently skips node_modules.
-        # TODO(alexeagle): turn on strict deps checking when we have a real
-        # provider for JS/DTS inputs to ts_library.
         deps = ctx.attr.deps,
         compile_action = _compile_action,
         devmode_compile_action = _devmode_compile_action,


### PR DESCRIPTION
These are all the changes required in this repo to get npm strict deps to work.

We have a chicken & egg problem to land this so we need to:

1) Land this PR
2) Update the rules_nodejs commit hash in rules_typescript and land https://github.com/bazelbuild/rules_typescript/pull/445
3) Update the commit hash in rules_nodejs in another PR

(3) will be a breaking change and downstream users that are depending on transitive @npm deps in their ts_library or ng_module rules will see errors that look like so:

```
main.spec.ts:1:21 - error TS2307: transitive dependency on external/npm/node_modules/typescript/lib/typescript.d.ts not allowed. Please add the BUILD target to your rule's deps.
1 import * as ts from 'typescript';
```