### PR TITLE
Update examples/vendored_node to reflect best practice of specifying node version

### DIFF
--- a/examples/vendored_node/WORKSPACE
+++ b/examples/vendored_node/WORKSPACE
@@ -31,6 +31,7 @@ local_repository(
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "npm_install", "yarn_install")
 
 node_repositories(
+    node_version = "10.12.0",
     vendored_node = "@examples_vendored_node//:node-v10.12.0-linux-x64",
     vendored_yarn = "@examples_vendored_node//:yarn-v1.10.0",
 )


### PR DESCRIPTION
The docs for node_repositories() reflect this now and the reason is that node_repositories() will set node options depending on version used
