### PR TITLE
Update ts_proto_library to use ProtoInfo.

### DIFF
--- a/packages/typescript/internal/protobufjs/ts_proto_library.bzl
+++ b/packages/typescript/internal/protobufjs/ts_proto_library.bzl
@@ -70,14 +70,14 @@ def _run_pbts(actions, executable, js_file):
 def _ts_proto_library(ctx):
     sources = depset()
     for dep in ctx.attr.deps:
-        if not hasattr(dep, "proto"):
+        if ProtoInfo not in dep:
             fail("ts_proto_library dep %s must be a proto_library rule" % dep.label)
 
         # TODO(alexeagle): go/new-proto-library suggests
         # > should not parse .proto files. Instead, they should use the descriptor
         # > set output from proto_library
         # but protobuf.js doesn't seem to accept that bin format
-        sources = depset(transitive = [sources, dep.proto.transitive_sources])
+        sources = depset(transitive = [sources, dep[ProtoInfo].transitive_sources])
 
     output_name = ctx.attr.output_name or ctx.label.name
 


### PR DESCRIPTION
Instead of the deprecated .proto. provider .

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
`ts_proto_library` depends on the `.proto.` provider which is going to be removed in Bazel 1.0:
https://github.com/bazelbuild/bazel/issues/7152

Issue Number: https://github.com/bazelbuild/bazel/issues/7152



## What is the new behavior?
It uses the new `ProtoInfo` provider.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

