### PR TITLE
Add NodeJSRuntimeInfo provider

### DIFF
--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -208,6 +208,7 @@ def _nodejs_binary_impl(ctx):
             # https://github.com/bazelbuild/bazel/issues/6908
             runfiles = ctx.runfiles(
                 transitive_files = runfiles,
+                collect_data = True,
             ),
         ),
         NodeJSRuntimeInfo(

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -138,22 +138,21 @@ def _nodejs_binary_impl(ctx):
     node = ctx.file.node
     node_modules = depset(ctx.files.node_modules)
 
-    # Also include files from npm fine grained deps as inputs.
-    # These deps are identified by the NodeModuleSources provider.
-    for d in ctx.attr.data:
-        if NodeModuleSources in d:
-            node_modules = depset(transitive = [node_modules, d[NodeModuleSources].sources])
-
     # Using a depset will allow us to avoid flattening files and sources
     # inside this loop. This should reduce the performances hits,
     # since we don't need to call .to_list()
     sources = depset()
 
+    # Also include files from npm fine grained deps as inputs.
+    # These deps are identified by the NodeModuleSources provider.
     for d in ctx.attr.data:
-        if hasattr(d, "node_sources"):
-            sources = depset(transitive = [sources, d.node_sources])
-        if hasattr(d, "files"):
-            sources = depset(transitive = [sources, d.files])
+        if NodeModuleSources in d:
+            node_modules = depset(transitive = [node_modules, d[NodeModuleSources].sources])
+        else:
+            if hasattr(d, "node_sources"):
+                sources = depset(transitive = [sources, d.node_sources])
+            if hasattr(d, "files"):
+                sources = depset(transitive = [sources, d.files])
 
     _write_loader_script(ctx)
 

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -221,7 +221,7 @@ def _nodejs_binary_impl(ctx):
             node_runfiles = depset([ctx.outputs.loader, ctx.file._repository_args] + ctx.files._source_map_support_files),
             sources = sources,
             node_modules = node_modules,
-        )
+        ),
     ]
 
 _NODEJS_EXECUTABLE_ATTRS = {

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -20,7 +20,7 @@ They support module mapping: any targets in the transitive dependencies with
 a `module_name` attribute can be `require`d by that name.
 """
 
-load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleSources", "NodeModuleInfo", "collect_node_modules_aspect")
+load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleInfo", "NodeModuleSources", "collect_node_modules_aspect")
 load("//internal/common:expand_into_runfiles.bzl", "expand_location_into_runfiles", "expand_path_into_runfiles")
 load("//internal/common:module_mappings.bzl", "module_mappings_runtime_aspect")
 load("//internal/common:sources_aspect.bzl", "sources_aspect")

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -2,6 +2,8 @@ load("//:defs.bzl", "nodejs_binary")
 load("//internal/js_library:js_library.bzl", "js_library")
 load(":nodejs_binary_test.bzl", "nodejs_binary_test_suite")
 
+exports_files(["has-deps.js"])
+
 nodejs_binary_test_suite()
 
 # You can have a nodejs_binary with no node_modules attribute

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -1,5 +1,8 @@
 load("//:defs.bzl", "nodejs_binary")
 load("//internal/js_library:js_library.bzl", "js_library")
+load(":nodejs_binary_test.bzl", "nodejs_binary_test_suite")
+
+nodejs_binary_test_suite()
 
 # You can have a nodejs_binary with no node_modules attribute
 # and no fine grained deps

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -1,10 +1,26 @@
 load("//:defs.bzl", "nodejs_binary")
 load("//internal/js_library:js_library.bzl", "js_library")
+load(":js_import.bzl", "js_import")
 load(":nodejs_binary_test.bzl", "nodejs_binary_test_suite")
 
 exports_files(["has-deps.js"])
 
 nodejs_binary_test_suite()
+
+js_import(
+    name = "transitive-dep",
+    srcs = [":has-deps.js"],
+    deps = ["@fine_grained_deps_yarn//typescript"],
+)
+
+nodejs_binary(
+    name = "transitive_deps",
+    data = [
+        "transitive-deps.js",
+        ":transitive-dep",
+    ],
+    entry_point = ":transitive-deps.js",
+)
 
 # You can have a nodejs_binary with no node_modules attribute
 # and no fine grained deps

--- a/internal/node/test/js_import.bzl
+++ b/internal/node/test/js_import.bzl
@@ -1,3 +1,5 @@
+"""Allow to test transtive depedency loading with nodejs_binary"""
+
 load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleInfo")
 
 def _collect_sources(ctx):
@@ -56,4 +58,3 @@ js_import = rule(
         "deps": attr.label_list(allow_files = True),
     },
 )
-"""Allow to test transtive depedency loading with nodejs_binary"""

--- a/internal/node/test/js_import.bzl
+++ b/internal/node/test/js_import.bzl
@@ -1,35 +1,35 @@
 load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleInfo")
 
 def _collect_sources(ctx):
-  es5_sources = depset(ctx.files.srcs)
-  transitive_es5_sources = depset()
-  transitive_es6_sources = depset()
-  for dep in ctx.attr.deps:
-    if hasattr(dep, "typescript"):
-        transitive_es5_sources = depset(transitive = [
-            transitive_es5_sources,
-            dep.typescript.transitive_es5_sources,
-        ])
-        transitive_es6_sources = depset(transitive = [
-            transitive_es6_sources,
-            dep.typescript.transitive_es6_sources,
-        ])
-    elif not NodeModuleInfo in dep and hasattr(dep, "files"):
-        transitive_es5_sources = depset(transitive = [
-            transitive_es5_sources,
-            dep.files,
-        ])
-        transitive_es6_sources = depset(transitive = [
-            transitive_es6_sources,
-            dep.files,
-        ])
+    es5_sources = depset(ctx.files.srcs)
+    transitive_es5_sources = depset()
+    transitive_es6_sources = depset()
+    for dep in ctx.attr.deps:
+        if hasattr(dep, "typescript"):
+            transitive_es5_sources = depset(transitive = [
+                transitive_es5_sources,
+                dep.typescript.transitive_es5_sources,
+            ])
+            transitive_es6_sources = depset(transitive = [
+                transitive_es6_sources,
+                dep.typescript.transitive_es6_sources,
+            ])
+        elif not NodeModuleInfo in dep and hasattr(dep, "files"):
+            transitive_es5_sources = depset(transitive = [
+                transitive_es5_sources,
+                dep.files,
+            ])
+            transitive_es6_sources = depset(transitive = [
+                transitive_es6_sources,
+                dep.files,
+            ])
 
-  return struct(
-    es5_sources = es5_sources,
-    transitive_es5_sources = depset(transitive = [transitive_es5_sources, es5_sources]),
-    es6_sources = es5_sources,
-    transitive_es6_sources = depset(transitive = [transitive_es6_sources, es5_sources])
-  )
+    return struct(
+        es5_sources = es5_sources,
+        transitive_es5_sources = depset(transitive = [transitive_es5_sources, es5_sources]),
+        es6_sources = es5_sources,
+        transitive_es6_sources = depset(transitive = [transitive_es6_sources, es5_sources]),
+    )
 
 def _js_import(ctx):
     js = _collect_sources(ctx)

--- a/internal/node/test/js_import.bzl
+++ b/internal/node/test/js_import.bzl
@@ -1,0 +1,59 @@
+load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleInfo")
+
+def _collect_sources(ctx):
+  es5_sources = depset(ctx.files.srcs)
+  transitive_es5_sources = depset()
+  transitive_es6_sources = depset()
+  for dep in ctx.attr.deps:
+    if hasattr(dep, "typescript"):
+        transitive_es5_sources = depset(transitive = [
+            transitive_es5_sources,
+            dep.typescript.transitive_es5_sources,
+        ])
+        transitive_es6_sources = depset(transitive = [
+            transitive_es6_sources,
+            dep.typescript.transitive_es6_sources,
+        ])
+    elif not NodeModuleInfo in dep and hasattr(dep, "files"):
+        transitive_es5_sources = depset(transitive = [
+            transitive_es5_sources,
+            dep.files,
+        ])
+        transitive_es6_sources = depset(transitive = [
+            transitive_es6_sources,
+            dep.files,
+        ])
+
+  return struct(
+    es5_sources = es5_sources,
+    transitive_es5_sources = depset(transitive = [transitive_es5_sources, es5_sources]),
+    es6_sources = es5_sources,
+    transitive_es6_sources = depset(transitive = [transitive_es6_sources, es5_sources])
+  )
+
+def _js_import(ctx):
+    js = _collect_sources(ctx)
+    return struct(
+        typescript = struct(
+            es6_sources = js.es6_sources,
+            transitive_es6_sources = js.transitive_es6_sources,
+            es5_sources = js.es5_sources,
+            transitive_es5_sources = js.transitive_es5_sources,
+        ),
+        legacy_info = struct(
+            files = js.es5_sources,
+            tags = ctx.attr.tags,
+        ),
+        providers = [
+            DefaultInfo(files = js.es5_sources),
+        ],
+    )
+
+js_import = rule(
+    implementation = _js_import,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "deps": attr.label_list(allow_files = True),
+    },
+)
+"""Allow to test transtive depedency loading with nodejs_binary"""

--- a/internal/node/test/nodejs_binary_test.bzl
+++ b/internal/node/test/nodejs_binary_test.bzl
@@ -3,13 +3,17 @@
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@build_bazel_rules_nodejs//internal/node:node.bzl", "NodeJSRuntimeInfo", "nodejs_binary")
 
+def _or(expected, expected_or, actual):
+  return expected == actual or expected_or == actual
+
 def _provider_contents_test_impl(ctx):
     env = analysistest.begin(ctx)
     target_under_test = analysistest.target_under_test(env)
 
     # check toolchain
     asserts.equals(env, "File", type(target_under_test[NodeJSRuntimeInfo].toolchain))
-    asserts.equals(env, "external/nodejs/bin/nodejs/bin/node", target_under_test[NodeJSRuntimeInfo].toolchain.path)
+    correct_node_path = _or("external/nodejs/bin/nodejs/bin/node", "external/nodejs/bin/nodejs/bin/node.exe", target_under_test[NodeJSRuntimeInfo].toolchain.path)
+    asserts.true(env, correct_node_path)
     asserts.equals(env, True, target_under_test[NodeJSRuntimeInfo].toolchain.is_source)
     asserts.equals(env, False, target_under_test[NodeJSRuntimeInfo].toolchain.is_directory)
 

--- a/internal/node/test/nodejs_binary_test.bzl
+++ b/internal/node/test/nodejs_binary_test.bzl
@@ -1,30 +1,38 @@
 "Unit tests for node.bzl"
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest", "analysistest")
-load("@build_bazel_rules_nodejs//internal:node.bzl", "nodejs_binary", "NodeJSRuntimeInfo")
+load("@build_bazel_rules_nodejs//internal/node:node.bzl", "nodejs_binary", "NodeJSRuntimeInfo")
 
 def _provider_contents_test_impl(ctx):
   env = analysistest.begin(ctx)
   target_under_test = analysistest.target_under_test(env)
-  asserts.equals(env, "some value", target_under_test[NodeJSRuntimeInfo].val)
-  asserts.equals(env,
-      expected="some value",
-      actual=target_under_test[NodeJSRuntimeInfo].val)
+  # check toolchain
+  asserts.equals(env, "File", type(target_under_test[NodeJSRuntimeInfo].toolchain))
+  asserts.equals(env, "external/nodejs/bin/nodejs/bin/node", target_under_test[NodeJSRuntimeInfo].toolchain.path)
+  asserts.equals(env, True, target_under_test[NodeJSRuntimeInfo].toolchain.is_source)
+  asserts.equals(env, False, target_under_test[NodeJSRuntimeInfo].toolchain.is_directory)
+
+  # print(dir(target_under_test))
+
+  # check sources
+  # asserts.equals(env, "depset", type(target_under_test[NodeJSRuntimeInfo].sources))
+  # asserts.equals(env, 1, len(target_under_test[NodeJSRuntimeInfo].sources.to_list()))
+  # asserts.equals(env, target_under_test.files, target_under_test[NodeJSRuntimeInfo].sources)
   return analysistest.end(env)
 
 provider_contents_test = analysistest.make(_provider_contents_test_impl)
 
 def test_nodejs_runtime_info_contents():
-    # Rule under test.
-    myrule(name = "provider_contents_subject")
-    # Testing rule.
+    nodejs_binary(
+      name = "nodejs_runtime_info_test",
+      data = [":has-deps.js"],
+      entry_point = ":has-deps.js",
+    )
     provider_contents_test(name = "provider_contents",
-                          target_under_test = ":provider_contents_subject")
-    # Note the target_under_test attribute is how the test rule depends on
-    # the real rule target.
+                          target_under_test = ":nodejs_runtime_info_test")
 
-def nodejs_runtime_info_test_suite():
-    test_provider_contents()
+def nodejs_binary_test_suite():
+    test_nodejs_runtime_info_contents()
 
     native.test_suite(
         name = "nodejs_binary_test",

--- a/internal/node/test/nodejs_binary_test.bzl
+++ b/internal/node/test/nodejs_binary_test.bzl
@@ -22,41 +22,41 @@ def _provider_contents_test_impl(ctx):
     asserts.equals(env, False, target_under_test[NodeJSRuntimeInfo].toolchain.is_directory)
 
     # check sources
-    asserts.equals(env, 'depset', type(target_under_test[NodeJSRuntimeInfo].sources))
+    asserts.equals(env, "depset", type(target_under_test[NodeJSRuntimeInfo].sources))
     asserts.equals(env, ctx.files.data, target_under_test[NodeJSRuntimeInfo].sources.to_list())
 
     # check node_modules
-    asserts.equals(env, 'depset', type(target_under_test[NodeJSRuntimeInfo].node_modules))
+    asserts.equals(env, "depset", type(target_under_test[NodeJSRuntimeInfo].node_modules))
     asserts.equals(env, [], target_under_test[NodeJSRuntimeInfo].node_modules.to_list())
 
     # check node_runfiles
     actions = analysistest.target_actions(env)
     action_output = actions[0].outputs.to_list()[0]
-    asserts.equals(env, 'depset', type(target_under_test[NodeJSRuntimeInfo].node_runfiles))
+    asserts.equals(env, "depset", type(target_under_test[NodeJSRuntimeInfo].node_runfiles))
     node_runfiles = [action_output, ctx.file._repository_args] + ctx.files._source_map_support_files
-    asserts.equals(env, , target_under_test[NodeJSRuntimeInfo].node_runfiles.to_list())
+    asserts.equals(env, node_runfiles, target_under_test[NodeJSRuntimeInfo].node_runfiles.to_list())
     return analysistest.end(env)
 
 provider_contents_test = analysistest.make(
-  _provider_contents_test_impl,
-  attrs = {
-    "data": attr.label_list(
-      allow_files = True,
-      default = [Label("//internal/node/test:has-deps.js")]
-    ),
-    "_repository_args": attr.label(
-        default = Label("@nodejs//:bin/node_repo_args.sh"),
-        allow_single_file = True,
-    ),
-    "_source_map_support_files": attr.label_list(
-        default = [
-            Label("@build_bazel_rules_nodejs//third_party/github.com/buffer-from:contents"),
-            Label("@build_bazel_rules_nodejs//third_party/github.com/source-map:contents"),
-            Label("@build_bazel_rules_nodejs//third_party/github.com/source-map-support:contents"),
-        ],
-        allow_files = True,
-    ),
-  }
+    _provider_contents_test_impl,
+    attrs = {
+        "data": attr.label_list(
+            allow_files = True,
+            default = [Label("//internal/node/test:has-deps.js")],
+        ),
+        "_repository_args": attr.label(
+            default = Label("@nodejs//:bin/node_repo_args.sh"),
+            allow_single_file = True,
+        ),
+        "_source_map_support_files": attr.label_list(
+            default = [
+                Label("@build_bazel_rules_nodejs//third_party/github.com/buffer-from:contents"),
+                Label("@build_bazel_rules_nodejs//third_party/github.com/source-map:contents"),
+                Label("@build_bazel_rules_nodejs//third_party/github.com/source-map-support:contents"),
+            ],
+            allow_files = True,
+        ),
+    },
 )
 
 def test_nodejs_runtime_info_contents():

--- a/internal/node/test/nodejs_binary_test.bzl
+++ b/internal/node/test/nodejs_binary_test.bzl
@@ -4,7 +4,7 @@ load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@build_bazel_rules_nodejs//internal/node:node.bzl", "NodeJSRuntimeInfo", "nodejs_binary")
 
 def _or(expected, expected_or, actual):
-  return expected == actual or expected_or == actual
+    return expected == actual or expected_or == actual
 
 def _provider_contents_test_impl(ctx):
     env = analysistest.begin(ctx)
@@ -12,7 +12,11 @@ def _provider_contents_test_impl(ctx):
 
     # check toolchain
     asserts.equals(env, "File", type(target_under_test[NodeJSRuntimeInfo].toolchain))
-    correct_node_path = _or("external/nodejs/bin/nodejs/bin/node", "external/nodejs/bin/nodejs/bin/node.exe", target_under_test[NodeJSRuntimeInfo].toolchain.path)
+    correct_node_path = _or(
+        "external/nodejs/bin/nodejs/bin/node",
+        "external/nodejs/bin/nodejs/bin/node.exe",
+        target_under_test[NodeJSRuntimeInfo].toolchain.path,
+    )
     asserts.true(env, correct_node_path)
     asserts.equals(env, True, target_under_test[NodeJSRuntimeInfo].toolchain.is_source)
     asserts.equals(env, False, target_under_test[NodeJSRuntimeInfo].toolchain.is_directory)
@@ -20,7 +24,8 @@ def _provider_contents_test_impl(ctx):
     # print(dir(target_under_test))
 
     # check sources
-    # asserts.equals(env, "depset", type(target_under_test[NodeJSRuntimeInfo].sources))
+    asserts.equals(env, "depset", type(target_under_test[NodeJSRuntimeInfo].sources))
+
     # asserts.equals(env, 1, len(target_under_test[NodeJSRuntimeInfo].sources.to_list()))
     # asserts.equals(env, target_under_test.files, target_under_test[NodeJSRuntimeInfo].sources)
     return analysistest.end(env)

--- a/internal/node/test/nodejs_binary_test.bzl
+++ b/internal/node/test/nodejs_binary_test.bzl
@@ -13,7 +13,7 @@ def _provider_contents_test_impl(ctx):
 
     # check sources
     asserts.equals(env, "depset", type(target_under_test[NodeJSRuntimeInfo].sources))
-    asserts.equals(env, ctx.files.my_sources, target_under_test[NodeJSRuntimeInfo].sources.to_list())
+    asserts.equals(env, ctx.files.sources, target_under_test[NodeJSRuntimeInfo].sources.to_list())
 
     # check node_modules
     asserts.equals(env, "depset", type(target_under_test[NodeJSRuntimeInfo].node_modules))
@@ -30,10 +30,6 @@ def _provider_contents_test_impl(ctx):
 provider_contents_test = analysistest.make(
     _provider_contents_test_impl,
     attrs = {
-        "my_sources": attr.label_list(
-            allow_files = True,
-            default = [Label("//internal/node/test:has-deps.js")],
-        ),
         "node_modules": attr.label_list(
             allow_files = True,
             default = [Label("@fine_grained_deps_yarn//typescript")],
@@ -41,6 +37,10 @@ provider_contents_test = analysistest.make(
         "node": attr.label(
             default = Label("@nodejs//:node_bin"),
             allow_single_file = True,
+        ),
+        "sources": attr.label_list(
+            allow_files = True,
+            default = [Label("//internal/node/test:has-deps.js")],
         ),
         "_repository_args": attr.label(
             default = Label("@nodejs//:bin/node_repo_args.sh"),

--- a/internal/node/test/nodejs_binary_test.bzl
+++ b/internal/node/test/nodejs_binary_test.bzl
@@ -13,11 +13,11 @@ def _provider_contents_test_impl(ctx):
 
     # check sources
     asserts.equals(env, "depset", type(target_under_test[NodeJSRuntimeInfo].sources))
-    asserts.equals(env, ctx.files.data, target_under_test[NodeJSRuntimeInfo].sources.to_list())
+    asserts.equals(env, ctx.files.my_sources, target_under_test[NodeJSRuntimeInfo].sources.to_list())
 
     # check node_modules
     asserts.equals(env, "depset", type(target_under_test[NodeJSRuntimeInfo].node_modules))
-    asserts.equals(env, [], target_under_test[NodeJSRuntimeInfo].node_modules.to_list())
+    asserts.equals(env, ctx.files.node_modules, target_under_test[NodeJSRuntimeInfo].node_modules.to_list())
 
     # check node_runfiles
     actions = analysistest.target_actions(env)
@@ -30,9 +30,13 @@ def _provider_contents_test_impl(ctx):
 provider_contents_test = analysistest.make(
     _provider_contents_test_impl,
     attrs = {
-        "data": attr.label_list(
+        "my_sources": attr.label_list(
             allow_files = True,
             default = [Label("//internal/node/test:has-deps.js")],
+        ),
+        "node_modules": attr.label_list(
+            allow_files = True,
+            default = [Label("@fine_grained_deps_yarn//typescript")],
         ),
         "node": attr.label(
           default = Label("@nodejs//:node_bin"),
@@ -56,7 +60,10 @@ provider_contents_test = analysistest.make(
 def test_nodejs_runtime_info_contents():
     nodejs_binary(
         name = "nodejs_runtime_info_test",
-        data = [":has-deps.js"],
+        data = [
+          ":has-deps.js",
+          "@fine_grained_deps_yarn//typescript",
+        ],
         entry_point = ":has-deps.js",
     )
     provider_contents_test(

--- a/internal/node/test/nodejs_binary_test.bzl
+++ b/internal/node/test/nodejs_binary_test.bzl
@@ -21,9 +21,9 @@ _DEFAULT_ATTRS = {
         allow_files = True,
     ),
     "_bash": attr.label(
-      default = "@bazel_tools//tools/bash/runfiles",
-      allow_single_file = True,
-    )
+        default = "@bazel_tools//tools/bash/runfiles",
+        allow_single_file = True,
+    ),
 }
 
 def _provider_contents_test_impl(ctx):
@@ -80,8 +80,8 @@ transitive_provider_contents_test = analysistest.make(
         "sources": attr.label_list(
             allow_files = True,
             default = [
-              Label("//internal/node/test:transitive-deps.js"),
-              Label("//internal/node/test:has-deps.js"),
+                Label("//internal/node/test:transitive-deps.js"),
+                Label("//internal/node/test:has-deps.js"),
             ],
         ),
     }),
@@ -94,8 +94,8 @@ def test_nodejs_runtime_info_contents():
     )
 
     transitive_provider_contents_test(
-      name = "transitive_provider_contents_test",
-      target_under_test = ":transitive_deps_bin"
+        name = "transitive_provider_contents_test",
+        target_under_test = ":transitive_deps_bin",
     )
 
 def nodejs_binary_test_suite():

--- a/internal/node/test/nodejs_binary_test.bzl
+++ b/internal/node/test/nodejs_binary_test.bzl
@@ -1,0 +1,34 @@
+"Unit tests for node.bzl"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest", "analysistest")
+load("@build_bazel_rules_nodejs//internal:node.bzl", "nodejs_binary", "NodeJSRuntimeInfo")
+
+def _provider_contents_test_impl(ctx):
+  env = analysistest.begin(ctx)
+  target_under_test = analysistest.target_under_test(env)
+  asserts.equals(env, "some value", target_under_test[NodeJSRuntimeInfo].val)
+  asserts.equals(env,
+      expected="some value",
+      actual=target_under_test[NodeJSRuntimeInfo].val)
+  return analysistest.end(env)
+
+provider_contents_test = analysistest.make(_provider_contents_test_impl)
+
+def test_nodejs_runtime_info_contents():
+    # Rule under test.
+    myrule(name = "provider_contents_subject")
+    # Testing rule.
+    provider_contents_test(name = "provider_contents",
+                          target_under_test = ":provider_contents_subject")
+    # Note the target_under_test attribute is how the test rule depends on
+    # the real rule target.
+
+def nodejs_runtime_info_test_suite():
+    test_provider_contents()
+
+    native.test_suite(
+        name = "nodejs_binary_test",
+        tests = [
+            ":provider_contents",
+        ],
+  )

--- a/internal/node/test/nodejs_binary_test.bzl
+++ b/internal/node/test/nodejs_binary_test.bzl
@@ -1,35 +1,38 @@
 "Unit tests for node.bzl"
 
-load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest", "analysistest")
-load("@build_bazel_rules_nodejs//internal/node:node.bzl", "nodejs_binary", "NodeJSRuntimeInfo")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@build_bazel_rules_nodejs//internal/node:node.bzl", "NodeJSRuntimeInfo", "nodejs_binary")
 
 def _provider_contents_test_impl(ctx):
-  env = analysistest.begin(ctx)
-  target_under_test = analysistest.target_under_test(env)
-  # check toolchain
-  asserts.equals(env, "File", type(target_under_test[NodeJSRuntimeInfo].toolchain))
-  asserts.equals(env, "external/nodejs/bin/nodejs/bin/node", target_under_test[NodeJSRuntimeInfo].toolchain.path)
-  asserts.equals(env, True, target_under_test[NodeJSRuntimeInfo].toolchain.is_source)
-  asserts.equals(env, False, target_under_test[NodeJSRuntimeInfo].toolchain.is_directory)
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
 
-  # print(dir(target_under_test))
+    # check toolchain
+    asserts.equals(env, "File", type(target_under_test[NodeJSRuntimeInfo].toolchain))
+    asserts.equals(env, "external/nodejs/bin/nodejs/bin/node", target_under_test[NodeJSRuntimeInfo].toolchain.path)
+    asserts.equals(env, True, target_under_test[NodeJSRuntimeInfo].toolchain.is_source)
+    asserts.equals(env, False, target_under_test[NodeJSRuntimeInfo].toolchain.is_directory)
 
-  # check sources
-  # asserts.equals(env, "depset", type(target_under_test[NodeJSRuntimeInfo].sources))
-  # asserts.equals(env, 1, len(target_under_test[NodeJSRuntimeInfo].sources.to_list()))
-  # asserts.equals(env, target_under_test.files, target_under_test[NodeJSRuntimeInfo].sources)
-  return analysistest.end(env)
+    # print(dir(target_under_test))
+
+    # check sources
+    # asserts.equals(env, "depset", type(target_under_test[NodeJSRuntimeInfo].sources))
+    # asserts.equals(env, 1, len(target_under_test[NodeJSRuntimeInfo].sources.to_list()))
+    # asserts.equals(env, target_under_test.files, target_under_test[NodeJSRuntimeInfo].sources)
+    return analysistest.end(env)
 
 provider_contents_test = analysistest.make(_provider_contents_test_impl)
 
 def test_nodejs_runtime_info_contents():
     nodejs_binary(
-      name = "nodejs_runtime_info_test",
-      data = [":has-deps.js"],
-      entry_point = ":has-deps.js",
+        name = "nodejs_runtime_info_test",
+        data = [":has-deps.js"],
+        entry_point = ":has-deps.js",
     )
-    provider_contents_test(name = "provider_contents",
-                          target_under_test = ":nodejs_runtime_info_test")
+    provider_contents_test(
+        name = "provider_contents",
+        target_under_test = ":nodejs_runtime_info_test",
+    )
 
 def nodejs_binary_test_suite():
     test_nodejs_runtime_info_contents()
@@ -39,4 +42,4 @@ def nodejs_binary_test_suite():
         tests = [
             ":provider_contents",
         ],
-  )
+    )

--- a/internal/node/test/nodejs_binary_test.bzl
+++ b/internal/node/test/nodejs_binary_test.bzl
@@ -8,6 +8,10 @@ _DEFAULT_ATTRS = {
         default = Label("@nodejs//:node_bin"),
         allow_single_file = True,
     ),
+    "_bash": attr.label(
+        default = "@bazel_tools//tools/bash/runfiles",
+        allow_single_file = True,
+    ),
     "_repository_args": attr.label(
         default = Label("@nodejs//:bin/node_repo_args.sh"),
         allow_single_file = True,
@@ -19,10 +23,6 @@ _DEFAULT_ATTRS = {
             Label("//third_party/github.com/source-map-support:contents"),
         ],
         allow_files = True,
-    ),
-    "_bash": attr.label(
-        default = "@bazel_tools//tools/bash/runfiles",
-        allow_single_file = True,
     ),
 }
 

--- a/internal/node/test/nodejs_binary_test.bzl
+++ b/internal/node/test/nodejs_binary_test.bzl
@@ -21,16 +21,43 @@ def _provider_contents_test_impl(ctx):
     asserts.equals(env, True, target_under_test[NodeJSRuntimeInfo].toolchain.is_source)
     asserts.equals(env, False, target_under_test[NodeJSRuntimeInfo].toolchain.is_directory)
 
-    # print(dir(target_under_test))
-
     # check sources
-    asserts.equals(env, "depset", type(target_under_test[NodeJSRuntimeInfo].sources))
+    asserts.equals(env, 'depset', type(target_under_test[NodeJSRuntimeInfo].sources))
+    asserts.equals(env, ctx.files.data, target_under_test[NodeJSRuntimeInfo].sources.to_list())
 
-    # asserts.equals(env, 1, len(target_under_test[NodeJSRuntimeInfo].sources.to_list()))
-    # asserts.equals(env, target_under_test.files, target_under_test[NodeJSRuntimeInfo].sources)
+    # check node_modules
+    asserts.equals(env, 'depset', type(target_under_test[NodeJSRuntimeInfo].node_modules))
+    asserts.equals(env, [], target_under_test[NodeJSRuntimeInfo].node_modules.to_list())
+
+    # check node_runfiles
+    actions = analysistest.target_actions(env)
+    action_output = actions[0].outputs.to_list()[0]
+    asserts.equals(env, 'depset', type(target_under_test[NodeJSRuntimeInfo].node_runfiles))
+    node_runfiles = [action_output, ctx.file._repository_args] + ctx.files._source_map_support_files
+    asserts.equals(env, , target_under_test[NodeJSRuntimeInfo].node_runfiles.to_list())
     return analysistest.end(env)
 
-provider_contents_test = analysistest.make(_provider_contents_test_impl)
+provider_contents_test = analysistest.make(
+  _provider_contents_test_impl,
+  attrs = {
+    "data": attr.label_list(
+      allow_files = True,
+      default = [Label("//internal/node/test:has-deps.js")]
+    ),
+    "_repository_args": attr.label(
+        default = Label("@nodejs//:bin/node_repo_args.sh"),
+        allow_single_file = True,
+    ),
+    "_source_map_support_files": attr.label_list(
+        default = [
+            Label("@build_bazel_rules_nodejs//third_party/github.com/buffer-from:contents"),
+            Label("@build_bazel_rules_nodejs//third_party/github.com/source-map:contents"),
+            Label("@build_bazel_rules_nodejs//third_party/github.com/source-map-support:contents"),
+        ],
+        allow_files = True,
+    ),
+  }
+)
 
 def test_nodejs_runtime_info_contents():
     nodejs_binary(

--- a/internal/node/test/nodejs_binary_test.bzl
+++ b/internal/node/test/nodejs_binary_test.bzl
@@ -39,8 +39,8 @@ provider_contents_test = analysistest.make(
             default = [Label("@fine_grained_deps_yarn//typescript")],
         ),
         "node": attr.label(
-          default = Label("@nodejs//:node_bin"),
-          allow_single_file = True,
+            default = Label("@nodejs//:node_bin"),
+            allow_single_file = True,
         ),
         "_repository_args": attr.label(
             default = Label("@nodejs//:bin/node_repo_args.sh"),
@@ -61,8 +61,8 @@ def test_nodejs_runtime_info_contents():
     nodejs_binary(
         name = "nodejs_runtime_info_test",
         data = [
-          ":has-deps.js",
-          "@fine_grained_deps_yarn//typescript",
+            ":has-deps.js",
+            "@fine_grained_deps_yarn//typescript",
         ],
         entry_point = ":has-deps.js",
     )

--- a/internal/node/test/nodejs_binary_test.bzl
+++ b/internal/node/test/nodejs_binary_test.bzl
@@ -30,13 +30,13 @@ def _provider_contents_test_impl(ctx):
 provider_contents_test = analysistest.make(
     _provider_contents_test_impl,
     attrs = {
-        "node_modules": attr.label_list(
-            allow_files = True,
-            default = [Label("@fine_grained_deps_yarn//typescript")],
-        ),
         "node": attr.label(
             default = Label("@nodejs//:node_bin"),
             allow_single_file = True,
+        ),
+        "node_modules": attr.label_list(
+            allow_files = True,
+            default = [Label("@fine_grained_deps_yarn//typescript")],
         ),
         "sources": attr.label_list(
             allow_files = True,

--- a/internal/node/test/transitive-deps.js
+++ b/internal/node/test/transitive-deps.js
@@ -1,0 +1,3 @@
+require('./has-deps');
+
+console.log('Imported dep transitively.');

--- a/package.bzl
+++ b/package.bzl
@@ -74,12 +74,12 @@ def rules_nodejs_dev_dependencies():
         url = "https://github.com/bazelbuild/skydoc/archive/0.3.0.tar.gz",
     )
 
-    # bazel-skylib 0.8.0 released 2019.03.20 (https://github.com/bazelbuild/bazel-skylib/releases/tag/0.8.0)
+    # bazel-skylib master 2019.05.03 to get support for https://github.com/bazelbuild/bazel-skylib/pull/140
     http_archive(
         name = "bazel_skylib",
-        type = "tar.gz",
-        url = "https://github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz",
-        sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
+        sha256 = "afbe4d9d033c007940acd24bb9becf1580a0280ae0b2ebbb5a7cb12912d2c115",
+        strip_prefix = "bazel-skylib-ffad33e9bfc60bdfa98292ca655a4e7035792046",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/ffad33e9bfc60bdfa98292ca655a4e7035792046.tar.gz"],
     )
 
     # Needed for Remote Build Execution


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
When using `nodejs_image` of `rules_docker` there currently was no way for it to put the npm modules and source files into different layers so even if just changes are being made to the source files incremental rebuilds will have to repack all of node_modules which can be quite slow. In our app a rebuild could take up to 10s.

## What is the new behavior?
We now expose a provider that other rules can access the needed `nodejs_binary` runfiles separately, split by its toolchain (i.e. the node binary), node_modules, source files and all other necessary/implicit runfiles. This would allow for `nodejs_image´ to create dedicated layers and in my tests it brought incremental builds, where just source files changed, down to ~3s.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

This replaces #283 as it has gotten stale by now but also updates the provider to be compatible with the upcoming toolchain support.
