### PR TITLE
Forward all args to originalResolveFilename

### DIFF
--- a/internal/e2e/fine_grained_no_bin/BUILD.bazel
+++ b/internal/e2e/fine_grained_no_bin/BUILD.bazel
@@ -9,6 +9,7 @@ nodejs_binary(
     name = "index",
     data = [
         "index.js",
+        "test/test.js",
         "@fine_grained_no_bin//fs.realpath",
     ],
     entry_point = "build_bazel_rules_nodejs/internal/e2e/fine_grained_no_bin/index.js",

--- a/internal/e2e/fine_grained_no_bin/index.js
+++ b/internal/e2e/fine_grained_no_bin/index.js
@@ -1,3 +1,3 @@
 const path = require("path");
 
-console.log('hello ' + require.resolve("./test.js", { path: path.join(__dirname, 'test') }));
+console.log('hello ' + require.resolve("./test.js", { paths: [ path.join(__dirname, 'test') ] }));

--- a/internal/e2e/fine_grained_no_bin/index.js
+++ b/internal/e2e/fine_grained_no_bin/index.js
@@ -1,1 +1,3 @@
-console.log('hello world');
+const path = require("path");
+
+console.log('hello ' + require.resolve("./test.js", { path: path.join(__dirname, 'test') }));

--- a/internal/node/node_loader.js
+++ b/internal/node/node_loader.js
@@ -351,7 +351,7 @@ module.constructor._resolveFilename = function(request, parent) {
   // Built-in modules, relative, absolute imports and npm dependencies
   // can be resolved using request
   try {
-    const resolved = originalResolveFilename(request, parent);
+    const resolved = originalResolveFilename.apply(null, arguments);
     if (resolved === request || request.startsWith('.') || request.startsWith('/') ||
         request.match(/^[A-Z]\:[\\\/]/i)) {
       if (DEBUG)

--- a/internal/node/node_loader.js
+++ b/internal/node/node_loader.js
@@ -332,6 +332,7 @@ module.constructor._resolveFilename = function(request, parent) {
     console.error(`node_loader: resolve ${request} from ${parentFilename}`);
 
   const failedResolutions = [];
+  const slicedArgs = Array.prototype.slice.call(arguments, 2);
 
   // Attempt to resolve to module root.
   // This should be the first attempted resolution because:
@@ -391,7 +392,9 @@ module.constructor._resolveFilename = function(request, parent) {
   // If the import is not a built-in module, an absolute, relative import or a
   // dependency of an npm package, attempt to resolve against the runfiles location
   try {
-    const resolved = originalResolveFilename(resolveRunfiles(parentFilename, request), parent);
+    const newArgs = [resolveRunfiles(parentFilename, request), parent];
+    newArgs.push.apply(slicedArgs);
+    const resolved = originalResolveFilename.apply(null, newArgs);
     if (DEBUG)
       console.error(
           `node_loader: resolved ${request} within runfiles to ${resolved} from ${parentFilename}`
@@ -416,8 +419,9 @@ module.constructor._resolveFilename = function(request, parent) {
     const parentSegments = relativeParentFilename.split('/');
     if (parentSegments[0] !== USER_WORKSPACE_NAME) {
       try {
-        const resolved = originalResolveFilename(
-            resolveRunfiles(undefined, parentSegments[0], 'node_modules', request), parent);
+        const newArgs = [resolveRunfiles(undefined, parentSegments[0], 'node_modules', request), parent]
+        newArgs.push.apply(slicedArgs);
+        const resolved = originalResolveFilename.apply(null, newArgs);
         if (DEBUG)
           console.error(
               `node_loader: resolved ${request} within node_modules ` +
@@ -433,8 +437,9 @@ module.constructor._resolveFilename = function(request, parent) {
   // If import was not resolved above then attempt to resolve
   // within the node_modules filegroup in use
   try {
-    const resolved = originalResolveFilename(
-        resolveRunfiles(undefined, NODE_MODULES_ROOT, request), parent);
+    const newArgs = [resolveRunfiles(undefined, NODE_MODULES_ROOT, request), parent];
+    newArgs.push.apply(slicedArgs);
+    const resolved = originalResolveFilename.apply(newArgs);
     if (DEBUG)
       console.error(
           `node_loader: resolved ${request} within node_modules (${NODE_MODULES_ROOT}) to ` +

--- a/internal/node/node_loader.js
+++ b/internal/node/node_loader.js
@@ -440,7 +440,6 @@ module.constructor._resolveFilename = function(request, parent, isMain, options)
       );
     return resolved;
   } catch (e) {
-    console.error(e);
     failedResolutions.push(`node_modules attribute (${NODE_MODULES_ROOT}) - ${e.toString()}`);
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

If I call `require.resolve("../test.js", { paths: ["/some/path/in/sandbox"] })` the options are not forwarded correctly because the `_resolveFilename` method takes 4 parameters.


## What is the new behavior?

All expected parameters are forwarded, so are the options now and paths will be respected.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



## Other information

I ran into this as the latest version of one of our npm dependencies is making use of this case and that fix fixes it.

