### PR TITLE
Fix angular-bazel-example CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,9 +299,35 @@ jobs:
       - *attach_workspace
       - *init_environment
       - *init_bazel
-      - run: ./scripts/setup_examples_angular.sh
       # Some examples such as app require xvfb
       - run: xvfb-run -a ./scripts/test_examples_all.sh ${CIRCLE_NODE_INDEX} ${CIRCLE_NODE_TOTAL}
+
+  # This job cannot run on BuildKite (BazelCI) because it requires changing
+  # directories to test inside nested workspaces.
+  # See https://github.com/bazelbuild/continuous-integration/issues/225
+  test_angular_bazel_example:
+    <<: *job_defaults
+    docker:
+      # Needed because some tests require local chrome
+      - image: *browsers_docker_image
+    resource_class: xlarge
+    steps:
+      - *attach_workspace
+      - *init_environment
+      - *init_bazel
+      - run: ./scripts/setup_examples_angular.sh
+      - run:
+          name: Test angular-bazel-example
+          command: |
+            cd ./examples/angular
+            ../../scripts/link_deps.sh
+            # Install Bazel from NPM
+            yarn
+            # Build and Test
+            yarn ng test
+            yarn ng e2e
+            # Also run prodserver test which is not covered by `ng e2e`
+            yarn bazel test //e2e:prodserver_test
 
 workflows:
   version: 2
@@ -350,6 +376,13 @@ workflows:
           requires:
           - build_release
       - test_examples:
+          requires:
+          - build_release
+          - build_typescript_package
+          - build_jasmine_package
+          - build_labs_package
+          - build_karma_package
+      - test_angular_bazel_example:
           requires:
           - build_release
           - build_typescript_package


### PR DESCRIPTION
Fix angular-bazel-example test in CI which was crashing and flaking out

`bazel test //e2e:all` was crashing before the tests even started in CI. Possibly out of memory but not sure how that is possible as it was running in the xlarge 16GB container. This PR moves the angular-bazel-example test to its own CI job (which speeds up overall CI time as its critical path) and runs the same CI tests that angular-bazel-example runs in its own CI.