### PR TITLE
build(typescript): switch back to upstream commit of rules_typescript

### DIFF
--- a/packages/typescript/WORKSPACE
+++ b/packages/typescript/WORKSPACE
@@ -38,13 +38,10 @@ rules_nodejs_dev_dependencies()
 
 # We use git_repository since Renovate knows how to update it.
 # With http_archive it only sees releases/download/*.tar.gz urls
-
-# TODO(gregmagolan): switch to https://github.com/bazelbuild/rules_typescript/ HEAD when
-#                    https://github.com/bazelbuild/rules_typescript/pull/453 lands
 git_repository(
     name = "build_bazel_rules_typescript",
-    commit = "bc7b3d3db3ecc4f5232586387638e7e4ccb67f17",
-    remote = "http://github.com/gregmagolan/rules_typescript.git",
+    commit = "66505d1e39bc1be973ffbb1e3f83df4d7e1373ef",
+    remote = "http://github.com/bazelbuild/rules_typescript.git",
 )
 
 # We have a source dependency on build_bazel_rules_typescript


### PR DESCRIPTION
Now that https://github.com/bazelbuild/rules_typescript/pull/453 has landed
