### PR TITLE
Remove detection logic for warning on global bazel

### DIFF
--- a/packages/bazel/index.js
+++ b/packages/bazel/index.js
@@ -6,15 +6,6 @@ const fs = require('fs');
 const path = require('path');
 const spawnSync = require('child_process').spawnSync;
 
-const warnGlobalInstall = `
-  *** WARNING
-    The Bazel binary is being run from a global install.
-
-    This means the version may not match the one used in your project.
-    We recommend installing the @bazel/bazel package locally in your project.
-  ***
-  `;
-
 /**
  * @returns the native `bazel` binary for the current platform
  * @throws when the `bazel` executable can not be found
@@ -24,29 +15,15 @@ function getNativeBinary() {
   const platformPackageJson = `@bazel/bazel-${platform}/package.json`;
   let nativePackage;
   try {
-    // First, look for the package locally installed under the current working directory
-    nativePackage = require.resolve(platformPackageJson, {paths: [process.cwd()]});
+    nativePackage = require.resolve(platformPackageJson);
   } catch (e) {
     if (e.code !== 'MODULE_NOT_FOUND') {
       // rethrow other errors
       throw e;
     }
-    try {
-      // Fall back to resolving the package anywhere, but if it succeeds, warn the user that we
-      // don't recommend relying on a global installation.
-      nativePackage = require.resolve(platformPackageJson);
-      console.error(warnGlobalInstall);
-    } catch (e) {
-      if (e.code !== 'MODULE_NOT_FOUND') {
-        // rethrow other errors
-        throw e;
-      }
-      // Give up on resolving the correct package anywhere
-      console.error(
-          `FATAL: Bazel has not published an executable for your platform. (${platform})\n` +
-          'Consider installing it following instructions at https://bazel.build instead.\n');
-      process.exit(1);
-    }
+    throw new Error(
+        `FATAL: Bazel has not published an executable for your platform (${platform})\n` +
+        'Consider installing it following instructions at https://bazel.build instead.\n');
   }
 
   const binary = JSON.parse(fs.readFileSync(nativePackage))['bin']['bazel'];


### PR DESCRIPTION
It was failing in some cases, see attached bug.
We shouldn't recommend a global install anyway. using yarn bazel or npx bazel is probably better

Fixes #656