### PR TITLE
fix: license SPDX should be `Apache-2.0` instead of `Apache 2.0`

### DIFF
--- a/packages/bazel-darwin_x64/package.json
+++ b/packages/bazel-darwin_x64/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/bazelbuild/rules_nodejs.git",
     "directory": "packages/bazel-darwin_x64"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/bazelbuild/bazel/issues"
   }

--- a/packages/bazel-linux_x64/package.json
+++ b/packages/bazel-linux_x64/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/bazelbuild/rules_nodejs.git",
     "directory": "packages/bazel-linux_x64"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/bazelbuild/bazel/issues"
   }

--- a/packages/bazel-win32_x64/package.json
+++ b/packages/bazel-win32_x64/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/bazelbuild/rules_nodejs.git",
     "directory": "packages/bazel-win32_x64"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/bazelbuild/bazel/issues"
   }

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -4,7 +4,7 @@
     "bazel": "./index.js"
   },
   "version": "0.26.0-rc10",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "description": "Build and test software of any size, quickly and reliably",
   "homepage": "https://bazel.build/",
   "repository": {

--- a/packages/buildifier-darwin_x64/package.json
+++ b/packages/buildifier-darwin_x64/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/bazelbuild/rules_nodejs.git",
     "directory": "packages/buildifier-darwin_x64"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/bazelbuild/buildtools/issues"
   }

--- a/packages/buildifier-linux_x64/package.json
+++ b/packages/buildifier-linux_x64/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/bazelbuild/rules_nodejs.git",
     "directory": "packages/buildifier-linux_x64"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/bazelbuild/buildtools/issues"
   }

--- a/packages/buildifier-win32_x64/package.json
+++ b/packages/buildifier-win32_x64/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/bazelbuild/rules_nodejs.git",
     "directory": "packages/buildifier-win32_x64"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/bazelbuild/buildtools/issues"
   }

--- a/packages/buildifier/package.json
+++ b/packages/buildifier/package.json
@@ -5,7 +5,7 @@
   },
   "version": "0.25.1",
   "description": "A tool for formatting bazel BUILD and .bzl files with a standard convention",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/bazelbuild/rules_nodejs.git",

--- a/packages/buildozer-darwin_x64/package.json
+++ b/packages/buildozer-darwin_x64/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/bazelbuild/rules_nodejs.git",
     "directory": "packages/buildozer-darwin_x64"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/bazelbuild/buildtools/issues"
   }

--- a/packages/buildozer-linux_x64/package.json
+++ b/packages/buildozer-linux_x64/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/bazelbuild/rules_nodejs.git",
     "directory": "packages/buildozer-linux_x64"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/bazelbuild/buildtools/issues"
   }

--- a/packages/buildozer-win32_x64/package.json
+++ b/packages/buildozer-win32_x64/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/bazelbuild/rules_nodejs.git",
     "directory": "packages/buildozer-win32_x64"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/bazelbuild/buildtools/issues"
   }

--- a/packages/buildozer/package.json
+++ b/packages/buildozer/package.json
@@ -5,7 +5,7 @@
   },
   "version": "0.25.1",
   "description": "A command line tool to rewrite multiple Bazel BUILD files using standard commands",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/bazelbuild/rules_nodejs.git",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@bazel/create",
     "bin": "index.js",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "version": "0.0.0-PLACEHOLDER",
     "keywords": [
         "bazel"

--- a/packages/jasmine/package.json
+++ b/packages/jasmine/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@bazel/jasmine",
     "description": "Run Jasmine tests under Bazel",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "version": "0.0.0-PLACEHOLDER",
     "repository": {
         "type" : "git",


### PR DESCRIPTION
The Apache license version 2.0 SPDX short identifier is Apache-2.0

//cc @clydin 

More info: https://spdx.org/licenses/