### PR TITLE
Update @bazel/karma to latest sable Chromium 74 for osx & linux

### DIFF
--- a/packages/karma/browser_repositories.bzl
+++ b/packages/karma/browser_repositories.bzl
@@ -23,20 +23,23 @@ def browser_repositories():
     platform_http_file(
         name = "org_chromium_chromium",
         amd64_sha256 =
-            "941de83d78b27d43db07f427136ba159d661bb111db8d9ffe12499b863a003e1",
+            "eb6754c7918da5eab42a42bbda7efdf7f1661eaa3802b8940841f0c2c312299f",
         amd64_urls = [
-            # Chromium 69.0.3497.0 (2018-07-19 snaphot 576668)
-            # https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Linux_x64/576668/
-            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/576668/chrome-linux.zip",
+            # Chromium 74.0.3729.0 (2019-03-08 snaphot 638880)
+            # https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Linux_x64/638880/
+            # Current linux stable as of 2019-05-15
+            # https://www.chromium.org/developers/calendar
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/638880/chrome-linux.zip",
         ],
         licenses = ["notice"],  # BSD 3-clause (maybe more?)
         macos_sha256 =
-            "bd01783e7d179e9f85d4b6f0c9df53118d13977cc7d365a1caa9d198c6afcfd8",
+            "c48bdffac6a91c85c17a848012b1a45fbf36e3a2d4aaac5b6ded8ac65b1d96e3",
         macos_urls = [
-            # Chromium 69.0.3497.0 (2018-07-19 snaphot 576668)
-            # https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Mac/576668/
-            # NOTE: There is an issue with ChromeHeadless on OSX chromium 70+
-            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/576668/chrome-mac.zip",
+            # Chromium 74.0.3729.0 (2019-03-08 snaphot 638880)
+            # https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Mac/638880/
+            # Current mac stable as of 2019-05-15
+            # https://www.chromium.org/developers/calendar
+            "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/638880/chrome-mac.zip",
         ],
         windows_sha256 =
             "d1bb728118c12ea436d8ea07dba980789e7d860aa664dd1fad78bc20e8d9391c",
@@ -53,19 +56,19 @@ def browser_repositories():
     platform_http_file(
         name = "org_chromium_chromedriver",
         amd64_sha256 =
-            "687d2e15c42908e2911344c08a949461b3f20a83017a7a682ef4d002e05b5d46",
+            "ec9dbe021338f0befaecca702abc576cb7cc31a2f5a852c2c41e94721af5d3ad",
         amd64_urls = [
-            # ChromeDriver 2.44 supports Chrome v69-71
+            # ChromeDriver 74.0.3729.6 supports Chrome 74
             # http://chromedriver.chromium.org/downloads
-            "https://chromedriver.storage.googleapis.com/2.44/chromedriver_linux64.zip",
+            "https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip",
         ],
         licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
         macos_sha256 =
-            "3fd49c2782a5f93cb48ff2dee021004d9a7fb393798e4c4807b391cedcd30ed9",
+            "b4b73681404d231d81a9b7ab9d4f0cb090f3e69240296eca2eb46e2629519152",
         macos_urls = [
-            # ChromeDriver 2.44 supports Chrome v69-71
+            # ChromeDriver 74.0.3729.6 supports Chrome 74
             # http://chromedriver.chromium.org/downloads
-            "https://chromedriver.storage.googleapis.com/2.44/chromedriver_mac64.zip",
+            "https://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_mac64.zip",
         ],
         windows_sha256 =
             "a8fa028acebef7b931ef9cb093f02865f9f7495e49351f556e919f7be77f072e",

--- a/packages/karma/karma.conf.js
+++ b/packages/karma/karma.conf.js
@@ -60,31 +60,51 @@ try {
   }
 
   /**
-   * Chrome on Linux uses sandboxing, which needs user namespaces to be enabled.
-   * This is not available on all kernels and it might be turned off even if it is available.
-   * Notable examples where user namespaces are not available include:
-   * - In Debian it is compiled-in but disabled by default.
-   * - The Docker daemon for Windows or OSX does not support user namespaces.
-   * We can detect if user namespaces are supported via /proc/sys/kernel/unprivileged_userns_clone.
-   * For more information see:
-   * https://github.com/Googlechrome/puppeteer/issues/290
-   * https://superuser.com/questions/1094597/enable-user-namespaces-in-debian-kernel#1122977
-   * https://github.com/karma-runner/karma-chrome-launcher/issues/158
-   * https://github.com/angular/angular/pull/24906
+   * Check if Chrome sandboxing is supported on the current platform.
    */
-  function supportsSandboxing() {
-    if (process.platform !== 'linux') {
-      return true;
-    }
-    try {
-      const res = child_process.execSync('cat /proc/sys/kernel/unprivileged_userns_clone')
-                      .toString()
-                      .trim();
-      return res === '1';
-    } catch (error) {
+  function supportChromeSandboxing() {
+    if (process.platform === 'darwin') {
+      // Chrome 73+ fails to initialize the sandbox on OSX when running under Bazel.
+      // ```
+      // ERROR [launcher]: Cannot start ChromeHeadless
+      // ERROR:crash_report_database_mac.mm(96)] mkdir
+      // /private/var/tmp/_bazel_greg/62ef096b0da251c6d093468a1efbfbd3/execroot/angular/bazel-out/darwin-fastbuild/bin/external/io_bazel_rules_webtesting/third_party/chromium/chromium.out/chrome-mac/Chromium.app/Contents/Versions/73.0.3683.0/Chromium
+      // Framework.framework/Versions/A/new: Permission denied (13) ERROR:file_io.cc(89)]
+      // ReadExactly: expected 8, observed 0 ERROR:crash_report_database_mac.mm(96)] mkdir
+      // /private/var/tmp/_bazel_greg/62ef096b0da251c6d093468a1efbfbd3/execroot/angular/bazel-out/darwin-fastbuild/bin/external/io_bazel_rules_webtesting/third_party/chromium/chromium.out/chrome-mac/Chromium.app/Contents/Versions/73.0.3683.0/Chromium
+      // Framework.framework/Versions/A/new: Permission denied (13) Chromium Helper[94642] <Error>:
+      // SeatbeltExecServer: Failed to initialize sandbox: -1 Operation not permitted Failed to
+      // initialize sandbox. [0213/201206.137114:FATAL:content_main_delegate.cc(54)] Check failed:
+      // false. 0   Chromium Framework                  0x000000010c078bc9 ChromeMain + 43788137 1
+      // Chromium Framework                  0x000000010bfc0f43 ChromeMain + 43035363
+      // ...
+      // ```
+      return false;
     }
 
-    return false;
+    if (process.platform === 'linux') {
+      // Chrome on Linux uses sandboxing, which needs user namespaces to be enabled.
+      // This is not available on all kernels and it might be turned off even if it is available.
+      // Notable examples where user namespaces are not available include:
+      // - In Debian it is compiled-in but disabled by default.
+      // - The Docker daemon for Windows or OSX does not support user namespaces.
+      // We can detect if user namespaces are supported via
+      // /proc/sys/kernel/unprivileged_userns_clone. For more information see:
+      // https://github.com/Googlechrome/puppeteer/issues/290
+      // https://superuser.com/questions/1094597/enable-user-namespaces-in-debian-kernel#1122977
+      // https://github.com/karma-runner/karma-chrome-launcher/issues/158
+      // https://github.com/angular/angular/pull/24906
+      try {
+        const res = child_process.execSync('cat /proc/sys/kernel/unprivileged_userns_clone')
+                        .toString()
+                        .trim();
+        return res === '1';
+      } catch (error) {
+      }
+      return false;
+    }
+
+    return true;
   }
 
   /**
@@ -324,7 +344,7 @@ try {
             process.env.CHROME_BIN = require.resolve(webTestNamedFiles['CHROMIUM']);
           }
           const browser = process.env['DISPLAY'] ? 'Chrome' : 'ChromeHeadless';
-          if (!supportsSandboxing()) {
+          if (!supportChromeSandboxing()) {
             const launcher = 'CustomChromeWithoutSandbox';
             conf.customLaunchers = {[launcher]: {base: browser, flags: ['--no-sandbox']}};
             conf.browsers.push(launcher);


### PR DESCRIPTION
OSX Chromium 73+ requires disabling of the sandbox under Bazel

Windows still on Chromium 66 and updating that is a separate task and requires changes to rules_webtesting as the archive name & executable path has changed
