### PR TITLE
fix(builtin): fix for issue 834

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,7 @@ jobs:
       - run: bazel run //internal/node/test:has_deps_legacy
       - run: bazel run //internal/node/test:has_deps
       - run: bazel run //internal/node/test:has_deps_hybrid
+      - run: bazel run //internal/node/test:module_name_test
       - run: bazel run //internal/e2e/fine_grained_no_bin:index
       - run: bazel run @fine_grained_deps_yarn//typescript/bin:tsc
       - run: bazel run @bazel_workspace_a//:bin

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//:defs.bzl", "nodejs_binary")
+load("//internal/js_library:js_library.bzl", "js_library")
 
 # You can have a nodejs_binary with no node_modules attribute
 # and no fine grained deps
@@ -48,4 +49,18 @@ filegroup(
 nodejs_binary(
     name = "has_entry_file",
     entry_point = ":entry_file",
+)
+
+# Coverage for issue https://github.com/bazelbuild/rules_nodejs/issues/834
+# where module_name is equal to the workspace naem
+js_library(
+    name = "module_name_lib",
+    srcs = ["module-name.js"],
+    module_name = "build_bazel_rules_nodejs",
+)
+
+nodejs_binary(
+    name = "module_name_test",
+    data = [":module_name_lib"],
+    entry_point = ":module-name.js",
 )

--- a/internal/node/test/module-name.js
+++ b/internal/node/test/module-name.js
@@ -1,0 +1,1 @@
+console.log('Awesome APP is launched!');

--- a/scripts/test_all.sh
+++ b/scripts/test_all.sh
@@ -44,6 +44,7 @@ echo_and_run bazel run //internal/node/test:no_deps
 echo_and_run bazel run //internal/node/test:has_deps_legacy
 echo_and_run bazel run //internal/node/test:has_deps
 echo_and_run bazel run //internal/node/test:has_deps_hybrid
+echo_and_run bazel run //internal/node/test:module_name_test
 echo_and_run bazel run //internal/e2e/fine_grained_no_bin:index
 echo_and_run bazel run @fine_grained_deps_yarn//typescript/bin:tsc
 


### PR DESCRIPTION
Skip module root resolution in node resolver if main entry point. Also don't throw on resolve failure so that resolve does cascade down incase the module_root conflicts with the workspace name for fully resolved requires

Fixes #834