### PR TITLE
rollup_bundle/tsc: add --downlevelIteration

### DIFF
--- a/internal/rollup/rollup_bundle.bzl
+++ b/internal/rollup/rollup_bundle.bzl
@@ -245,6 +245,7 @@ def _run_tsc(ctx, input, output):
     args.add_all(["--target", "es5"])
     args.add_all(["--lib", "es2015,dom"])
     args.add("--allowJS")
+    args.add("--downlevelIteration")
     args.add(input.path)
     args.add_all(["--outFile", output.path])
 


### PR DESCRIPTION
This allows usage of for..of on iterators, even when targeting ES5.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

The following code gets mis-downleveled by tsc:
```
let foo = new Map();
for (const [k, v] of foo) {
    console.log(k, v);
}
```
into:
```
var foo = new Map();
for (var _i = 0, foo_1 = foo; _i < foo_1.length; _i++) {
    var _a = foo_1[_i], k = _a[0], v = _a[1];
    console.log(k, v);
}
```

because of https://github.com/Microsoft/TypeScript/issues/11209 .  This is broken code. 

Since `tsc` is hardcoded to target ES5, we should add this flag in order to prevent `rollup_bundle` from emitting broken code.

Issue Number: N/A

## What is the new behavior?

The sample code gets transpiled correctly:

```
var __values = (this && this.__values) || function (o) {
    var m = typeof Symbol === "function" && o[Symbol.iterator], i = 0;
    if (m) return m.call(o);
    return {
        next: function () {
            if (o && i >= o.length) o = void 0;
            return { value: o && o[i++], done: !o };
        }
    };
};
var __read = (this && this.__read) || function (o, n) {
    var m = typeof Symbol === "function" && o[Symbol.iterator];
    if (!m) return o;
    var i = m.call(o), r, ar = [], e;
    try {
        while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
    }
    catch (error) { e = { error: error }; }
    finally {
        try {
            if (r && !r.done && (m = i["return"])) m.call(i);
        }
        finally { if (e) throw e.error; }
    }
    return ar;
};
var e_1, _a;
var foo = new Map();
try {
    for (var foo_1 = __values(foo), foo_1_1 = foo_1.next(); !foo_1_1.done; foo_1_1 = foo_1.next()) {
        var _b = __read(foo_1_1.value, 2), k = _b[0], v = _b[1];
        console.log(k, v);
    }
}
catch (e_1_1) { e_1 = { error: e_1_1 }; }
finally {
    try {
        if (foo_1_1 && !foo_1_1.done && (_a = foo_1.return)) _a.call(foo_1);
    }
    finally { if (e_1) throw e_1.error; }
}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

