### PR TITLE
Update to latest rules_typescript commit

### DIFF
--- a/packages/typescript/WORKSPACE
+++ b/packages/typescript/WORKSPACE
@@ -40,7 +40,7 @@ rules_nodejs_dev_dependencies()
 # With http_archive it only sees releases/download/*.tar.gz urls
 git_repository(
     name = "build_bazel_rules_typescript",
-    commit = "c160db910772b2e58a46aaa0430e9b167a77eb6c",
+    commit = "4ae7cda81c7ea3215a024f10b00ee38a0755549d",
     remote = "http://github.com/bazelbuild/rules_typescript.git",
 )
 


### PR DESCRIPTION
https://github.com/bazelbuild/rules_typescript/pull/455 must land first and the commit updated to upstream

UPDATE: https://github.com/bazelbuild/rules_typescript/pull/455 landed and commit updated to upstream