### PR TITLE
Remove sh_* wrappers from nodejs_* rules

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -22,11 +22,7 @@ load("//internal/common:check_version.bzl", "check_version")
 load("//internal/history-server:history_server.bzl", _history_server = "history_server")
 load("//internal/http-server:http_server.bzl", _http_server = "http_server")
 load("//internal/jasmine_node_test:jasmine_node_test.bzl", _jasmine_node_test = "jasmine_node_test")
-load(
-    "//internal/node:node.bzl",
-    _nodejs_binary = "nodejs_binary_macro",
-    _nodejs_test = "nodejs_test_macro",
-)
+load("//internal/node:node.bzl", _nodejs_binary = "nodejs_binary", _nodejs_test = "nodejs_test")
 load("//internal/node:node_repositories.bzl", _node_repositories = "node_repositories")
 load("//internal/npm_install:npm_install.bzl", _npm_install = "npm_install", _yarn_install = "yarn_install")
 load("//internal/npm_package:npm_package.bzl", _npm_package = "npm_package")

--- a/examples/app/protractor.on-prepare.js
+++ b/examples/app/protractor.on-prepare.js
@@ -14,7 +14,7 @@ module.exports = function(config) {
   // selected port (given a port flag to pass to the server as an argument).
   // The port used is returned in serverSpec and the protractor serverUrl
   // is the configured.
-  const isProdserver = config.server.endsWith('prodserver');
+  const isProdserver = config.server.endsWith('prodserver.sh');
   return protractorUtils
       .runServer(config.workspace, config.server, isProdserver ? '-p' : '-port', [])
       .then(serverSpec => {

--- a/examples/protocol_buffers/protractor.on-prepare.js
+++ b/examples/protocol_buffers/protractor.on-prepare.js
@@ -14,7 +14,7 @@ module.exports = function(config) {
   // selected port (given a port flag to pass to the server as an argument).
   // The port used is returned in serverSpec and the protractor serverUrl
   // is the configured.
-  const isProdserver = config.server.endsWith('prodserver');
+  const isProdserver = config.server.endsWith('prodserver.sh');
   return protractorUtils
       .runServer(config.workspace, config.server, isProdserver ? '-p' : '-port', [])
       .then(serverSpec => {

--- a/internal/history-server/history_server.bzl
+++ b/internal/history-server/history_server.bzl
@@ -1,6 +1,6 @@
 "Run history-server"
 
-load("@build_bazel_rules_nodejs//internal/node:node.bzl", "nodejs_binary_macro")
+load("@build_bazel_rules_nodejs//internal/node:node.bzl", "nodejs_binary")
 
 def history_server(templated_args = [], **kwargs):
     """
@@ -24,7 +24,7 @@ def history_server(templated_args = [], **kwargs):
         else:
             templated_args = ["."]
 
-    nodejs_binary_macro(
+    nodejs_binary(
         node_modules = "@history-server_runtime_deps//:node_modules",
         entry_point = "@history-server_runtime_deps//:node_modules/history-server/modules/cli.js",
         install_source_map_support = False,

--- a/internal/http-server/http_server.bzl
+++ b/internal/http-server/http_server.bzl
@@ -1,6 +1,6 @@
 "Run http-server"
 
-load("@build_bazel_rules_nodejs//internal/node:node.bzl", "nodejs_binary_macro")
+load("@build_bazel_rules_nodejs//internal/node:node.bzl", "nodejs_binary")
 
 def http_server(templated_args = [], **kwargs):
     """
@@ -27,7 +27,7 @@ def http_server(templated_args = [], **kwargs):
     if not templated_args:
         templated_args = [native.package_name()]
 
-    nodejs_binary_macro(
+    nodejs_binary(
         node_modules = "@http-server_runtime_deps//:node_modules",
         entry_point = "@http-server_runtime_deps//:node_modules/http-server/bin/http-server",
         install_source_map_support = False,

--- a/internal/npm_install/test/bazel_bin_test.sh
+++ b/internal/npm_install/test/bazel_bin_test.sh
@@ -27,9 +27,9 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
-readonly OUT=$($(rlocation "npm/testy/bin/testy"))
+readonly OUT=$($(rlocation "npm/testy/bin/testy.sh"))
 
 if [ "$OUT" != "Hello some_value" ]; then
-  echo "Expected output 'Hello world' but was '$OUT'"
+  echo "Expected output 'Hello some_value' but was '$OUT'"
   exit 1
 fi

--- a/packages/protractor/test/protractor-2/on-prepare.js
+++ b/packages/protractor/test/protractor-2/on-prepare.js
@@ -22,7 +22,7 @@ module.exports = function(config) {
   if (!global.userOnPrepareGotCalled) {
     throw new Error('Expecting user configuration onPrepare to have been called');
   }
-  const portFlag = /prodserver(\.exe)?$/.test(config.server) ? '-p' : '-port';
+  const portFlag = /prodserver(\.sh)?(\.exe)?$/.test(config.server) ? '-p' : '-port';
   return protractorUtils.runServer(config.workspace, config.server, portFlag, [])
       .then(serverSpec => {
         const serverUrl = `http://localhost:${serverSpec.port}`;

--- a/packages/protractor/test/protractor-utils/index_test.ts
+++ b/packages/protractor/test/protractor-utils/index_test.ts
@@ -21,7 +21,7 @@ describe('Bazel protractor utils', () => {
   it('should be able to start devserver', async () => {
     // Test will automatically time out if the server couldn't be launched as expected.
     await runServer(
-        'build_bazel_rules_nodejs', 'packages/protractor/test/protractor-utils/fake-devserver',
+        'build_bazel_rules_nodejs', 'packages/protractor/test/protractor-utils/fake-devserver.sh',
         '--port', []);
   });
 });

--- a/packages/typescript/test/some_module/module_load_test.sh
+++ b/packages/typescript/test/some_module/module_load_test.sh
@@ -27,7 +27,7 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
-readonly OUT=$($(rlocation "build_bazel_rules_nodejs/packages/typescript/test/some_module/bin"))
+readonly OUT=$($(rlocation "build_bazel_rules_nodejs/packages/typescript/test/some_module/bin.sh"))
 
 if [ "$OUT" != "hello world" ]; then
   echo "Expected output 'hello world' but was $OUT"


### PR DESCRIPTION
These were a clumsy workaround for Windows but cause a number of problems.

Fixes #51
Fixes #733

Note to reviewers: this will require a bunch of manual testing on Windows I think.