### PR TITLE
build: switch to upstream rules_typescript commit

### DIFF
--- a/packages/typescript/WORKSPACE
+++ b/packages/typescript/WORKSPACE
@@ -38,11 +38,10 @@ rules_nodejs_dev_dependencies()
 
 # We use git_repository since Renovate knows how to update it.
 # With http_archive it only sees releases/download/*.tar.gz urls
-# TODO(gregmagolan): switch back to upstream
 git_repository(
     name = "build_bazel_rules_typescript",
-    commit = "a0cd838f80a70a65f6f82b0fa2bf5812ffc6a1ef",
-    remote = "http://github.com/gregmagolan/rules_typescript.git",
+    commit = "0efe29e17efee84f722326378b7585dac4f48784",
+    remote = "http://github.com/bazelbuild/rules_typescript.git",
 )
 
 # We have a source dependency on build_bazel_rules_typescript


### PR DESCRIPTION
Now that https://github.com/bazelbuild/rules_typescript/pull/458 has landed
