### PR TITLE
Add support for Label in nodejs_binary and rollup_bundle entry_point

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,19 +320,8 @@ For example, the `protractor` package has two bin entries in its `package.json`:
 These will result in two generated `nodejs_binary` targets in the `@npm//protractor/bin`
 package (if your npm deps workspace is `@npm`):
 
-```python
-nodejs_binary(
-    name = "protractor",
-    entry_point = "protractor/bin/protractor",
-    data = ["//protractor"],
-)
-
-nodejs_binary(
-    name = "webdriver-manager",
-    entry_point = "protractor/bin/webdriver-manager",
-    data = ["//protractor"],
-)
-```
+* `@npm//protractor/bin:protractor`
+* `@npm//protractor/bin:webdriver-manager`
 
 These targets can be used as executables for actions in custom rules or can
 be run by Bazel directly. For example, you can run protractor with the
@@ -452,7 +441,7 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
 
 nodejs_binary(
     name = "rollup",
-    entry_point = "rollup/bin/rollup",
+    entry_point = "//:node_modules/rollup/bin/rollup",
 )
 ```
 
@@ -480,7 +469,7 @@ nodejs_binary(
         "@//:node_modules",
         "main.js",
     ],
-    entry_point = "workspace_name/main.js",
+    entry_point = ":main.js",
     args = ["--node_options=--expose-gc"],
 )
 ```

--- a/e2e/jasmine/BUILD.bazel
+++ b/e2e/jasmine/BUILD.bazel
@@ -3,10 +3,6 @@ load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
 jasmine_node_test(
     name = "test",
     srcs = ["test.spec.js"],
-    jasmine = "@npm_bazel_jasmine//:index.js",
-    deps = [
-        "@npm//@bazel/jasmine",
-    ],
 )
 
 jasmine_node_test(
@@ -14,9 +10,7 @@ jasmine_node_test(
     srcs = ["jasmine_shared_env_test.spec.js"],
     bootstrap = ["e2e_jasmine/jasmine_shared_env_bootstrap.js"],
     data = ["jasmine_shared_env_bootstrap.js"],
-    jasmine = "@npm_bazel_jasmine//:index.js",
     deps = [
-        "@npm//@bazel/jasmine",
         "@npm//jasmine",
         "@npm//jasmine-core",
         "@npm//zone.js",
@@ -30,8 +24,4 @@ jasmine_node_test(
         "coverage_source.js",
     ],
     coverage = True,
-    jasmine = "@npm_bazel_jasmine//:index.js",
-    deps = [
-        "@npm//@bazel/jasmine",
-    ],
 )

--- a/e2e/jasmine/BUILD.bazel
+++ b/e2e/jasmine/BUILD.bazel
@@ -3,6 +3,10 @@ load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
 jasmine_node_test(
     name = "test",
     srcs = ["test.spec.js"],
+    jasmine = "@npm_bazel_jasmine//:index.js",
+    deps = [
+        "@npm//@bazel/jasmine",
+    ],
 )
 
 jasmine_node_test(
@@ -10,7 +14,9 @@ jasmine_node_test(
     srcs = ["jasmine_shared_env_test.spec.js"],
     bootstrap = ["e2e_jasmine/jasmine_shared_env_bootstrap.js"],
     data = ["jasmine_shared_env_bootstrap.js"],
+    jasmine = "@npm_bazel_jasmine//:index.js",
     deps = [
+        "@npm//@bazel/jasmine",
         "@npm//jasmine",
         "@npm//jasmine-core",
         "@npm//zone.js",
@@ -24,4 +30,8 @@ jasmine_node_test(
         "coverage_source.js",
     ],
     coverage = True,
+    jasmine = "@npm_bazel_jasmine//:index.js",
+    deps = [
+        "@npm//@bazel/jasmine",
+    ],
 )

--- a/e2e/ts_library/googmodule/BUILD.bazel
+++ b/e2e/ts_library/googmodule/BUILD.bazel
@@ -13,7 +13,7 @@ nodejs_binary(
         "@npm//@bazel/typescript",
         "@npm//tsickle",
     ],
-    entry_point = "@bazel/typescript/internal/tsc_wrapped/tsc_wrapped.js",
+    entry_point = "@npm//node_modules/@bazel/typescript:internal/tsc_wrapped/tsc_wrapped.js",
     install_source_map_support = False,
 )
 

--- a/e2e/ts_library/some_module/BUILD.bazel
+++ b/e2e/ts_library/some_module/BUILD.bazel
@@ -25,7 +25,7 @@ nodejs_binary(
         ":main",
         ":some_module",
     ],
-    entry_point = "e2e_ts_library/some_module/main.js",
+    entry_point = ":main.js",
 )
 
 sh_test(

--- a/e2e/ts_library/some_module/BUILD.bazel
+++ b/e2e/ts_library/some_module/BUILD.bazel
@@ -25,7 +25,7 @@ nodejs_binary(
         ":main",
         ":some_module",
     ],
-    entry_point = ":main.js",
+    entry_point = ":main.ts",
 )
 
 sh_test(

--- a/e2e/typescript_3.1/BUILD.bazel
+++ b/e2e/typescript_3.1/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary", "rollup_bundle")
+load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
 load("@npm_bazel_typescript//:index.bzl", "ts_library")
 
@@ -57,26 +57,9 @@ jasmine_node_test(
     ],
 )
 
-nodejs_binary(
-    name = "main_js",
-    data = [
-        ":main",
-    ],
-    entry_point = "e2e_typescript_3_1/main.js",
-)
-
-nodejs_binary(
-    name = "main_js_sm",
-    data = [
-        ":main",
-        "@npm//source-map-support",
-    ],
-    entry_point = "e2e_typescript_3_1/main.js",
-)
-
 rollup_bundle(
     name = "bundle",
-    entry_point = "main",
+    entry_point = ":main.ts",
     deps = [
         ":main",
     ],
@@ -84,7 +67,7 @@ rollup_bundle(
 
 rollup_bundle(
     name = "bundle_sm",
-    entry_point = "main",
+    entry_point = ":main.ts",
     deps = [
         ":main",
         "@npm//source-map-support",

--- a/examples/app/BUILD.bazel
+++ b/examples/app/BUILD.bazel
@@ -19,7 +19,7 @@ ts_devserver(
 
 rollup_bundle(
     name = "bundle",
-    entry_point = "examples_app/app",
+    entry_point = ":app.ts",
     deps = [":app"],
 )
 

--- a/examples/parcel/BUILD.bazel
+++ b/examples/parcel/BUILD.bazel
@@ -5,9 +5,8 @@ parcel(
     name = "bundle",
     srcs = [
         "bar.js",
-        "foo.js",
     ],
-    entry_point = "foo.js",
+    entry_point = ":foo.js",
 )
 
 jasmine_node_test(

--- a/examples/parcel/parcel.bzl
+++ b/examples/parcel/parcel.bzl
@@ -27,12 +27,12 @@ def _parcel_impl(ctx):
     """
 
     # Options documented at https://parceljs.org/cli.html
-    args = ["build", ctx.attr.entry_point]
+    args = ["build", ctx.file.entry_point.short_path]
     args += ["--out-dir", ctx.outputs.bundle.dirname]
     args += ["--out-file", ctx.outputs.bundle.basename]
 
     ctx.actions.run(
-        inputs = ctx.files.srcs,
+        inputs = ctx.files.srcs + [ctx.file.entry_point],
         executable = ctx.executable.parcel,
         outputs = [ctx.outputs.bundle, ctx.outputs.sourcemap],
         arguments = args,
@@ -44,7 +44,10 @@ parcel = rule(
     implementation = _parcel_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
-        "entry_point": attr.string(mandatory = True),
+        "entry_point": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
         "parcel": attr.label(
             # This default assumes that users name their install "npm"
             default = Label("@npm//parcel-bundler/bin:parcel"),

--- a/examples/program/BUILD.bazel
+++ b/examples/program/BUILD.bazel
@@ -38,7 +38,7 @@ nodejs_binary(
         "index.js",
         ":node_modules",
     ],
-    entry_point = "examples_program/index.js",
+    entry_point = ":index.js",
 )
 
 jasmine_node_test(

--- a/examples/protocol_buffers/BUILD.bazel
+++ b/examples/protocol_buffers/BUILD.bazel
@@ -70,7 +70,7 @@ ts_devserver(
 # Test for production mode
 rollup_bundle(
     name = "bundle",
-    entry_point = "examples_protocol_buffers/app",
+    entry_point = ":app.ts",
     # TODO(alexeagle): we should be able to get this from //:protobufjs_bootstrap_scripts
     # and automatically plumb it through to Rollup.
     globals = {

--- a/examples/webapp/BUILD.bazel
+++ b/examples/webapp/BUILD.bazel
@@ -6,7 +6,7 @@ load("@build_bazel_rules_nodejs//internal/web_package:web_package.bzl", "web_pac
 rollup_bundle(
     name = "bundle",
     srcs = glob(["*.js"]),
-    entry_point = "index.js",
+    entry_point = ":index.js",
 )
 
 web_package(

--- a/internal/common/collect_es6_sources.bzl
+++ b/internal/common/collect_es6_sources.bzl
@@ -31,6 +31,11 @@ def collect_es6_sources(ctx):
     non_rerooted_files = [d for d in ctx.files.deps if d.is_source]
     if hasattr(ctx.attr, "srcs"):
         non_rerooted_files += ctx.files.srcs
+
+    # Some rules such as rollup_bundle specify an entry_point which should
+    # be collected if the file is a js file.
+    if hasattr(ctx.attr, "entry_point"):
+        non_rerooted_files += [s for s in ctx.files.entry_point if s.extension == "js"]
     for dep in ctx.attr.deps:
         if hasattr(dep, "typescript"):
             non_rerooted_files += dep.typescript.transitive_es6_sources.to_list()

--- a/internal/e2e/fine_grained_no_bin/BUILD.bazel
+++ b/internal/e2e/fine_grained_no_bin/BUILD.bazel
@@ -12,5 +12,5 @@ nodejs_binary(
         "test/test.js",
         "@fine_grained_no_bin//fs.realpath",
     ],
-    entry_point = "build_bazel_rules_nodejs/internal/e2e/fine_grained_no_bin/index.js",
+    entry_point = ":index.js",
 )

--- a/internal/e2e/rollup/BUILD.bazel
+++ b/internal/e2e/rollup/BUILD.bazel
@@ -3,11 +3,8 @@ load("//:defs.bzl", "rollup_bundle")
 
 rollup_bundle(
     name = "bundle",
-    srcs = [
-        "bar.js",
-        "foo.js",
-    ],
-    entry_point = "internal/e2e/rollup/foo.js",
+    srcs = ["bar.js"],
+    entry_point = ":foo.js",
     globals = {"some_global_var": "runtime_name_of_global_var"},
     license_banner = ":license.txt",
     deps = [

--- a/internal/e2e/rollup_code_splitting/BUILD.bazel
+++ b/internal/e2e/rollup_code_splitting/BUILD.bazel
@@ -6,8 +6,8 @@ rollup_bundle(
         ["*.js"],
         exclude = ["*.spec.js"],
     ),
-    additional_entry_points = ["internal/e2e/rollup_code_splitting/additional_entry.js"],
-    entry_point = "internal/e2e/rollup_code_splitting/main1.js",
+    additional_entry_points = ["build_bazel_rules_nodejs/internal/e2e/rollup_code_splitting/additional_entry.js"],
+    entry_point = ":main1.js",
     license_banner = ":license.txt",
 )
 
@@ -18,10 +18,11 @@ jasmine_node_test(
         "main1.spec.js",
     ],
     data = glob([
-        "*_golden.js_",
+        "goldens/*",
     ]) + [
         ":bundle",
         ":bundle.min.js",
+        ":bundle.min.es2015.js",
     ],
     deps = [
         "//internal/e2e:check_lib",

--- a/internal/e2e/rollup_code_splitting/additional_entry.spec.js
+++ b/internal/e2e/rollup_code_splitting/additional_entry.spec.js
@@ -5,7 +5,8 @@ const path = __dirname;
 
 describe('bundling additional entry point', () => {
   it('should work', () => {
-    check(path, 'bundle.min.js', 'bundle-min_golden.js_');
+    check(path, 'bundle.min.js', 'goldens/bundle.min.js_');
+    check(path, 'bundle.min.es2015.js', 'goldens/bundle.min.es2015.js_');
   });
 
   // Disabled because native ESModules can't be loaded in current nodejs

--- a/internal/e2e/rollup_code_splitting/goldens/bundle.min.es2015.js_
+++ b/internal/e2e/rollup_code_splitting/goldens/bundle.min.es2015.js_
@@ -1,0 +1,1 @@
+import('./bundle_chunks_min_es2015/main1.js');

--- a/internal/e2e/rollup_code_splitting/goldens/bundle.min.js_
+++ b/internal/e2e/rollup_code_splitting/goldens/bundle.min.js_
@@ -3,7 +3,7 @@
 (function(global) {
 System.config({
   packages: {
-    '': {map: {"./main1.js": "bundle_chunks_min/main1.js", "./additional_entry.js": "bundle_chunks_min/additional_entry.js"}, defaultExtension: 'js'},
+    '': {map: {"./main1": "bundle_chunks_min/main1", "./additional_entry.js": "bundle_chunks_min/additional_entry.js"}, defaultExtension: 'js'},
   }
 });
 System.import('main1.js').catch(function(err) {

--- a/internal/e2e/rollup_fine_grained_deps/BUILD.bazel
+++ b/internal/e2e/rollup_fine_grained_deps/BUILD.bazel
@@ -93,6 +93,6 @@ nodejs_binary(
         "@npm//jasmine",
         "@npm//unidiff",
     ],
-    entry_point = "build_bazel_rules_nodejs/internal/e2e/rollup_fine_grained_deps/update_golden.js",
+    entry_point = ":update_golden.js",
     install_source_map_support = False,
 )

--- a/internal/e2e/rollup_fine_grained_deps/BUILD.bazel
+++ b/internal/e2e/rollup_fine_grained_deps/BUILD.bazel
@@ -4,16 +4,14 @@ load("//:defs.bzl", "jasmine_node_test", "nodejs_binary", "rollup_bundle")
 # and no fine grained deps
 rollup_bundle(
     name = "bundle_no_deps",
-    srcs = ["no-deps.js"],
-    entry_point = "internal/e2e/rollup_fine_grained_deps/no-deps.js",
+    entry_point = ":no-deps.js",
 )
 
 # You can have a rollup_bundle with no node_modules attribute
 # and fine grained deps
 rollup_bundle(
     name = "bundle",
-    srcs = ["has-deps.js"],
-    entry_point = "internal/e2e/rollup_fine_grained_deps/has-deps.js",
+    entry_point = ":has-deps.js",
     deps = [
         "@fine_grained_deps_yarn//@gregmagolan/test-a",
         "@fine_grained_deps_yarn//@gregmagolan/test-b",
@@ -24,8 +22,7 @@ rollup_bundle(
 # and no fine grained deps
 rollup_bundle(
     name = "bundle_legacy",
-    srcs = ["has-deps.js"],
-    entry_point = "internal/e2e/rollup_fine_grained_deps/has-deps.js",
+    entry_point = ":has-deps.js",
     node_modules = "@fine_grained_deps_yarn//:node_modules",
 )
 
@@ -33,8 +30,7 @@ rollup_bundle(
 # and fine grained deps so long as they come from the same root
 rollup_bundle(
     name = "bundle_hybrid",
-    srcs = ["has-deps.js"],
-    entry_point = "internal/e2e/rollup_fine_grained_deps/has-deps.js",
+    entry_point = ":has-deps.js",
     node_modules = "@fine_grained_deps_yarn//:node_modules",
     deps = [
         "@fine_grained_deps_yarn//@gregmagolan/test-a",

--- a/internal/history-server/history_server.bzl
+++ b/internal/history-server/history_server.bzl
@@ -26,7 +26,7 @@ def history_server(templated_args = [], **kwargs):
 
     nodejs_binary_macro(
         node_modules = "@history-server_runtime_deps//:node_modules",
-        entry_point = "history-server/modules/cli.js",
+        entry_point = "@history-server_runtime_deps//node_modules/history-server:modules/cli.js",
         install_source_map_support = False,
         templated_args = templated_args,
         **kwargs

--- a/internal/http-server/http_server.bzl
+++ b/internal/http-server/http_server.bzl
@@ -29,7 +29,7 @@ def http_server(templated_args = [], **kwargs):
 
     nodejs_binary_macro(
         node_modules = "@http-server_runtime_deps//:node_modules",
-        entry_point = "http-server/bin/http-server",
+        entry_point = "@http-server_runtime_deps//node_modules/http-server:bin/http-server",
         install_source_map_support = False,
         templated_args = templated_args,
         **kwargs

--- a/internal/jasmine_node_test/jasmine_node_test.bzl
+++ b/internal/jasmine_node_test/jasmine_node_test.bzl
@@ -56,10 +56,11 @@ def jasmine_node_test(
         tags = tags,
     )
 
+    jasmine_runner_label = Label("//internal/jasmine_node_test:jasmine_runner.js")
+
     all_data = data + srcs + deps
-    all_data += [Label("//internal/jasmine_node_test:jasmine_runner.js")]
     all_data += [":%s_devmode_srcs.MF" % name]
-    entry_point = "build_bazel_rules_nodejs/internal/jasmine_node_test/jasmine_runner.js"
+    entry_point = jasmine_runner_label.relative(":jasmine_runner.js")
 
     # If the target specified templated_args, pass it through.
     templated_args = kwargs.pop("templated_args", []) + ["$(location :%s_devmode_srcs.MF)" % name]

--- a/internal/jasmine_node_test/jasmine_node_test.bzl
+++ b/internal/jasmine_node_test/jasmine_node_test.bzl
@@ -56,11 +56,9 @@ def jasmine_node_test(
         tags = tags,
     )
 
-    jasmine_runner_label = Label("//internal/jasmine_node_test:jasmine_runner.js")
-
     all_data = data + srcs + deps
     all_data += [":%s_devmode_srcs.MF" % name]
-    entry_point = jasmine_runner_label.relative(":jasmine_runner.js")
+    entry_point = Label("//internal/jasmine_node_test:jasmine_runner.js")
 
     # If the target specified templated_args, pass it through.
     templated_args = kwargs.pop("templated_args", []) + ["$(location :%s_devmode_srcs.MF)" % name]

--- a/internal/jasmine_node_test/test/BUILD.bazel
+++ b/internal/jasmine_node_test/test/BUILD.bazel
@@ -30,5 +30,5 @@ nodejs_test(
         "no_jasmine_test.js",
         "//internal/jasmine_node_test:jasmine_runner.js",
     ],
-    entry_point = "build_bazel_rules_nodejs/internal/jasmine_node_test/test/no_jasmine_test.js",
+    entry_point = ":no_jasmine_test.js",
 )

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -21,7 +21,7 @@ a `module_name` attribute can be `require`d by that name.
 """
 
 load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleSources", "collect_node_modules_aspect")
-load("//internal/common:expand_into_runfiles.bzl", "expand_location_into_runfiles")
+load("//internal/common:expand_into_runfiles.bzl", "expand_location_into_runfiles", "expand_path_into_runfiles")
 load("//internal/common:module_mappings.bzl", "module_mappings_runtime_aspect")
 load("//internal/common:sources_aspect.bzl", "sources_aspect")
 
@@ -86,6 +86,9 @@ def _write_loader_script(ctx):
 
     node_modules_root = _compute_node_modules_root(ctx)
 
+    if len(ctx.attr.entry_point.files) != 1:
+        fail("labels in entry_point must contain exactly one file")
+
     ctx.actions.expand_template(
         template = ctx.file._loader_template,
         output = ctx.outputs.loader,
@@ -94,7 +97,7 @@ def _write_loader_script(ctx):
             "TEMPLATED_bootstrap": "\n  " + ",\n  ".join(
                 ["\"" + d + "\"" for d in ctx.attr.bootstrap],
             ),
-            "TEMPLATED_entry_point": ctx.attr.entry_point,
+            "TEMPLATED_entry_point": expand_path_into_runfiles(ctx, ctx.file.entry_point.short_path),
             "TEMPLATED_gen_dir": ctx.genfiles_dir.path,
             "TEMPLATED_install_source_map_support": str(ctx.attr.install_source_map_support).lower(),
             "TEMPLATED_module_roots": "\n  " + ",\n  ".join(module_mappings),
@@ -169,7 +172,7 @@ def _nodejs_binary_impl(ctx):
         is_executable = True,
     )
 
-    runfiles = depset([node, ctx.outputs.loader, ctx.file._repository_args], transitive = [sources, node_modules])
+    runfiles = depset([node, ctx.outputs.loader, ctx.file._repository_args, ctx.file.entry_point], transitive = [sources, node_modules])
 
     return [DefaultInfo(
         executable = ctx.outputs.script,
@@ -209,12 +212,38 @@ _NODEJS_EXECUTABLE_ATTRS = {
         allow_files = True,
         aspects = [sources_aspect, module_mappings_runtime_aspect, collect_node_modules_aspect],
     ),
-    "entry_point": attr.string(
+    "entry_point": attr.label(
         doc = """The script which should be executed first, usually containing a main function.
-        This attribute expects a string starting with the workspace name, so that it's not ambiguous
-        in cases where a script with the same name appears in another directory or external workspace.
+        The `entry_point` accepts a target's name as an entry point. 
+        If the target is a rule, it should produce the JavaScript entry file that will be passed to the nodejs_binary rule). 
+        For example:
+
+        ```
+        filegroup(
+            name = "entry_file",
+            srcs = ["workspace/path/to/entry/file"]
+        )
+        nodejs_binary(
+            name = "my_binary",
+            ...
+            entry_point = ":entry_file",
+        )
+        ```
+
+        If the entry JavaScript file belongs to the same package (as the BUILD file), 
+        you can simply reference it by its relative name to the package directory:
+
+        ```
+        nodejs_binary(
+            name = "my_binary",
+            ...
+            entry_point = ":file.js",
+        )
+        ```
+
         """,
         mandatory = True,
+        allow_single_file = True,
     ),
     "install_source_map_support": attr.bool(
         doc = """Install the source-map-support package.

--- a/internal/node/node_loader.js
+++ b/internal/node/node_loader.js
@@ -49,16 +49,26 @@ var BOOTSTRAP = [TEMPLATED_bootstrap];
 const USER_WORKSPACE_NAME = 'TEMPLATED_user_workspace_name';
 const NODE_MODULES_ROOT = 'TEMPLATED_node_modules_root';
 const BIN_DIR = 'TEMPLATED_bin_dir';
+const ENTRY_POINT = 'TEMPLATED_entry_point';
 const GEN_DIR = 'TEMPLATED_gen_dir';
+const INSTALL_SOURCE_MAP_SUPPORT = TEMPLATED_install_source_map_support;
+const TARGET = 'TEMPLATED_target';
 
 if (DEBUG)
   console.error(`
-node_loader: running TEMPLATED_target with
-  MODULE_ROOTS: ${JSON.stringify(MODULE_ROOTS, undefined, 2)}
-  BOOTSTRAP: ${JSON.stringify(BOOTSTRAP, undefined, 2)}
-  NODE_MODULES_ROOT: ${NODE_MODULES_ROOT}
+node_loader: running ${TARGET} with
+  cwd: ${process.cwd()}
+  runfiles: ${process.env.RUNFILES}
+
   BIN_DIR: ${BIN_DIR}
+  BOOTSTRAP: ${JSON.stringify(BOOTSTRAP, undefined, 2)}
+  ENTRY_POINT: ${ENTRY_POINT}
   GEN_DIR: ${GEN_DIR}
+  INSTALL_SOURCE_MAP_SUPPORT: ${INSTALL_SOURCE_MAP_SUPPORT}
+  MODULE_ROOTS: ${JSON.stringify(MODULE_ROOTS, undefined, 2)}
+  NODE_MODULES_ROOT: ${NODE_MODULES_ROOT}
+  TARGET: ${TARGET}
+  USER_WORKSPACE_NAME: ${USER_WORKSPACE_NAME}
 `);
 
 function resolveToModuleRoot(path) {
@@ -448,7 +458,7 @@ module.constructor._resolveFilename = function(request, parent, isMain, options)
   }
 
   const error = new Error(
-      `TEMPLATED_target cannot find module '${request}' required by '${parentFilename}'\n  looked in:\n` +
+      `${TARGET} cannot find module '${request}' required by '${parentFilename}'\n  looked in:\n` +
       failedResolutions.map(r => `    ${r}`).join('\n') + '\n');
   error.code = 'MODULE_NOT_FOUND';
   throw error;
@@ -456,7 +466,7 @@ module.constructor._resolveFilename = function(request, parent, isMain, options)
 
 // Before loading anything that might print a stack, install the
 // source-map-support.
-if (TEMPLATED_install_source_map_support) {
+if (INSTALL_SOURCE_MAP_SUPPORT) {
   try {
     const sourcemap_support_package = path.resolve(process.cwd(),
           '../build_bazel_rules_nodejs/third_party/github.com/source-map-support');
@@ -465,7 +475,7 @@ if (TEMPLATED_install_source_map_support) {
     if (DEBUG) {
       console.error(`WARNING: source-map-support module not installed.
       Stack traces from languages like TypeScript will point to generated .js files.
-      Set install_source_map_support = False in TEMPLATED_target to turn off this warning.
+      Set install_source_map_support = False in ${TARGET} to turn off this warning.
       `);
     }
   }
@@ -484,7 +494,7 @@ if (require.main === module) {
   // Set the actual entry point in the arguments list.
   // argv[0] == node, argv[1] == entry point.
   // NB: entry_point below is replaced during the build process.
-  var mainScript = process.argv[1] = 'TEMPLATED_entry_point';
+  var mainScript = process.argv[1] = ENTRY_POINT;
   try {
     module.constructor._load(mainScript, this, /*isMain=*/true);
   } catch (e) {
@@ -496,7 +506,7 @@ if (require.main === module) {
       // (which is an empty filegroup).
       // See https://github.com/bazelbuild/rules_nodejs/wiki#migrating-to-rules_nodejs-013
       console.error(
-          `\nWARNING: Due to a breaking change in rules_nodejs 0.13.0, target TEMPLATED_target\n` +
+          `\nWARNING: Due to a breaking change in rules_nodejs 0.13.0, target ${TARGET}\n` +
           `must now declare either an explicit node_modules attribute, or\n` +
           `list explicit deps[] or data[] fine grained dependencies on npm labels\n` +
           `if it has any node_modules dependencies.\n` +

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -5,7 +5,7 @@ load("//:defs.bzl", "nodejs_binary")
 nodejs_binary(
     name = "no_deps",
     data = ["no-deps.js"],
-    entry_point = "build_bazel_rules_nodejs/internal/node/test/no-deps",
+    entry_point = ":no-deps.js",
 )
 
 # You can have a nodejs_binary with a node_modules attribute
@@ -13,7 +13,7 @@ nodejs_binary(
 nodejs_binary(
     name = "has_deps_legacy",
     data = ["has-deps.js"],
-    entry_point = "build_bazel_rules_nodejs/internal/node/test/has-deps",
+    entry_point = ":has-deps.js",
     node_modules = "@fine_grained_deps_yarn//:node_modules",
 )
 
@@ -25,7 +25,7 @@ nodejs_binary(
         "has-deps.js",
         "@fine_grained_deps_yarn//typescript",
     ],
-    entry_point = "build_bazel_rules_nodejs/internal/node/test/has-deps",
+    entry_point = ":has-deps.js",
 )
 
 # You can have a nodejs_binary with both a node_modules attribute
@@ -36,6 +36,16 @@ nodejs_binary(
         "has-deps.js",
         "@fine_grained_deps_yarn//typescript",
     ],
-    entry_point = "build_bazel_rules_nodejs/internal/node/test/has-deps",
+    entry_point = ":has-deps.js",
     node_modules = "@fine_grained_deps_yarn//:node_modules",
+)
+
+filegroup(
+    name = "entry_file",
+    srcs = ["no-deps.js"],
+)
+
+nodejs_binary(
+    name = "has_entry_file",
+    entry_point = ":entry_file",
 )

--- a/internal/npm_install/BUILD.bazel
+++ b/internal/npm_install/BUILD.bazel
@@ -33,7 +33,7 @@ nodejs_binary(
         ":browserify-wrapped.js",
         "//third_party/github.com/browserify/browserify:sources",
     ],
-    entry_point = "build_bazel_rules_nodejs/internal/npm_install/browserify-wrapped.js",
+    entry_point = ":browserify-wrapped.js",
     install_source_map_support = False,
     visibility = ["//visibility:public"],
 )

--- a/internal/npm_install/generate_build_file.js
+++ b/internal/npm_install/generate_build_file.js
@@ -887,7 +887,7 @@ npm_umd_bundle(
       result += `# Wire up the \`bin\` entry \`${name}\`
 nodejs_binary(
     name = "${name}__bin",
-    entry_point = "${pkg._dir}/${path}",
+    entry_point = ":${path}",
     install_source_map_support = False,
     data = [":${pkg._name}__pkg"],${additionalAttributes}
 )

--- a/internal/npm_install/test/BUILD.bazel
+++ b/internal/npm_install/test/BUILD.bazel
@@ -34,6 +34,6 @@ nodejs_binary(
         "@npm//jasmine",
         "@npm//unidiff",
     ],
-    entry_point = "build_bazel_rules_nodejs/internal/npm_install/test/update_golden.js",
+    entry_point = ":update_golden.js",
     install_source_map_support = False,
 )

--- a/internal/npm_install/test/golden/node_modules/@gregmagolan/test-a/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/@gregmagolan/test-a/BUILD.bazel.golden
@@ -33,7 +33,7 @@ npm_umd_bundle(
 )
 nodejs_binary(
     name = "test__bin",
-    entry_point = "@gregmagolan/test-a/@bin/test.js",
+    entry_point = ":@bin/test.js",
     install_source_map_support = False,
     data = [":test-a__pkg"],
 )

--- a/internal/npm_install/test/golden/node_modules/jasmine/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/node_modules/jasmine/BUILD.bazel.golden
@@ -56,7 +56,7 @@ npm_umd_bundle(
 )
 nodejs_binary(
     name = "jasmine__bin",
-    entry_point = "jasmine/bin/jasmine.js",
+    entry_point = ":bin/jasmine.js",
     install_source_map_support = False,
     data = [":jasmine__pkg"],
 )

--- a/internal/npm_package/BUILD.bazel
+++ b/internal/npm_package/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
 
+package(default_visibility = ["//visibility:public"])
+
 bzl_library(
     name = "bzl",
     srcs = glob(["*.bzl"]),
@@ -17,7 +19,7 @@ nodejs_binary(
         "//third_party/github.com/gjtorikian/isBinaryFile",
         "@nodejs//:run_npm.sh.template",
     ],
-    entry_point = "build_bazel_rules_nodejs/internal/npm_package/packager.js",
+    entry_point = ":packager.js",
     install_source_map_support = False,
     visibility = ["//visibility:public"],
 )

--- a/internal/rollup/BUILD.bazel
+++ b/internal/rollup/BUILD.bazel
@@ -38,7 +38,7 @@ nodejs_binary(
     # Allow --define=ROLLUP_BUNDLE_FIXED_CHUNK_NAMES=1 to be passed as
     # process.env so we can give predictable chunk names in CI
     configuration_env_vars = ["ROLLUP_BUNDLE_FIXED_CHUNK_NAMES"],
-    entry_point = "build_bazel_rules_nodejs_rollup_deps/node_modules/rollup/bin/rollup",
+    entry_point = "@build_bazel_rules_nodejs_rollup_deps//node_modules/rollup:bin/rollup",
     install_source_map_support = False,
     node_modules = "@build_bazel_rules_nodejs_rollup_deps//:node_modules",
     visibility = ["//visibility:public"],
@@ -46,7 +46,7 @@ nodejs_binary(
 
 nodejs_binary(
     name = "tsc",
-    entry_point = "build_bazel_rules_nodejs_rollup_deps/node_modules/typescript/bin/tsc",
+    entry_point = "@build_bazel_rules_nodejs_rollup_deps//node_modules/typescript:bin/tsc",
     install_source_map_support = False,
     node_modules = "@build_bazel_rules_nodejs_rollup_deps//:node_modules",
     visibility = ["//visibility:public"],
@@ -54,7 +54,7 @@ nodejs_binary(
 
 nodejs_binary(
     name = "terser",
-    entry_point = "build_bazel_rules_nodejs_rollup_deps/node_modules/terser/bin/uglifyjs",
+    entry_point = "@build_bazel_rules_nodejs_rollup_deps//node_modules/terser:bin/uglifyjs",
     install_source_map_support = False,
     node_modules = "@build_bazel_rules_nodejs_rollup_deps//:node_modules",
     visibility = ["//visibility:public"],
@@ -63,7 +63,7 @@ nodejs_binary(
 nodejs_binary(
     name = "terser-wrapped",
     data = [":terser-wrapped.js"],
-    entry_point = "build_bazel_rules_nodejs/internal/rollup/terser-wrapped.js",
+    entry_point = ":terser-wrapped.js",
     install_source_map_support = False,
     node_modules = "@build_bazel_rules_nodejs_rollup_deps//:node_modules",
     visibility = ["//visibility:public"],
@@ -72,7 +72,7 @@ nodejs_binary(
 nodejs_binary(
     name = "tsc-directory",
     data = [":tsc-directory.js"],
-    entry_point = "build_bazel_rules_nodejs/internal/rollup/tsc-directory.js",
+    entry_point = ":tsc-directory.js",
     install_source_map_support = False,
     node_modules = "@build_bazel_rules_nodejs_rollup_deps//:node_modules",
     visibility = ["//visibility:public"],
@@ -80,7 +80,7 @@ nodejs_binary(
 
 nodejs_binary(
     name = "source-map-explorer",
-    entry_point = "build_bazel_rules_nodejs_rollup_deps/node_modules/source-map-explorer",
+    entry_point = "@build_bazel_rules_nodejs_rollup_deps//node_modules/source-map-explorer:index.js",
     install_source_map_support = False,
     node_modules = "@build_bazel_rules_nodejs_rollup_deps//:node_modules",
     visibility = ["//visibility:public"],

--- a/internal/web_package/BUILD.bazel
+++ b/internal/web_package/BUILD.bazel
@@ -21,7 +21,7 @@ filegroup(
 nodejs_binary(
     name = "assembler",
     data = ["assembler.js"],
-    entry_point = "build_bazel_rules_nodejs/internal/web_package/assembler.js",
+    entry_point = ":assembler.js",
     install_source_map_support = False,
     node_modules = ":node_modules_none",
 )
@@ -32,7 +32,7 @@ nodejs_binary(
         "injector.js",
         "//third_party/github.com/inikulin/parse5",
     ],
-    entry_point = "build_bazel_rules_nodejs/internal/web_package/injector.js",
+    entry_point = ":injector.js",
     install_source_map_support = False,
 )
 

--- a/internal/web_package/test/BUILD.bazel
+++ b/internal/web_package/test/BUILD.bazel
@@ -5,8 +5,7 @@ package(default_visibility = ["//visibility:public"])
 
 rollup_bundle(
     name = "bundle",
-    srcs = glob(["*.js"]),
-    entry_point = "internal/web_package/test/script.js",
+    entry_point = ":script.js",
 )
 
 web_package(

--- a/internal/web_package/test2/BUILD.bazel
+++ b/internal/web_package/test2/BUILD.bazel
@@ -3,8 +3,7 @@ load("@build_bazel_rules_nodejs//internal/web_package:web_package.bzl", "web_pac
 
 rollup_bundle(
     name = "local_bundle",
-    srcs = glob(["*.js"]),
-    entry_point = "internal/web_package/test2/script.js",
+    entry_point = ":script.js",
 )
 
 # Same exts as //internal/web_package/test-exports, //internal/web_package/test2/rel-exports

--- a/package.bzl
+++ b/package.bzl
@@ -35,11 +35,11 @@ def rules_nodejs_dev_dependencies():
     """
 
     # Dependencies for generating documentation
+    # TODO(manekinekko): switch to https://github.com/bazelbuild/rules_sass/ when the changes have been released
     http_archive(
         name = "io_bazel_rules_sass",
-        url = "https://github.com/bazelbuild/rules_sass/archive/8ccf4f1c351928b55d5dddf3672e3667f6978d60.zip",  # 2018-11-23
-        strip_prefix = "rules_sass-8ccf4f1c351928b55d5dddf3672e3667f6978d60",
-        sha256 = "894d7928df8da85e263d743c8434d4c10ab0a3f0708fed0d53394e688e3faf70",
+        url = "https://github.com/manekinekko/rules_sass/archive/9862dfc96a4a1f66fe171ef5e043b29853e8445b.zip",
+        strip_prefix = "rules_sass-9862dfc96a4a1f66fe171ef5e043b29853e8445b",
     )
 
     # Needed for stardoc

--- a/package.bzl
+++ b/package.bzl
@@ -35,7 +35,8 @@ def rules_nodejs_dev_dependencies():
     """
 
     # Dependencies for generating documentation
-    # TODO(manekinekko): switch to https://github.com/bazelbuild/rules_sass/ when the changes have been released
+    # TODO(gregmagolan): switch to https://github.com/bazelbuild/rules_sass/ when
+    #                    https://github.com/bazelbuild/rules_sass/pull/87 lands
     http_archive(
         name = "io_bazel_rules_sass",
         url = "https://github.com/manekinekko/rules_sass/archive/9862dfc96a4a1f66fe171ef5e043b29853e8445b.zip",

--- a/packages/create/BUILD.bazel
+++ b/packages/create/BUILD.bazel
@@ -27,7 +27,7 @@ nodejs_test(
         ":npm_package",
         "@npm//minimist",
     ],
-    entry_point = "build_bazel_rules_nodejs/packages/create/test.js",
+    entry_point = ":test.js",
 )
 
 # TODO(alexeagle): add e2e testing by running bazel in a newly created project

--- a/packages/jasmine/BUILD.bazel
+++ b/packages/jasmine/BUILD.bazel
@@ -60,7 +60,7 @@ npm_package(
 )
 
 js_library(
-    name = "jasmine_runner",
+    name = "jasmine__pkg",
     srcs = [
         "index.js",
         "src/jasmine_runner.js",

--- a/packages/jasmine/src/jasmine_node_test.bzl
+++ b/packages/jasmine/src/jasmine_node_test.bzl
@@ -28,8 +28,8 @@ def jasmine_node_test(
         deps = [],
         expected_exit_code = 0,
         tags = [],
-        jasmine = Label("@npm//@bazel/jasmine"),
         coverage = False,
+        jasmine = "@npm//@bazel/jasmine",
         **kwargs):
     """Runs tests in NodeJS using the Jasmine test runner.
 
@@ -42,7 +42,7 @@ def jasmine_node_test(
       deps: Other targets which produce JavaScript, such as ts_library
       expected_exit_code: The expected exit code for the test. Defaults to 0.
       tags: bazel tags applied to test
-      jasmine: a label providing the jasmine dependency
+      jasmine: a label providing the @bazel/jasmine npm dependency
       coverage: Enables code coverage collection and reporting
       **kwargs: remaining arguments are passed to the test rule
     """
@@ -57,7 +57,7 @@ def jasmine_node_test(
 
     all_data += [":%s_devmode_srcs.MF" % name]
     all_data += [Label("@bazel_tools//tools/bash/runfiles")]
-    entry_point = "@bazel/jasmine/src/jasmine_runner.js"
+    entry_point = Label(jasmine).relative(":src/jasmine_runner.js")
 
     # If the target specified templated_args, pass it through.
     templated_args = kwargs.pop("templated_args", []) + ["$(location :%s_devmode_srcs.MF)" % name]

--- a/packages/jasmine/src/jasmine_node_test.bzl
+++ b/packages/jasmine/src/jasmine_node_test.bzl
@@ -29,22 +29,25 @@ def jasmine_node_test(
         expected_exit_code = 0,
         tags = [],
         coverage = False,
-        jasmine = "@npm//@bazel/jasmine",
+        jasmine = "@npm//node_modules/@bazel/jasmine:index.js",
         **kwargs):
     """Runs tests in NodeJS using the Jasmine test runner.
 
     To debug the test, see debugging notes in `nodejs_test`.
 
     Args:
-      name: name of the resulting label
+      name: Name of the resulting label
       srcs: JavaScript source files containing Jasmine specs
       data: Runtime dependencies which will be loaded while the test executes
       deps: Other targets which produce JavaScript, such as ts_library
       expected_exit_code: The expected exit code for the test. Defaults to 0.
-      tags: bazel tags applied to test
-      jasmine: a label providing the @bazel/jasmine npm dependency
-      coverage: Enables code coverage collection and reporting
-      **kwargs: remaining arguments are passed to the test rule
+      tags: Bazel tags applied to test
+      coverage: Enables code coverage collection and reporting. Defaults to False.
+      jasmine: A label providing the @bazel/jasmine npm dependency. Defaults
+               to "@npm//node_modules/@bazel/jasmine:index.js" so that the correct
+               jasmine & jasmine-core dependencies are resolved unless they are
+               overwritten in a bootstrap file.
+      **kwargs: Remaining arguments are passed to the test rule
     """
     devmode_js_sources(
         name = "%s_devmode_srcs" % name,
@@ -53,7 +56,7 @@ def jasmine_node_test(
         tags = tags,
     )
 
-    all_data = data + srcs + deps + [jasmine]
+    all_data = data + srcs + deps + [Label(jasmine).relative(":jasmine__pkg")]
 
     all_data += [":%s_devmode_srcs.MF" % name]
     all_data += [Label("@bazel_tools//tools/bash/runfiles")]

--- a/packages/jasmine/test/BUILD.bazel
+++ b/packages/jasmine/test/BUILD.bazel
@@ -1,86 +1,36 @@
-load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
+load(":jasmine_node_test.bzl", "jasmine_node_test")
 
 jasmine_node_test(
     name = "underscore_spec_test",
     srcs = ["foo_spec.js"],
-    # The jasmine label here is specific to local testing since
-    # there is no @bazel/jasmine npm package here. Users
-    # will always have this label point to their @foobar//@bazel/jasmine
-    # target if they are not using the default @npm//@bazel/jasmine
-    jasmine = "@npm_bazel_jasmine//:index.js",
-    deps = [
-        "//:jasmine_runner",
-        "@npm//jasmine",
-    ],
 )
 
 jasmine_node_test(
     name = "underscore_test_test",
     srcs = ["foo_test.js"],
-    # The jasmine label here is specific to local testing since
-    # there is no @bazel/jasmine npm package here. Users
-    # will always have this label point to their @foobar//@bazel/jasmine
-    # target if they are not using the default @npm//@bazel/jasmine
-    jasmine = "@npm_bazel_jasmine//:index.js",
-    deps = [
-        "//:jasmine_runner",
-        "@npm//jasmine",
-    ],
 )
 
 jasmine_node_test(
     name = "dot_spec_test",
     srcs = ["foo.spec.js"],
-    # The jasmine label here is specific to local testing since
-    # there is no @bazel/jasmine npm package here. Users
-    # will always have this label point to their @foobar//@bazel/jasmine
-    # target if they are not using the default @npm//@bazel/jasmine
-    jasmine = "@npm_bazel_jasmine//:index.js",
-    deps = [
-        "//:jasmine_runner",
-        "@npm//jasmine",
-    ],
 )
 
 jasmine_node_test(
     name = "dot_test_test",
     srcs = ["foo.test.js"],
-    # The jasmine label here is specific to local testing since
-    # there is no @bazel/jasmine npm package here. Users
-    # will always have this label point to their @foobar//@bazel/jasmine
-    # target if they are not using the default @npm//@bazel/jasmine
-    jasmine = "@npm_bazel_jasmine//:index.js",
-    deps = [
-        "//:jasmine_runner",
-        "@npm//jasmine",
-    ],
 )
 
 jasmine_node_test(
     name = "sharding_test",
     srcs = ["sharded_test.js"],
-    # The jasmine label here is specific to local testing since
-    # there is no @bazel/jasmine npm package here. Users
-    # will always have this label point to their @foobar//@bazel/jasmine
-    # target if they are not using the default @npm//@bazel/jasmine
-    jasmine = "@npm_bazel_jasmine//:index.js",
     shard_count = 3,
-    deps = [
-        "//:jasmine_runner",
-        "@npm//jasmine",
-    ],
 )
 
 jasmine_node_test(
     name = "failing_sharding_test",
     srcs = ["failing_sharded_test.js"],
     expected_exit_code = 3,
-    jasmine = "@npm_bazel_jasmine//:index.js",
     shard_count = 2,
-    deps = [
-        "//:jasmine_runner",
-        "@npm//jasmine",
-    ],
 )
 
 jasmine_node_test(
@@ -92,19 +42,6 @@ jasmine_node_test(
     # maybe sniff the stdout for Ran 1 of 3 specs
     # or change the exit code for Jasmine 'incomplete' status
     expected_exit_code = 3,
-    # The jasmine label here is specific to local testing since
-    # there is no @bazel/jasmine npm package here. Users
-    # will always have this label point to their @foobar//@bazel/jasmine
-    # target if they are not using the default @npm//@bazel/jasmine
-    jasmine = "@npm_bazel_jasmine//:index.js",
-    # Only run this test when explicitly included in the target patterns
-    # It will fail because usage of `fit` and `fdescribe` cause Jasmine
-    # to return a 'incomplete' status
-    tags = ["manual"],
-    deps = [
-        "//:jasmine_runner",
-        "@npm//jasmine",
-    ],
 )
 
 jasmine_node_test(
@@ -114,10 +51,7 @@ jasmine_node_test(
         "coverage_source.js",
     ],
     coverage = True,
-    jasmine = "@npm_bazel_jasmine//:index.js",
     deps = [
-        "//:jasmine_runner",
-        "@npm//jasmine",
         "@npm//v8-coverage",
     ],
 )
@@ -125,9 +59,7 @@ jasmine_node_test(
 jasmine_node_test(
     name = "templated_args_test",
     srcs = ["templated_args_test.js"],
-    jasmine = "@npm//jasmine",
     templated_args = [
         "--node_options=--experimental-modules",
     ],
-    deps = ["//:jasmine_runner"],
 )

--- a/packages/jasmine/test/BUILD.bazel
+++ b/packages/jasmine/test/BUILD.bazel
@@ -3,46 +3,84 @@ load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
 jasmine_node_test(
     name = "underscore_spec_test",
     srcs = ["foo_spec.js"],
-    jasmine = "@npm//jasmine",
-    deps = ["//:jasmine_runner"],
+    # The jasmine label here is specific to local testing since
+    # there is no @bazel/jasmine npm package here. Users
+    # will always have this label point to their @foobar//@bazel/jasmine
+    # target if they are not using the default @npm//@bazel/jasmine
+    jasmine = "@npm_bazel_jasmine//:index.js",
+    deps = [
+        "//:jasmine_runner",
+        "@npm//jasmine",
+    ],
 )
 
 jasmine_node_test(
     name = "underscore_test_test",
     srcs = ["foo_test.js"],
-    jasmine = "@npm//jasmine",
-    deps = ["//:jasmine_runner"],
+    # The jasmine label here is specific to local testing since
+    # there is no @bazel/jasmine npm package here. Users
+    # will always have this label point to their @foobar//@bazel/jasmine
+    # target if they are not using the default @npm//@bazel/jasmine
+    jasmine = "@npm_bazel_jasmine//:index.js",
+    deps = [
+        "//:jasmine_runner",
+        "@npm//jasmine",
+    ],
 )
 
 jasmine_node_test(
     name = "dot_spec_test",
     srcs = ["foo.spec.js"],
-    jasmine = "@npm//jasmine",
-    deps = ["//:jasmine_runner"],
+    # The jasmine label here is specific to local testing since
+    # there is no @bazel/jasmine npm package here. Users
+    # will always have this label point to their @foobar//@bazel/jasmine
+    # target if they are not using the default @npm//@bazel/jasmine
+    jasmine = "@npm_bazel_jasmine//:index.js",
+    deps = [
+        "//:jasmine_runner",
+        "@npm//jasmine",
+    ],
 )
 
 jasmine_node_test(
     name = "dot_test_test",
     srcs = ["foo.test.js"],
-    jasmine = "@npm//jasmine",
-    deps = ["//:jasmine_runner"],
+    # The jasmine label here is specific to local testing since
+    # there is no @bazel/jasmine npm package here. Users
+    # will always have this label point to their @foobar//@bazel/jasmine
+    # target if they are not using the default @npm//@bazel/jasmine
+    jasmine = "@npm_bazel_jasmine//:index.js",
+    deps = [
+        "//:jasmine_runner",
+        "@npm//jasmine",
+    ],
 )
 
 jasmine_node_test(
     name = "sharding_test",
     srcs = ["sharded_test.js"],
-    jasmine = "@npm//jasmine",
+    # The jasmine label here is specific to local testing since
+    # there is no @bazel/jasmine npm package here. Users
+    # will always have this label point to their @foobar//@bazel/jasmine
+    # target if they are not using the default @npm//@bazel/jasmine
+    jasmine = "@npm_bazel_jasmine//:index.js",
     shard_count = 3,
-    deps = ["//:jasmine_runner"],
+    deps = [
+        "//:jasmine_runner",
+        "@npm//jasmine",
+    ],
 )
 
 jasmine_node_test(
     name = "failing_sharding_test",
     srcs = ["failing_sharded_test.js"],
     expected_exit_code = 3,
-    jasmine = "@npm//jasmine",
+    jasmine = "@npm_bazel_jasmine//:index.js",
     shard_count = 2,
-    deps = ["//:jasmine_runner"],
+    deps = [
+        "//:jasmine_runner",
+        "@npm//jasmine",
+    ],
 )
 
 jasmine_node_test(
@@ -54,8 +92,19 @@ jasmine_node_test(
     # maybe sniff the stdout for Ran 1 of 3 specs
     # or change the exit code for Jasmine 'incomplete' status
     expected_exit_code = 3,
-    jasmine = "@npm//jasmine",
-    deps = ["//:jasmine_runner"],
+    # The jasmine label here is specific to local testing since
+    # there is no @bazel/jasmine npm package here. Users
+    # will always have this label point to their @foobar//@bazel/jasmine
+    # target if they are not using the default @npm//@bazel/jasmine
+    jasmine = "@npm_bazel_jasmine//:index.js",
+    # Only run this test when explicitly included in the target patterns
+    # It will fail because usage of `fit` and `fdescribe` cause Jasmine
+    # to return a 'incomplete' status
+    tags = ["manual"],
+    deps = [
+        "//:jasmine_runner",
+        "@npm//jasmine",
+    ],
 )
 
 jasmine_node_test(
@@ -65,9 +114,10 @@ jasmine_node_test(
         "coverage_source.js",
     ],
     coverage = True,
-    jasmine = "@npm//jasmine",
+    jasmine = "@npm_bazel_jasmine//:index.js",
     deps = [
         "//:jasmine_runner",
+        "@npm//jasmine",
         "@npm//v8-coverage",
     ],
 )

--- a/packages/jasmine/test/jasmine_node_test.bzl
+++ b/packages/jasmine/test/jasmine_node_test.bzl
@@ -1,0 +1,33 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Test API surface is
+"""
+
+load("//:src/jasmine_node_test.bzl", _jasmine_node_test = "jasmine_node_test")
+
+def jasmine_node_test(deps = [], **kwargs):
+    deps = deps + [
+        "//:jasmine__pkg",
+        "@npm//jasmine",
+    ]
+    _jasmine_node_test(
+        # The jasmine label here is specific to local testing since
+        # there is no @npm//@bazel/jasmine package here. Users
+        # will always have this label point to their @foobar//node_modules/@bazel/jasmine:index.js
+        # target if there is no @npm//@bazel/jasmine package
+        jasmine = "@npm_bazel_jasmine//:index.js",
+        deps = deps,
+        **kwargs
+    )

--- a/packages/karma/BUILD.bazel
+++ b/packages/karma/BUILD.bazel
@@ -53,7 +53,7 @@ nodejs_binary(
         "@npm//requirejs",
         "@npm//tmp",
     ],
-    entry_point = "karma/bin/karma",
+    entry_point = "@npm//node_modules/karma:bin/karma",
     install_source_map_support = False,
 )
 

--- a/packages/karma/docs/install.md
+++ b/packages/karma/docs/install.md
@@ -45,7 +45,7 @@ If you didn't use the `yarn_install` or `npm_install` rule to create an `npm` wo
 # attribute when using self-managed dependencies
 nodejs_binary(
     name = "karma/karma",
-    entry_point = "karma/bin/karma",
+    entry_point = "//:node_modules/karma/bin/karma",
     # Point bazel to your node_modules to find the entry point
     node_modules = ["//:node_modules"],
 )

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -11,6 +11,9 @@
     "bugs": {
         "url": "https://github.com/bazelbuild/rules_nodejs/issues"
     },
+    "bin": {
+        "webpack": "./webpack/src/cli.js"
+    },
     "devDependencies": {
         "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
         "@types/jasmine": "^3.3.9",

--- a/packages/labs/webpack/BUILD.bazel
+++ b/packages/labs/webpack/BUILD.bazel
@@ -1,5 +1,5 @@
 # BEGIN-INTERNAL
-load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package")
+load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary", "npm_package")
 
 npm_package(
     name = "webpack",
@@ -10,9 +10,18 @@ npm_package(
     replacements = {"#@external\\s": ""},
     visibility = ["//:__pkg__"],
     deps = [
-        "//webpack/src:cli",
+        "//webpack/src:cli_lib",
         "//webpack/src:package_contents",
     ],
 )
 
+nodejs_binary(
+    name = "cli",
+    data = [
+        "//webpack/src:cli_lib",
+        "@npm//webpack",
+    ],
+    entry_point = "//webpack/src:cli.ts",
+    visibility = ["//visibility:public"],
+)
 # END-INTERNAL

--- a/packages/labs/webpack/src/BUILD.bazel
+++ b/packages/labs/webpack/src/BUILD.bazel
@@ -1,11 +1,12 @@
-load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
-
 # BEGIN-INTERNAL
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
+
+exports_files(["cli.ts"])
 
 ts_library(
     name = "cli_lib",
     srcs = glob(["*.ts"]),
+    visibility = ["//:__subpackages__"],
     deps = [
         "@npm//@types",
     ],
@@ -20,24 +21,3 @@ filegroup(
     visibility = ["//webpack:__subpackages__"],
 )
 # END-INTERNAL
-
-nodejs_binary(
-    name = "cli",
-    data = [
-        # BEGIN-INTERNAL
-        # For local development, we depend on the TypeScript output
-        ":cli_lib",
-        # END-INTERNAL
-
-        # For external usage, we depend on the published .JS files
-        #@external "@npm//@bazel/labs",
-        "@npm//webpack",
-    ],
-    # BEGIN-INTERNAL
-    # For local development, our module has this AMD name
-    entry_point = ":cli_lib",
-    # END-INTERNAL
-    # For external usage, we resolve the module from node_modules
-    #@external entry_point = "@bazel/labs/webpack/src:cli_lib",
-    visibility = ["//visibility:public"],
-)

--- a/packages/labs/webpack/src/BUILD.bazel
+++ b/packages/labs/webpack/src/BUILD.bazel
@@ -35,9 +35,9 @@ nodejs_binary(
     ],
     # BEGIN-INTERNAL
     # For local development, our module has this AMD name
-    entry_point = "npm_bazel_labs/webpack/src/cli.js",
+    entry_point = ":cli_lib",
     # END-INTERNAL
     # For external usage, we resolve the module from node_modules
-    #@external entry_point = "@bazel/labs/webpack/src/cli.js",
+    #@external entry_point = "@bazel/labs/webpack/src:cli_lib",
     visibility = ["//visibility:public"],
 )

--- a/packages/labs/webpack/src/webpack_bundle.bzl
+++ b/packages/labs/webpack/src/webpack_bundle.bzl
@@ -20,7 +20,7 @@ This rule is experimental, as part of Angular Labs! There may be breaking change
 WEBPACK_BUNDLE_ATTRS = {
     "srcs": attr.label_list(allow_files = True),
     "entry_point": attr.label(allow_single_file = True, mandatory = True),
-    "webpack": attr.label(default = "@npm_bazel_labs//webpack/src:cli", executable = True, cfg = "host"),
+    "webpack": attr.label(default = "@npm//@bazel/labs/bin:webpack", executable = True, cfg = "host"),
 }
 WEBPACK_BUNDLE_OUTS = {
     "bundle": "%{name}.js",

--- a/packages/labs/webpack/test/BUILD.bazel
+++ b/packages/labs/webpack/test/BUILD.bazel
@@ -6,6 +6,11 @@ webpack_bundle(
     name = "bundle",
     srcs = glob(["*.js"]),
     entry_point = "index.js",
+    # The webpack label here is specific to local testing since
+    # there is no @bazel/labs npm package here. Users
+    # will always have this label point to their @foobar//@bazel/labs/bin:webpack
+    # target if they are not using the default @npm//@bazel/labs/bin:webpack
+    webpack = "@npm_bazel_labs//webpack:cli",
 )
 
 ts_library(

--- a/packages/typescript/WORKSPACE
+++ b/packages/typescript/WORKSPACE
@@ -38,6 +38,8 @@ rules_nodejs_dev_dependencies()
 
 # We use git_repository since Renovate knows how to update it.
 # With http_archive it only sees releases/download/*.tar.gz urls
+
+# TODO(manekinekko): switch to https://github.com/bazelbuild/rules_typescript/ when the changes have been released
 git_repository(
     name = "build_bazel_rules_typescript",
     commit = "4ae7cda81c7ea3215a024f10b00ee38a0755549d",

--- a/packages/typescript/WORKSPACE
+++ b/packages/typescript/WORKSPACE
@@ -39,11 +39,12 @@ rules_nodejs_dev_dependencies()
 # We use git_repository since Renovate knows how to update it.
 # With http_archive it only sees releases/download/*.tar.gz urls
 
-# TODO(manekinekko): switch to https://github.com/bazelbuild/rules_typescript/ when the changes have been released
+# TODO(gregmagolan): switch to https://github.com/bazelbuild/rules_typescript/ HEAD when
+#                    https://github.com/bazelbuild/rules_typescript/pull/453 lands
 git_repository(
     name = "build_bazel_rules_typescript",
-    commit = "4ae7cda81c7ea3215a024f10b00ee38a0755549d",
-    remote = "http://github.com/bazelbuild/rules_typescript.git",
+    commit = "6521ce4e0d4959eaf46a4738d45f3f480d4af25f",
+    remote = "http://github.com/gregmagolan/rules_typescript.git",
 )
 
 # We have a source dependency on build_bazel_rules_typescript

--- a/packages/typescript/docs/BUILD.bazel
+++ b/packages/typescript/docs/BUILD.bazel
@@ -17,5 +17,5 @@ nodejs_test(
         "docs_test.js",
         ":index.md",
     ],
-    entry_point = "npm_bazel_typescript/docs/docs_test.js",
+    entry_point = ":docs_test.js",
 )

--- a/packages/typescript/internal/protobufjs/BUILD.bazel
+++ b/packages/typescript/internal/protobufjs/BUILD.bazel
@@ -42,7 +42,7 @@ nodejs_binary(
         "@build_bazel_rules_typescript_protobufs_compiletime_deps//escodegen",
         "@build_bazel_rules_typescript_protobufs_compiletime_deps//estraverse",
     ],
-    entry_point = "protobufjs/bin/pbjs",
+    entry_point = "@build_bazel_rules_typescript_protobufs_compiletime_deps//node_modules/protobufjs:bin/pbjs",
     install_source_map_support = False,
 )
 
@@ -65,7 +65,7 @@ nodejs_binary(
         "@build_bazel_rules_typescript_protobufs_compiletime_deps//escodegen",
         "@build_bazel_rules_typescript_protobufs_compiletime_deps//estraverse",
     ],
-    entry_point = "protobufjs/bin/pbts",
+    entry_point = "@build_bazel_rules_typescript_protobufs_compiletime_deps//node_modules/protobufjs:bin/pbts",
     install_source_map_support = False,
 )
 

--- a/scripts/setup_examples_angular.sh
+++ b/scripts/setup_examples_angular.sh
@@ -28,7 +28,8 @@ printf "\n\nSetting up /examples/angular\n"
   # Clean example
   echo_and_run cd ${EXAMPLES_DIR}
   rm -rf angular
-  echo_and_run git clone https://github.com/angular/angular-bazel-example.git angular
+  # TODO(gmagolan): switch back upstream when https://github.com/angular/angular-bazel-example/pull/450 lands
+  echo_and_run git clone --single-branch --branch entry-point https://github.com/gregmagolan/angular-bazel-example.git angular
   (
     echo_and_run cd angular
 

--- a/tools/npm_packages/bazel_workspaces/a/BUILD.bazel
+++ b/tools/npm_packages/bazel_workspaces/a/BUILD.bazel
@@ -5,5 +5,5 @@ nodejs_binary(
     data = [
         ":index.js",
     ],
-    entry_point = "bazel_workspace_a/index.js",
+    entry_point = ":index.js",
 )

--- a/tools/npm_packages/bazel_workspaces/a/subdir/BUILD.bazel
+++ b/tools/npm_packages/bazel_workspaces/a/subdir/BUILD.bazel
@@ -5,5 +5,5 @@ nodejs_binary(
     data = [
         ":index.js",
     ],
-    entry_point = "bazel_workspace_a/subdir/index.js",
+    entry_point = ":index.js",
 )

--- a/tools/npm_packages/bazel_workspaces/b/BUILD.bazel
+++ b/tools/npm_packages/bazel_workspaces/b/BUILD.bazel
@@ -5,5 +5,5 @@ nodejs_binary(
     data = [
         ":index.js",
     ],
-    entry_point = "bazel_workspace_b/index.js",
+    entry_point = ":index.js",
 )

--- a/tools/npm_packages/bazel_workspaces/b/subdir/BUILD.bazel
+++ b/tools/npm_packages/bazel_workspaces/b/subdir/BUILD.bazel
@@ -5,5 +5,5 @@ nodejs_binary(
     data = [
         ":index.js",
     ],
-    entry_point = "bazel_workspace_b/subdir/index.js",
+    entry_point = ":index.js",
 )

--- a/tools/npm_packages/bazel_workspaces/package.json
+++ b/tools/npm_packages/bazel_workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bazel_workspace",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "bazelWorkspaces": {
     "bazel_workspace_a": {
         "rootPath": "a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,7 +442,7 @@ base@^0.11.1:
     pascalcase "^0.1.1"
 
 "bazel_workspaces@file:./tools/npm_packages/bazel_workspaces":
-  version "0.0.1"
+  version "0.0.2"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"


### PR DESCRIPTION
Replaces #480

Closes #32

⚠️ Depends on upstream sass change: https://github.com/bazelbuild/rules_sass/pull/87
⚠️ Depends on upstream rules_typescript change: https://github.com/bazelbuild/rules_typescript/pull/453
⚠️ Depends on downstream angular-bazel-example change: https://github.com/angular/angular-bazel-example/pull/450

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

nodejs_binary#entry_point was a string.


## What is the new behavior?

nodejs_binary#entry_point is now a Label.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


The `entry_point` accepts a target's name as an entry point. If the target is a rule, it should produce the JavaScript entry file that will be passed to the nodejs_binary rule). For example:

 ```
        filegroup(
            name = "entry_file",
            srcs = ["workspace/path/to/entry/file"]
        )
        nodejs_binary(
          name = "my_binary",
          ...
          entry_point = ":entry_file",
        )
```

If the entry JavaScript file belongs to the same package (as the BUILD file), you can simply reference it by its relative name to the package directory:

```
        nodejs_binary(
          name = "my_binary",
          ...
          entry_point = ":file.js",
        )
```
