### PR TITLE
Remove es5.min rollup_bundle output from runfiles

### DIFF
--- a/internal/rollup/rollup_bundle.bzl
+++ b/internal/rollup/rollup_bundle.bzl
@@ -537,7 +537,11 @@ def _rollup_bundle(ctx):
         )
 
     return [
-        DefaultInfo(files = depset(files), runfiles = ctx.runfiles(files)),
+        DefaultInfo(
+            files = depset(files),
+            # NB: we don't include any runfiles here since they would always be built
+            # regardless if they are requested or not
+        ),
         output_group,
     ]
 


### PR DESCRIPTION
Having it there causes it to always be built, whether requested or not.
This partially unblocks using rollup_bundle in dev mode.

BREAKING CHANGE:
if you expect the rollup_bundle es5.min file to be a runtime dependency of a rule, you must now include it in the data[] of that rule
