### PR TITLE
Fix for --incompatible_depset_is_not_iterable

### DIFF
--- a/packages/typescript/internal/build_defs.bzl
+++ b/packages/typescript/internal/build_defs.bzl
@@ -194,7 +194,7 @@ def tsc_wrapped_tsconfig(
     node_modules_root = _compute_node_modules_root(ctx)
     config = create_tsconfig(
         ctx,
-        files,
+        files.to_list(),
         srcs,
         devmode_manifest = devmode_manifest,
         node_modules_root = node_modules_root,


### PR DESCRIPTION
https://github.com/bazelbuild/rules_typescript/issues/443

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe: