### PR TITLE
fix(karma): static_files overwrite files specified in dependencies

### DIFF
--- a/e2e/karma/BUILD.bazel
+++ b/e2e/karma/BUILD.bazel
@@ -16,15 +16,27 @@ load("@npm_bazel_karma//:index.bzl", "ts_web_test_suite")
 
 ts_web_test_suite(
     name = "testing",
-    srcs = glob(["*.js"]),
+    srcs = glob(
+        ["*.js"],
+        exclude = [
+            "unnamed-amd-module.js",
+            "init-test.js",
+        ],
+    ),
     browsers = [
         "@io_bazel_rules_webtesting//browsers:chromium-local",
         "@io_bazel_rules_webtesting//browsers:firefox-local",
     ],
     static_files = [
-        ":unnamed-amd-module.js",
+        "unnamed-amd-module.js",
+        # Add the "init-test.js" file to the "static_files" as well. This simulates
+        # a scenario where a developer has a NPM package in the "deps" that transitively
+        # brings in "tslib", whereas the target in the "static_files" can also bring
+        # in "tslib" transitively.
+        "init-test.js",
     ],
     deps = [
-        ":requirejs-config.js",
+        "init-test.js",
+        "requirejs-config.js",
     ],
 )

--- a/e2e/karma/init-test.js
+++ b/e2e/karma/init-test.js
@@ -1,0 +1,8 @@
+/**
+ * File that should mimic a file that is required for the tests to run. This file is used
+ * to ensure that the Karma bazel rules properly include the file in the ConcatJS bundle.
+ */
+
+define('e2e_karma/init-test', [], () => {
+  window['__testInitialized'] = true;
+});

--- a/e2e/karma/test-initialized.spec.js
+++ b/e2e/karma/test-initialized.spec.js
@@ -1,0 +1,13 @@
+define('e2e_karma/test-initialized.spec', [], () => {
+
+  // Test that ensures that the "init-test.js" file has been included in the
+  // ConcatJS module and was actually executed by the browser. The "init-test.js"
+  // file is included in "static_files" and in the "deps" but should not be treated
+  // as static file as it is specified as dependency.
+  describe('Test initialization', () => {
+
+    it('should have initialized tests', () => {
+      expect(window['__testInitialized']).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Currently when someone specifies a `static_files` target that transitively brings in
a package "X", and there is a target in the `deps` that transitively also brings in "X",
the files from "X" are accidentally **not** included in the Karma ConcatJS bundle. 

This causes the tests to fail since a required dependency is not executed/included.