### PR TITLE
test: disable our one py_test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,4 +4,10 @@ import %workspace%/common.bazelrc
 # Mock versioning command to test the --stamp behavior
 build --workspace_status_command="echo BUILD_SCM_VERSION 1.2.3"
 
+# Avoid python 3 which requires explicit toolchain config
+# This is needed only for the pkg_tar rule
+build --host_force_python=PY2
+
+# Opt-in to upcoming breaking changes
+build --incompatible_use_python_toolchains
 common --incompatible_string_join_requires_strings

--- a/internal/common/BUILD.bazel
+++ b/internal/common/BUILD.bazel
@@ -32,6 +32,9 @@ py_test(
     size = "small",
     srcs = ["check_version_test.py"],
     data = [":check_version.bzl"],
+    # Explicitly pin to Python 2 to avoid toolchain configuration
+    # TODO(alexeagle): switch to starlark test mechanism
+    python_version = "PY2",
 )
 
 filegroup(


### PR DESCRIPTION
This should unblock Bazel 0.27 RC which requires a python toolchain

See #809 