### PR TITLE
fix for angular/angular-bazel-example/issues/364

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -65,6 +65,7 @@ npm_package(
         "//internal/npm_install:package_contents",
         "//internal/npm_package:package_contents",
         "//internal/web_package:package_contents",
+        "//umd_shims:package_contents",
     ],
 )
 

--- a/e2e/karma_typescript/BUILD.bazel
+++ b/e2e/karma_typescript/BUILD.bazel
@@ -73,7 +73,7 @@ filegroup(
     srcs = [
         # do not sort
         "@npm//node_modules/rxjs:bundles/rxjs.umd.js",
-        ":rxjs_shims.js",
+        "@build_bazel_rules_nodejs//umd_shims:rxjs-shims.umd.js",
     ],
 )
 

--- a/e2e/karma_typescript/user_files.spec.js
+++ b/e2e/karma_typescript/user_files.spec.js
@@ -37,7 +37,7 @@ describe('ts_web_test_suite', () => {
       'e2e_karma_typescript/foobar.spec.js',
       'e2e_karma_typescript/decrement.js',
       'npm/node_modules/rxjs/bundles/rxjs.umd.js',
-      'e2e_karma_typescript/rxjs_shims.js',
+      'build_bazel_rules_nodejs/umd_shims/rxjs-shims.umd.js',
       'e2e_karma_typescript/hello_world.js',
     ]);
   });

--- a/umd_shims/BUILD.bazel
+++ b/umd_shims/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "package_contents",
+    srcs = glob(["**/*"]),
+)

--- a/umd_shims/rxjs-shims.umd.js
+++ b/umd_shims/rxjs-shims.umd.js
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+/**
+ * @fileoverview These named-UMD shims provide named UMD modules for deep rxjs 6
+ * imports such as `rxjs/operators` so that we can bundle an application that
+ * depends on rxjs 6 using the concatjs bundlers in ts_devserver & ts_web_test.
+ * To use, add `@build_bazel_rules_nodejs//umd_shims:rxjs-shims.umd.js` to `ts_devserver`
+ * `scripts` or `ts_web_test` `deps`.
+ */
+
+// rxjs/ajax
+(function(factory) {
+if (typeof module === 'object' && typeof module.exports === 'object') {
+  var v = factory(require, exports);
+  if (v !== undefined) module.exports = v;
+} else if (typeof define === 'function' && define.amd) {
+  define('rxjs/ajax', ['exports', 'rxjs'], factory);
+}
+})(function(exports, rxjs) {
+'use strict';
+Object.keys(rxjs.ajax).forEach(function(key) {
+  exports[key] = rxjs.ajax[key];
+});
+Object.defineProperty(exports, '__esModule', {value: true});
+});
+
+// rxjs/fetch
+(function(factory) {
+if (typeof module === 'object' && typeof module.exports === 'object') {
+  var v = factory(require, exports);
+  if (v !== undefined) module.exports = v;
+} else if (typeof define === 'function' && define.amd) {
+  define('rxjs/fetch', ['exports', 'rxjs'], factory);
+}
+})(function(exports, rxjs) {
+'use strict';
+Object.keys(rxjs.fetch).forEach(function(key) {
+  exports[key] = rxjs.fetch[key];
+});
+Object.defineProperty(exports, '__esModule', {value: true});
+});
+
+// rxjs/operators
+(function(factory) {
+if (typeof module === 'object' && typeof module.exports === 'object') {
+  var v = factory(require, exports);
+  if (v !== undefined) module.exports = v;
+} else if (typeof define === 'function' && define.amd) {
+  define('rxjs/operators', ['exports', 'rxjs'], factory);
+}
+})(function(exports, rxjs) {
+'use strict';
+Object.keys(rxjs.operators).forEach(function(key) {
+  exports[key] = rxjs.operators[key];
+});
+Object.defineProperty(exports, '__esModule', {value: true});
+});
+
+// rxjs/testing
+(function(factory) {
+if (typeof module === 'object' && typeof module.exports === 'object') {
+  var v = factory(require, exports);
+  if (v !== undefined) module.exports = v;
+} else if (typeof define === 'function' && define.amd) {
+  define('rxjs/testing', ['exports', 'rxjs'], factory);
+}
+})(function(exports, rxjs) {
+'use strict';
+Object.keys(rxjs.testing).forEach(function(key) {
+  exports[key] = rxjs.testing[key];
+});
+Object.defineProperty(exports, '__esModule', {value: true});
+});
+
+// rxjs/webSocket
+(function(factory) {
+if (typeof module === 'object' && typeof module.exports === 'object') {
+  var v = factory(require, exports);
+  if (v !== undefined) module.exports = v;
+} else if (typeof define === 'function' && define.amd) {
+  define('rxjs/webSocket', ['exports', 'rxjs'], factory);
+}
+})(function(exports, rxjs) {
+'use strict';
+Object.keys(rxjs.webSocket).forEach(function(key) {
+  exports[key] = rxjs.webSocket[key];
+});
+Object.defineProperty(exports, '__esModule', {value: true});
+});


### PR DESCRIPTION
This removes the need for downstream users that use rxjs with Bazel to maintain
their own rxjs_shims.js file. rxjs used commonly enough that the shims file can
be moved to `@build_bazel_rules_nodejs//umd_shims:rxjs-shims.umd.js` and
referenced from there downstream.

Upcoming rxjs 7 release may be publishing separate UMD bundles for each deep import which
would solve the underlying issue by not requiring any shims file.

Fixes https://github.com/angular/angular-bazel-example/issues/364 (kindof)