### PR TITLE
Use ANGULAR_PACKAGE magic file to detect APF

### DIFF
--- a/internal/npm_install/generate_build_file.js
+++ b/internal/npm_install/generate_build_file.js
@@ -694,6 +694,9 @@ function filterFiles(files, exts = []) {
  */
 function isNgApfPackage(pkg) {
   const set = new Set(pkg._files);
+  if (set.has('ANGULAR_PACKAGE')) {
+    return true;
+  }
   const metadataExt = /\.metadata\.json$/;
   return pkg._files.some((file) => {
     if (metadataExt.test(file)) {


### PR DESCRIPTION
`metadata.json` are no longer produced in Ivy mode, and this breaks the
detection logic for Angular Package Format (APF).
As a stop gap solution for the snapshot builds, use ANGULAR_PACKAGE
magic file in the package to detect APF.

Closes https://github.com/bazelbuild/rules_nodejs/issues/927

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

