### PR TITLE
Fix build with --incompatible_depset_is_not_iterable

### DIFF
--- a/internal/common/sources_aspect.bzl
+++ b/internal/common/sources_aspect.bzl
@@ -36,7 +36,7 @@ def _sources_aspect_impl(target, ctx):
     elif hasattr(target, "files") and not NodeModuleInfo in target:
         # Sources from npm fine grained deps should not be included
         node_sources = depset(
-            [f for f in target.files if f.path.endswith(".js")],
+            [f for f in target.files.to_list() if f.path.endswith(".js")],
             transitive = [node_sources],
         )
 


### PR DESCRIPTION
Soon, Bazel will forbid iteration on a depset, it needs to be explicitly
converted to list.

## PR Type

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No