### PR TITLE
Only require Bazel 0.26.0 when using symlinked node_modules...

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,7 +31,14 @@ load("//internal/common:check_bazel_version.bzl", "check_bazel_version")
 # 0.18.0: support for .bazelignore
 # 0.23.0: required fix for pkg_tar strip_prefix
 # 0.26.0: managed_directories feature added
-check_bazel_version(minimum_bazel_version = "0.26.0")
+check_bazel_version(
+    message = """
+You no longer need to install Bazel on your machine.
+rules_nodejs has a dependency on the @bazel/bazel package which supplies it.
+Try running `yarn bazel` instead.
+""",
+    minimum_bazel_version = "0.26.0",
+)
 
 #
 # Load and install our dependencies downloaded above.

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -535,8 +535,12 @@ def node_repositories(
     # 0.14.0: @bazel_tools//tools/bash/runfiles is required for nodejs
     # 0.17.1: allow @ in package names is required for fine grained deps
     # 0.21.0: repository_ctx.report_progress API
-    # 0.26.0: managed_directories feature added
-    check_bazel_version("0.26.0")
+    check_bazel_version(
+        message = """
+    A minimum Bazel version of 0.21.0 is required to use build_bazel_rules_nodejs.
+    """,
+        minimum_bazel_version = "0.21.0",
+    )
 
     _maybe(
         _nodejs_repo,

--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -21,6 +21,7 @@ as the package manager.
 See discussion in the README.
 """
 
+load("//internal/common:check_bazel_version.bzl", "check_bazel_version")
 load("//internal/common:os_name.bzl", "os_name")
 load("//internal/node:node_labels.bzl", "get_node_label", "get_npm_label", "get_yarn_label")
 
@@ -143,8 +144,27 @@ def _symlink_node_modules(repository_ctx):
     package_json_dir = repository_ctx.path(repository_ctx.attr.package_json).dirname
     repository_ctx.symlink(repository_ctx.path(str(package_json_dir) + "/node_modules"), repository_ctx.path("node_modules"))
 
+def _check_min_bazel_version(rule, repository_ctx):
+    if repository_ctx.attr.symlink_node_modules:
+        # When using symlink_node_modules enforce the minimum Bazel version required
+        check_bazel_version(
+            message = """
+        A minimum Bazel version of 0.26.0 is required for the %s @%s repository rule.
+
+        By default, yarn_install and npm_install in build_bazel_rules_nodejs >= 0.30.0
+        depends on the managed directory feature added in Bazel 0.26.0. See
+        https://github.com/bazelbuild/rules_nodejs/wiki#migrating-to-rules_nodejs-030.
+
+        You can opt out of this feature by setting `symlink_node_modules = False`
+        on all of your yarn_install & npm_install rules.
+        """ % (rule, repository_ctx.attr.name),
+            minimum_bazel_version = "0.26.0",
+        )
+
 def _npm_install_impl(repository_ctx):
     """Core implementation of npm_install."""
+
+    _check_min_bazel_version("npm_install", repository_ctx)
 
     is_windows = os_name(repository_ctx).find("windows") != -1
     node = repository_ctx.path(get_node_label(repository_ctx))
@@ -255,6 +275,8 @@ npm_install = repository_rule(
 
 def _yarn_install_impl(repository_ctx):
     """Core implementation of yarn_install."""
+
+    _check_min_bazel_version("yarn_install", repository_ctx)
 
     node = repository_ctx.path(get_node_label(repository_ctx))
     yarn = get_yarn_label(repository_ctx)


### PR DESCRIPTION
in yarn_install or npm_install as this requires the managed directories feature

If symlinked node_modules is not used the minimum Bazel version is 0.21.0.

This makes it easier for downstream rules such as rules_sass to updated to rules_nodejs 0.30.0 without changing also adopting a min Bazel version of 0.26.0. Unblocks: https://github.com/bazelbuild/rules_sass/pull/85