### PR TITLE
Remove temporary examples/angular patches...

### DIFF
--- a/scripts/setup_examples_angular.sh
+++ b/scripts/setup_examples_angular.sh
@@ -43,15 +43,6 @@ printf "\n\nSetting up /examples/angular\n"
     echo_and_run sedi "s#urls* = \[*\"https:\/\/github\.com\/[a-zA-Z_]*\/rules_nodejs[^\"]*\"\]*#url = \"file://${RULES_NODEJS_DIR}/dist/build_bazel_rules_nodejs/release.tar.gz\"#" WORKSPACE
     echo_and_run sedi "s#sha256 =#\# sha256 =#" WORKSPACE
 
-    # TEMPORARY for managed_directories
-    echo_and_run sedi "s#name \= \"angular_bazel_example\"#name = \"angular_bazel_example\", managed_directories = {\"@npm\": [\"node_modules\"]}#" WORKSPACE
-    echo_and_run sedi "s#\"\@bazel\/bazel\"\: \"0\.25\.1\"#\"@bazel/bazel\": \"file:../../node_modules/@bazel/bazel\"#" package.json
-    echo "" >> .bazelrc
-    echo "##################################################" >> .bazelrc
-    echo "# Turn on managed_directories" >> .bazelrc
-    echo "build --experimental_allow_incremental_repository_updates" >> .bazelrc
-    echo "query --experimental_allow_incremental_repository_updates" >> .bazelrc
-
     # Check that above replacements worked
     if ! grep -q "dist/npm_bazel_" package.json; then
       echo "package.json replacements failed!"


### PR DESCRIPTION
…now that angular-bazel-example is updated to nodejs rules 0.30.1
