### PR TITLE
Compatibility with Bazel 0.26.1

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,5 +1,4 @@
 ---
-bazel: 0.26.0
 platforms:
   ubuntu1604:
     run_targets:

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -86,7 +86,7 @@ def _write_loader_script(ctx):
 
     node_modules_root = _compute_node_modules_root(ctx)
 
-    if len(ctx.attr.entry_point.files) != 1:
+    if len(ctx.attr.entry_point.files.to_list()) != 1:
         fail("labels in entry_point must contain exactly one file")
 
     entry_point_path = expand_path_into_runfiles(ctx, ctx.file.entry_point.short_path)

--- a/internal/npm_install/npm_umd_bundle.bzl
+++ b/internal/npm_install/npm_umd_bundle.bzl
@@ -20,7 +20,7 @@ For use by yarn_install and npm_install. Not meant to be part of the public API.
 load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleSources", "collect_node_modules_aspect")
 
 def _npm_umd_bundle(ctx):
-    if len(ctx.attr.entry_point.files) != 1:
+    if len(ctx.attr.entry_point.files.to_list()) != 1:
         fail("labels in entry_point must contain exactly one file")
 
     output = ctx.actions.declare_file("%s.umd.js" % ctx.attr.package_name)

--- a/internal/rollup/rollup_bundle.bzl
+++ b/internal/rollup/rollup_bundle.bzl
@@ -443,7 +443,7 @@ def _generate_code_split_entry(ctx, bundles_folder, output):
     )
 
 def _rollup_bundle(ctx):
-    if len(ctx.attr.entry_point.files) != 1:
+    if len(ctx.attr.entry_point.files.to_list()) != 1:
         fail("labels in entry_point must contain exactly one file")
 
     if ctx.attr.additional_entry_points:

--- a/packages/typescript/WORKSPACE
+++ b/packages/typescript/WORKSPACE
@@ -43,7 +43,7 @@ rules_nodejs_dev_dependencies()
 #                    https://github.com/bazelbuild/rules_typescript/pull/453 lands
 git_repository(
     name = "build_bazel_rules_typescript",
-    commit = "6521ce4e0d4959eaf46a4738d45f3f480d4af25f",
+    commit = "bc7b3d3db3ecc4f5232586387638e7e4ccb67f17",
     remote = "http://github.com/gregmagolan/rules_typescript.git",
 )
 


### PR DESCRIPTION
Depsets are no longer iterable on Bazel 0.26.1
