### PR TITLE
Add test coverage for manual_build_file_contents... 

### DIFF
--- a/examples/bazel_managed_deps/BUILD.bazel
+++ b/examples/bazel_managed_deps/BUILD.bazel
@@ -7,6 +7,7 @@ jasmine_node_test(
     name = "test",
     srcs = glob(["*.spec.js"]),
     node_modules = "@npm//:node_modules",
+    data = ["@npm//:bin_files"],
 )
 
 # Test what happens when only certain NPM packages are in our dependencies.
@@ -19,4 +20,5 @@ jasmine_node_test(
         "@npm//jasmine",
         "@npm//typescript",
     ],
+    data = ["@npm//:bin_files"],
 )

--- a/examples/bazel_managed_deps/BUILD.bazel
+++ b/examples/bazel_managed_deps/BUILD.bazel
@@ -6,8 +6,8 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "jasmine_node_test")
 jasmine_node_test(
     name = "test",
     srcs = glob(["*.spec.js"]),
-    node_modules = "@npm//:node_modules",
     data = ["@npm//:bin_files"],
+    node_modules = "@npm//:node_modules",
 )
 
 # Test what happens when only certain NPM packages are in our dependencies.
@@ -16,9 +16,9 @@ jasmine_node_test(
 jasmine_node_test(
     name = "fine_grained_test",
     srcs = glob(["*.spec.js"]),
+    data = ["@npm//:bin_files"],
     deps = [
         "@npm//jasmine",
         "@npm//typescript",
     ],
-    data = ["@npm//:bin_files"],
 )

--- a/examples/bazel_managed_deps/WORKSPACE
+++ b/examples/bazel_managed_deps/WORKSPACE
@@ -33,11 +33,11 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")
 # @npm//jasmine
 yarn_install(
     name = "npm",
-    package_json = "//:package.json",
-    yarn_lock = "//:yarn.lock",
-  manual_build_file_contents = """
+    manual_build_file_contents = """
 filegroup(
   name = "bin_files",
   srcs = glob(["node_modules/.bin/*"]),
-)"""
+)""",
+    package_json = "//:package.json",
+    yarn_lock = "//:yarn.lock",
 )

--- a/examples/bazel_managed_deps/WORKSPACE
+++ b/examples/bazel_managed_deps/WORKSPACE
@@ -35,4 +35,9 @@ yarn_install(
     name = "npm",
     package_json = "//:package.json",
     yarn_lock = "//:yarn.lock",
+  manual_build_file_contents = """
+filegroup(
+  name = "bin_files",
+  srcs = glob(["node_modules/.bin/*"]),
+)"""
 )

--- a/examples/bazel_managed_deps/deps.spec.js
+++ b/examples/bazel_managed_deps/deps.spec.js
@@ -10,4 +10,15 @@ describe('dependencies', () => {
      () => {
        require('jasmine-core');
      });
+
+  it('.bin files should be in runfiles via @npm//:bin_files data dep', () => {
+    try {
+      expect(require.resolve('.bin/jasmine').endsWith('npm/node_modules/.bin/jasmine')).toBe(true);
+      expect(require.resolve('.bin/tsc').endsWith('npm/node_modules/.bin/tsc')).toBe(true);
+      expect(require.resolve('.bin/tsserver').endsWith('npm/node_modules/.bin/tsserver'))
+          .toBe(true);
+    } catch (_) {
+      fail('.bin file not resolved');
+    }
+  });
 });

--- a/examples/bazel_managed_deps/deps.spec.js
+++ b/examples/bazel_managed_deps/deps.spec.js
@@ -12,13 +12,13 @@ describe('dependencies', () => {
      });
 
   it('.bin files should be in runfiles via @npm//:bin_files data dep', () => {
-    try {
-      expect(require.resolve('.bin/jasmine').endsWith('npm/node_modules/.bin/jasmine')).toBe(true);
-      expect(require.resolve('.bin/tsc').endsWith('npm/node_modules/.bin/tsc')).toBe(true);
-      expect(require.resolve('.bin/tsserver').endsWith('npm/node_modules/.bin/tsserver'))
-          .toBe(true);
-    } catch (_) {
-      fail('.bin file not resolved');
+    const files = ['jasmine', 'tsc', 'tsserver'];
+    for (const f of files) {
+      try {
+        expect(require.resolve(`.bin/${f}`).endsWith(`/npm/node_modules/.bin/${f}`)).toBe(true);
+      } catch (_) {
+        fail(`.bin/${f} not resolved`);
+      }
     }
   });
 });


### PR DESCRIPTION
via an example of how to make a target for node_modules/.bin/*

Example also shows use of migration instructions for users that were depending on `node_modules/.bin/BUILD` targets: https://github.com/bazelbuild/rules_nodejs/wiki#node_modulesbinbuild-file-no-longer-generated.