### PR TITLE
Put release artifacts in /release folder as /dist is used by bazel

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,6 +1,7 @@
 node_modules
 internal/npm_install/test/node_modules
 dist
+release
 # Each e2e test is a nested workspace
 e2e/
 # Examples are tested by running examples/test_example.sh outside of Bazel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,15 +205,7 @@ jobs:
       - persist_to_workspace:
           root: ~/
           paths:
-            - ./rules_nodejs/dist/build_bazel_rules_nodejs
-            - ./rules_nodejs/dist/npm_bazel_typescript
-            - ./rules_nodejs/dist/npm_bazel_karma
-            - ./rules_nodejs/dist/npm_bazel_jasmine
-            - ./rules_nodejs/dist/npm_bazel_labs
-            - ./rules_nodejs/dist/npm_bazel_hide-bazel-files
-            - ./rules_nodejs/dist/npm_bazel_create
-            - ./rules_nodejs/dist/npm_bazel_protractor
-            - ./rules_nodejs/dist/npm_bazel_stylus
+            - ./rules_nodejs/release
 
   # This job cannot run on BuildKite (BazelCI) because it requires changing
   # directories to test inside nested workspaces.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 rules_nodejs-*.tar.gz
 dist
+release
 bazel-out
 /e2e/*/bazel-*
 /examples/*/bazel-*

--- a/e2e/bazel_bin/WORKSPACE
+++ b/e2e/bazel_bin/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "npm_install")

--- a/e2e/define_var/WORKSPACE
+++ b/e2e/define_var/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/jasmine/WORKSPACE
+++ b/e2e/jasmine/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/jasmine/package.json
+++ b/e2e/jasmine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "e2e-jasmine",
   "dependencies": {
-    "@bazel/jasmine": "file:../../dist/npm_bazel_jasmine",
+    "@bazel/jasmine": "file:../../release/npm_bazel_jasmine",
     "zone.js": "0.8.29"
   },
   "//": "Include an incompatible jasmine as a devDependency to verify that jasmine_node_test works regardless",

--- a/e2e/jasmine/yarn.lock
+++ b/e2e/jasmine/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@bazel/jasmine@file:../../dist/npm_bazel_jasmine":
+"@bazel/jasmine@file:../../release/npm_bazel_jasmine":
   version "1.2.3"
   dependencies:
     jasmine "~3.4.0"

--- a/e2e/karma/WORKSPACE
+++ b/e2e/karma/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/karma/package.json
+++ b/e2e/karma/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@bazel/karma": "file:../../dist/npm_bazel_karma",
+    "@bazel/karma": "file:../../release/npm_bazel_karma",
     "karma": "3.0.0"
   },
   "scripts": {

--- a/e2e/karma/yarn.lock
+++ b/e2e/karma/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@bazel/karma@file:../../dist/npm_bazel_karma":
+"@bazel/karma@file:../../release/npm_bazel_karma":
   version "1.2.3"
   dependencies:
     jasmine-core "2.8.0"

--- a/e2e/karma_stack_trace/WORKSPACE
+++ b/e2e/karma_stack_trace/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/karma_stack_trace/package.json
+++ b/e2e/karma_stack_trace/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@bazel/karma": "file:../../dist/npm_bazel_karma",
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/karma": "file:../../release/npm_bazel_karma",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "@types/jasmine": "2.8.2",
     "typescript": "3.1.x"
   },

--- a/e2e/karma_stack_trace/yarn.lock
+++ b/e2e/karma_stack_trace/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@bazel/karma@file:../../dist/npm_bazel_karma":
+"@bazel/karma@file:../../release/npm_bazel_karma":
   version "1.2.3"
   dependencies:
     jasmine-core "2.8.0"
@@ -17,7 +17,7 @@
     semver "5.6.0"
     tmp "0.0.33"
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/e2e/karma_typescript/WORKSPACE
+++ b/e2e/karma_typescript/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/karma_typescript/package.json
+++ b/e2e/karma_typescript/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@bazel/karma": "file:../../dist/npm_bazel_karma",
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/karma": "file:../../release/npm_bazel_karma",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "@types/jasmine": "^3.3.12",
     "jasmine": "^3.4.0",
     "rxjs": "6.5.0",

--- a/e2e/karma_typescript/yarn.lock
+++ b/e2e/karma_typescript/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@bazel/karma@file:../../dist/npm_bazel_karma":
+"@bazel/karma@file:../../release/npm_bazel_karma":
   version "1.2.3"
   dependencies:
     jasmine-core "2.8.0"
@@ -17,7 +17,7 @@
     semver "5.6.0"
     tmp "0.0.33"
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/e2e/stylus/WORKSPACE
+++ b/e2e/stylus/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/stylus/package.json
+++ b/e2e/stylus/package.json
@@ -2,7 +2,7 @@
     "name": "e2e-stylus",
     "private": true,
     "devDependencies": {
-        "@bazel/stylus": "file:../../dist/npm_bazel_stylus"
+        "@bazel/stylus": "file:../../release/npm_bazel_stylus"
     },
     "scripts": {
       "test": "bazel test ..."

--- a/e2e/stylus/yarn.lock
+++ b/e2e/stylus/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@bazel/stylus@file:../../dist/npm_bazel_stylus":
+"@bazel/stylus@file:../../release/npm_bazel_stylus":
   version "1.2.3"
   dependencies:
     stylus "~0.54.5"

--- a/e2e/symlinked_node_modules_npm/WORKSPACE
+++ b/e2e/symlinked_node_modules_npm/WORKSPACE
@@ -5,7 +5,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "npm_install")

--- a/e2e/symlinked_node_modules_yarn/WORKSPACE
+++ b/e2e/symlinked_node_modules_yarn/WORKSPACE
@@ -5,7 +5,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/symlinked_node_modules_yarn/package.json
+++ b/e2e/symlinked_node_modules_yarn/package.json
@@ -4,7 +4,7 @@
     "typescript": "2.9.1"
   },
   "devDependencies": {
-    "@bazel/hide-bazel-files": "file:../../dist/npm_bazel_hide-bazel-files"
+    "@bazel/hide-bazel-files": "file:../../release/npm_bazel_hide-bazel-files"
   },
   "scripts": {
     "test": "bazel test ... && rm -rf node_modules && bazel test ... && rm -rf node_modules && yarn install && yarn add @schematics/angular@8.0.0-beta.15 && bazel test ... && yarn remove @schematics/angular"

--- a/e2e/symlinked_node_modules_yarn/yarn.lock
+++ b/e2e/symlinked_node_modules_yarn/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@bazel/hide-bazel-files@file:../../dist/npm_bazel_hide-bazel-files":
+"@bazel/hide-bazel-files@file:../../release/npm_bazel_hide-bazel-files":
   version "1.2.3"
 
 rxjs@6.4.0:

--- a/e2e/ts_auto_deps/WORKSPACE
+++ b/e2e/ts_auto_deps/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/ts_auto_deps/package.json
+++ b/e2e/ts_auto_deps/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "typescript": "2.9.2"
   },
   "scripts": {

--- a/e2e/ts_auto_deps/yarn.lock
+++ b/e2e/ts_auto_deps/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/e2e/ts_devserver/WORKSPACE
+++ b/e2e/ts_devserver/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/ts_devserver/package.json
+++ b/e2e/ts_devserver/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@bazel/hide-bazel-files": "file:../../dist/npm_bazel_hide-bazel-files",
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/hide-bazel-files": "file:../../release/npm_bazel_hide-bazel-files",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "@types/jasmine": "2.8.2",
     "@types/node": "7.0.18",
     "concurrently": "^3.5.1",

--- a/e2e/ts_devserver/yarn.lock
+++ b/e2e/ts_devserver/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@bazel/hide-bazel-files@file:../../dist/npm_bazel_hide-bazel-files":
+"@bazel/hide-bazel-files@file:../../release/npm_bazel_hide-bazel-files":
   version "1.2.3"
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/e2e/ts_library/WORKSPACE
+++ b/e2e/ts_library/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/ts_library/package.json
+++ b/e2e/ts_library/package.json
@@ -1,8 +1,8 @@
 {
   "//": "When setting bazelOpts { tsickle: true }, you must also add a devDependency on the tsickle npm package",
   "dependencies": {
-    "@bazel/jasmine": "file:../../dist/npm_bazel_jasmine",
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/jasmine": "file:../../release/npm_bazel_jasmine",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "@types/hammerjs": "2.0.35",
     "@types/jasmine": "3.3.9",
     "@types/node": "11.11.2",

--- a/e2e/ts_library/yarn.lock
+++ b/e2e/ts_library/yarn.lock
@@ -2,14 +2,14 @@
 # yarn lockfile v1
 
 
-"@bazel/jasmine@file:../../dist/npm_bazel_jasmine":
+"@bazel/jasmine@file:../../release/npm_bazel_jasmine":
   version "1.2.3"
   dependencies:
     jasmine "~3.4.0"
     jasmine-core "~3.4.0"
     v8-coverage "1.0.9"
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/e2e/tsconfig_extends/WORKSPACE
+++ b/e2e/tsconfig_extends/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/tsconfig_extends/package.json
+++ b/e2e/tsconfig_extends/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "typescript": "^3.3.1"
   },
   "scripts": {

--- a/e2e/tsconfig_extends/yarn.lock
+++ b/e2e/tsconfig_extends/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/e2e/typescript_2.7/WORKSPACE
+++ b/e2e/typescript_2.7/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/typescript_2.7/package.json
+++ b/e2e/typescript_2.7/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@bazel/jasmine": "file:../../dist/npm_bazel_jasmine",
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/jasmine": "file:../../release/npm_bazel_jasmine",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "@types/jasmine": "2.8.2",
     "@types/node": "7.0.18",
     "typescript": "2.7.x"

--- a/e2e/typescript_2.7/yarn.lock
+++ b/e2e/typescript_2.7/yarn.lock
@@ -2,14 +2,14 @@
 # yarn lockfile v1
 
 
-"@bazel/jasmine@file:../../dist/npm_bazel_jasmine":
+"@bazel/jasmine@file:../../release/npm_bazel_jasmine":
   version "1.2.3"
   dependencies:
     jasmine "~3.4.0"
     jasmine-core "~3.4.0"
     v8-coverage "1.0.9"
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/e2e/typescript_2.8/WORKSPACE
+++ b/e2e/typescript_2.8/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/typescript_2.8/package.json
+++ b/e2e/typescript_2.8/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@bazel/jasmine": "file:../../dist/npm_bazel_jasmine",
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/jasmine": "file:../../release/npm_bazel_jasmine",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "@types/jasmine": "2.8.2",
     "@types/node": "7.0.18",
     "typescript": "2.8.x"

--- a/e2e/typescript_2.8/yarn.lock
+++ b/e2e/typescript_2.8/yarn.lock
@@ -2,14 +2,14 @@
 # yarn lockfile v1
 
 
-"@bazel/jasmine@file:../../dist/npm_bazel_jasmine":
+"@bazel/jasmine@file:../../release/npm_bazel_jasmine":
   version "1.2.3"
   dependencies:
     jasmine "~3.4.0"
     jasmine-core "~3.4.0"
     v8-coverage "1.0.9"
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/e2e/typescript_2.9/WORKSPACE
+++ b/e2e/typescript_2.9/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/typescript_2.9/package.json
+++ b/e2e/typescript_2.9/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@bazel/jasmine": "file:../../dist/npm_bazel_jasmine",
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/jasmine": "file:../../release/npm_bazel_jasmine",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "@types/jasmine": "2.8.2",
     "@types/node": "7.0.18",
     "typescript": "2.9.x"

--- a/e2e/typescript_2.9/yarn.lock
+++ b/e2e/typescript_2.9/yarn.lock
@@ -2,14 +2,14 @@
 # yarn lockfile v1
 
 
-"@bazel/jasmine@file:../../dist/npm_bazel_jasmine":
+"@bazel/jasmine@file:../../release/npm_bazel_jasmine":
   version "1.2.3"
   dependencies:
     jasmine "~3.4.0"
     jasmine-core "~3.4.0"
     v8-coverage "1.0.9"
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/e2e/typescript_3.0/WORKSPACE
+++ b/e2e/typescript_3.0/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/typescript_3.0/package.json
+++ b/e2e/typescript_3.0/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@bazel/jasmine": "file:../../dist/npm_bazel_jasmine",
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/jasmine": "file:../../release/npm_bazel_jasmine",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "@types/jasmine": "2.8.2",
     "@types/node": "7.0.18",
     "typescript": "3.0.x"

--- a/e2e/typescript_3.0/yarn.lock
+++ b/e2e/typescript_3.0/yarn.lock
@@ -2,14 +2,14 @@
 # yarn lockfile v1
 
 
-"@bazel/jasmine@file:../../dist/npm_bazel_jasmine":
+"@bazel/jasmine@file:../../release/npm_bazel_jasmine":
   version "1.2.3"
   dependencies:
     jasmine "~3.4.0"
     jasmine-core "~3.4.0"
     v8-coverage "1.0.9"
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/e2e/typescript_3.1/WORKSPACE
+++ b/e2e/typescript_3.1/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/typescript_3.1/package.json
+++ b/e2e/typescript_3.1/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@bazel/jasmine": "file:../../dist/npm_bazel_jasmine",
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/jasmine": "file:../../release/npm_bazel_jasmine",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "@types/jasmine": "2.8.2",
     "@types/node": "7.0.18",
     "date-fns": "^1.30.1",

--- a/e2e/typescript_3.1/yarn.lock
+++ b/e2e/typescript_3.1/yarn.lock
@@ -2,14 +2,14 @@
 # yarn lockfile v1
 
 
-"@bazel/jasmine@file:../../dist/npm_bazel_jasmine":
+"@bazel/jasmine@file:../../release/npm_bazel_jasmine":
   version "1.2.3"
   dependencies:
     jasmine "~3.4.0"
     jasmine-core "~3.4.0"
     v8-coverage "1.0.9"
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/e2e/webpack/WORKSPACE
+++ b/e2e/webpack/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/e2e/webpack/package.json
+++ b/e2e/webpack/package.json
@@ -2,8 +2,8 @@
     "name": "e2e-webpack",
     "private": true,
     "devDependencies": {
-        "@bazel/jasmine": "file:../../dist/npm_bazel_jasmine",
-        "@bazel/labs": "file:../../dist/npm_bazel_labs"
+        "@bazel/jasmine": "file:../../release/npm_bazel_jasmine",
+        "@bazel/labs": "file:../../release/npm_bazel_labs"
     },
     "scripts": {
       "test": "bazel test ..."

--- a/e2e/webpack/yarn.lock
+++ b/e2e/webpack/yarn.lock
@@ -2,14 +2,14 @@
 # yarn lockfile v1
 
 
-"@bazel/jasmine@file:../../dist/npm_bazel_jasmine":
+"@bazel/jasmine@file:../../release/npm_bazel_jasmine":
   version "1.2.3"
   dependencies:
     jasmine "~3.4.0"
     jasmine-core "~3.4.0"
     v8-coverage "1.0.9"
 
-"@bazel/labs@file:../../dist/npm_bazel_labs":
+"@bazel/labs@file:../../release/npm_bazel_labs":
   version "1.2.3"
   dependencies:
     webpack "~4.29.3"

--- a/examples/app/WORKSPACE
+++ b/examples/app/WORKSPACE
@@ -22,7 +22,7 @@ workspace(
 # repository with the rules_nodejs code and we want to test them together.
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -1,8 +1,8 @@
 {
   "devDependencies": {
-    "@bazel/hide-bazel-files": "file:../../dist/npm_bazel_hide-bazel-files",
-    "@bazel/protractor": "file:../../dist/npm_bazel_protractor",
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/hide-bazel-files": "file:../../release/npm_bazel_hide-bazel-files",
+    "@bazel/protractor": "file:../../release/npm_bazel_protractor",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "@types/jasmine": "3.3.15",
     "typescript": "2.7.x"
   },

--- a/examples/app/yarn.lock
+++ b/examples/app/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@bazel/hide-bazel-files@file:../../dist/npm_bazel_hide-bazel-files":
+"@bazel/hide-bazel-files@file:../../release/npm_bazel_hide-bazel-files":
   version "1.2.3"
 
-"@bazel/protractor@file:../../dist/npm_bazel_protractor":
+"@bazel/protractor@file:../../release/npm_bazel_protractor":
   version "1.2.3"
   dependencies:
     protractor "^5.4.2"
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/examples/bazel_managed_deps/WORKSPACE
+++ b/examples/bazel_managed_deps/WORKSPACE
@@ -22,7 +22,7 @@ workspace(
 # repository with the rules_nodejs code and we want to test them together.
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/examples/nestjs/WORKSPACE
+++ b/examples/nestjs/WORKSPACE
@@ -22,7 +22,7 @@ workspace(
 # repository with the rules_nodejs code and we want to test them together.
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/examples/nestjs/package.json
+++ b/examples/nestjs/package.json
@@ -9,7 +9,7 @@
     "rxjs": "6.5.2"
   },
   "devDependencies": {
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "@types/node": "12.6.3",
     "typescript": "3.5.3"
   },

--- a/examples/nestjs/yarn.lock
+++ b/examples/nestjs/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/examples/parcel/WORKSPACE
+++ b/examples/parcel/WORKSPACE
@@ -22,7 +22,7 @@ workspace(
 # repository with the rules_nodejs code and we want to test them together.
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "npm_install")

--- a/examples/program/WORKSPACE
+++ b/examples/program/WORKSPACE
@@ -5,7 +5,7 @@ workspace(name = "examples_program")
 # repository with the rules_nodejs code and we want to test them together.
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")

--- a/examples/protocol_buffers/WORKSPACE
+++ b/examples/protocol_buffers/WORKSPACE
@@ -21,7 +21,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 http_archive(

--- a/examples/protocol_buffers/package.json
+++ b/examples/protocol_buffers/package.json
@@ -1,8 +1,8 @@
 {
   "devDependencies": {
-    "@bazel/hide-bazel-files": "file:../../dist/npm_bazel_hide-bazel-files",
-    "@bazel/karma": "file:../../dist/npm_bazel_karma",
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/hide-bazel-files": "file:../../release/npm_bazel_hide-bazel-files",
+    "@bazel/karma": "file:../../release/npm_bazel_karma",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "@types/jasmine": "2.8.2",
     "@types/long": "^4.0.0",
     "@types/node": "11.11.1",

--- a/examples/protocol_buffers/yarn.lock
+++ b/examples/protocol_buffers/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@bazel/hide-bazel-files@file:../../dist/npm_bazel_hide-bazel-files":
+"@bazel/hide-bazel-files@file:../../release/npm_bazel_hide-bazel-files":
   version "1.2.3"
 
-"@bazel/karma@file:../../dist/npm_bazel_karma":
+"@bazel/karma@file:../../release/npm_bazel_karma":
   version "1.2.3"
   dependencies:
     jasmine-core "2.8.0"
@@ -20,7 +20,7 @@
     semver "5.6.0"
     tmp "0.0.33"
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/examples/vendored_node/WORKSPACE
+++ b/examples/vendored_node/WORKSPACE
@@ -25,7 +25,7 @@ workspace(
 # repository with the rules_nodejs code and we want to test them together.
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "npm_install", "yarn_install")

--- a/examples/web_testing/WORKSPACE
+++ b/examples/web_testing/WORKSPACE
@@ -19,7 +19,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/examples/web_testing/package.json
+++ b/examples/web_testing/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
-    "@bazel/karma": "file:../../dist/npm_bazel_karma",
-    "@bazel/typescript": "file:../../dist/npm_bazel_typescript",
+    "@bazel/karma": "file:../../release/npm_bazel_karma",
+    "@bazel/typescript": "file:../../release/npm_bazel_typescript",
     "@types/jasmine": "2.8.2",
     "@types/node": "11.11.1",
     "karma-json-result-reporter": "1.0.0",

--- a/examples/web_testing/yarn.lock
+++ b/examples/web_testing/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@bazel/karma@file:../../dist/npm_bazel_karma":
+"@bazel/karma@file:../../release/npm_bazel_karma":
   version "1.2.3"
   dependencies:
     jasmine-core "2.8.0"
@@ -17,7 +17,7 @@
     semver "5.6.0"
     tmp "0.0.33"
 
-"@bazel/typescript@file:../../dist/npm_bazel_typescript":
+"@bazel/typescript@file:../../release/npm_bazel_typescript":
   version "1.2.3"
   dependencies:
     protobufjs "6.8.8"

--- a/examples/webapp/WORKSPACE
+++ b/examples/webapp/WORKSPACE
@@ -22,7 +22,7 @@ workspace(
 # repository with the rules_nodejs code and we want to test them together.
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../dist/build_bazel_rules_nodejs/release",
+    path = "../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/internal/e2e/fine_grained_symlinks/WORKSPACE
+++ b/internal/e2e/fine_grained_symlinks/WORKSPACE
@@ -5,7 +5,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../../dist/build_bazel_rules_nodejs/release",
+    path = "../../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")

--- a/internal/e2e/node_loader_no_preserve_symlinks/WORKSPACE
+++ b/internal/e2e/node_loader_no_preserve_symlinks/WORKSPACE
@@ -7,7 +7,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../../dist/build_bazel_rules_nodejs/release",
+    path = "../../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories", "yarn_install")

--- a/internal/e2e/node_loader_preserve_symlinks/WORKSPACE
+++ b/internal/e2e/node_loader_preserve_symlinks/WORKSPACE
@@ -7,7 +7,7 @@ workspace(
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../../dist/build_bazel_rules_nodejs/release",
+    path = "../../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")

--- a/internal/e2e/packages/WORKSPACE
+++ b/internal/e2e/packages/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "internal_e2e_packages")
 
 local_repository(
     name = "build_bazel_rules_nodejs",
-    path = "../../../dist/build_bazel_rules_nodejs/release",
+    path = "../../../release/build_bazel_rules_nodejs/release",
 )
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "check_rules_nodejs_version", "node_repositories")

--- a/scripts/build_packages.sh
+++ b/scripts/build_packages.sh
@@ -9,22 +9,22 @@ readonly PACKAGES=${@:?"No package names specified"}
 
 readonly RULES_NODEJS_DIR=$(cd $(dirname "$0")/..; pwd)
 readonly PACKAGES_DIR="${RULES_NODEJS_DIR}/packages"
-readonly DIST_DIR="${RULES_NODEJS_DIR}/dist"
+readonly RELEASE_DIR="${RULES_NODEJS_DIR}/release"
 
 echo_and_run() { echo "+ $@" ; "$@" ; }
 
 for package in ${PACKAGES[@]} ; do
   (
-    readonly DEST_DIR="${DIST_DIR}/npm_bazel_${package}"
+    readonly DEST_DIR="${RELEASE_DIR}/npm_bazel_${package}"
 
     # Build npm package
     printf "\n\nBuilding package ${package} //packages/${package}:npm_package\n"
     echo_and_run bazel build //packages/${package}:npm_package
 
-    # Copy the npm_package to /dist
+    # Copy the npm_package to /release
     echo "Copying npm package to ${DEST_DIR}"
     rm -rf ${DEST_DIR}
-    mkdir -p ${DIST_DIR}
+    mkdir -p ${RELEASE_DIR}
     readonly BAZEL_BIN=$(bazel info bazel-bin)
     echo_and_run cp -R "${BAZEL_BIN}/packages/${package}/npm_package" ${DEST_DIR}
     chmod -R u+w ${DEST_DIR}

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -6,8 +6,8 @@ set -eu -o pipefail
 # -o pipefail: causes a pipeline to produce a failure return code if any command errors
 
 readonly RULES_NODEJS_DIR=$(cd $(dirname "$0")/..; pwd)
-readonly DEST_DIR="${RULES_NODEJS_DIR}/dist/build_bazel_rules_nodejs"
-readonly UNTAR_DIR="${RULES_NODEJS_DIR}/dist/build_bazel_rules_nodejs/release"
+readonly DEST_DIR="${RULES_NODEJS_DIR}/release/build_bazel_rules_nodejs"
+readonly UNTAR_DIR="${RULES_NODEJS_DIR}/release/build_bazel_rules_nodejs/release"
 
 echo_and_run() { echo "+ $@" ; "$@" ; }
 
@@ -16,7 +16,7 @@ printf "\n\nBuilding //:release archive\n"
 cd ${RULES_NODEJS_DIR}
 echo_and_run bazel build //:release
 
-# Copy the release archive to /dist
+# Copy the release archive to /release
 echo "Copying archive to ${DEST_DIR}"
 rm -rf ${DEST_DIR}
 mkdir -p ${DEST_DIR}

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -10,16 +10,16 @@ source "${RULES_NODEJS_DIR}/scripts/packages.sh"
 
 DEPS=()
 
-# Check for WORKSPACE dependency on release dist
-LINES=$(grep "/dist/build_bazel_rules_nodejs/release\"" WORKSPACE || echo "")
+# Check for WORKSPACE dependency on release
+LINES=$(grep "/release/build_bazel_rules_nodejs/release\"" WORKSPACE || echo "")
 if [[ "${LINES}" ]] ; then
   DEPS+=(release)
 fi
 
-# Check for file:../../dist/npm_bazel_foobar dependencies in package.json
-LINES=$(egrep -oh "file:../../dist/npm_bazel_([a-z_\-]+)" package.json || echo "")
+# Check for file:../../release/npm_bazel_foobar dependencies in package.json
+LINES=$(egrep -oh "file:../../release/npm_bazel_([a-z_\-]+)" package.json || echo "")
 for line in ${LINES[@]} ; do
-  # Trim the match from `file:../../dist/npm_bazel_foobar` to `foobar`
+  # Trim the match from `file:../../release/npm_bazel_foobar` to `foobar`
   DEP=$(echo $line | cut -c 27-)
   DEPS+=(${DEP})
 done
@@ -30,12 +30,12 @@ if [[ ${DEPS:-} ]] ; then
   echo "checking deps: ${DEPS}"
   for dep in ${DEPS} ; do
     if [[ ${dep} == "release" ]] ; then
-      if [[ ! -d "${RULES_NODEJS_DIR}/dist/build_bazel_rules_nodejs" ]] ; then
-          echo "ERROR: You must first run 'yarn build_release' to build /dist/build_bazel_rules_nodejs";
+      if [[ ! -d "${RULES_NODEJS_DIR}/release/build_bazel_rules_nodejs" ]] ; then
+          echo "ERROR: You must first run 'yarn build_release' to build /release/build_bazel_rules_nodejs";
           ALL_GOOD=0
       fi
     else
-      if [[ ! -d "${RULES_NODEJS_DIR}/dist/npm_bazel_${dep}" ]] ; then
+      if [[ ! -d "${RULES_NODEJS_DIR}/release/npm_bazel_${dep}" ]] ; then
         echo "ERROR: You must first run 'yarn build_packages ${dep}' or 'yarn build_packages_all'";
         ALL_GOOD=0
       fi

--- a/scripts/clean_all.sh
+++ b/scripts/clean_all.sh
@@ -10,7 +10,7 @@ cd ${RULES_NODEJS_DIR}
 
 echo_and_run() { echo "+ $@" ; "$@" ; }
 
-echo_and_run rm -rf ./dist
+echo_and_run rm -rf ./release
 echo_and_run rm -rf `find . -type d -name node_modules -prune`
 
 echo_and_run bazel clean --expunge

--- a/scripts/setup_examples_angular.sh
+++ b/scripts/setup_examples_angular.sh
@@ -34,21 +34,21 @@ printf "\n\nSetting up /examples/angular\n"
 
     # Replace @bazel/foobar packages in package.json with file paths to locally generated packages
     for package in ${PACKAGES[@]} ; do
-      echo_and_run sedi "s#\"@bazel\/${package}\":[[:blank:]]*\"[~_\-\.a-zA-Z0-9]*\"#\"@bazel\/${package}\": \"file://${RULES_NODEJS_DIR}/dist/npm_bazel_${package}\"#" package.json
+      echo_and_run sedi "s#\"@bazel\/${package}\":[[:blank:]]*\"[~_\-\.a-zA-Z0-9]*\"#\"@bazel\/${package}\": \"file://${RULES_NODEJS_DIR}/release/npm_bazel_${package}\"#" package.json
     done
 
     # We can't do multi-line replacements with sed so we'll keep the http_archive
     # for rules_nodejs and point it to our release archive instead. We comment out all
     # sha256 lines as well to make this work.
-    echo_and_run sedi "s#urls* = \[*\"https:\/\/github\.com\/[a-zA-Z_]*\/rules_nodejs[^\"]*\"\]*#url = \"file://${RULES_NODEJS_DIR}/dist/build_bazel_rules_nodejs/release.tar.gz\"#" WORKSPACE
+    echo_and_run sedi "s#urls* = \[*\"https:\/\/github\.com\/[a-zA-Z_]*\/rules_nodejs[^\"]*\"\]*#url = \"file://${RULES_NODEJS_DIR}/release/build_bazel_rules_nodejs/release.tar.gz\"#" WORKSPACE
     echo_and_run sedi "s#sha256 =#\# sha256 =#" WORKSPACE
 
     # Check that above replacements worked
-    if ! grep -q "dist/npm_bazel_" package.json; then
+    if ! grep -q "release/npm_bazel_" package.json; then
       echo "package.json replacements failed!"
       exit 1
     fi
-    if ! grep -q "dist/build_bazel_rules_nodejs/release.tar.gz" WORKSPACE; then
+    if ! grep -q "release/build_bazel_rules_nodejs/release.tar.gz" WORKSPACE; then
       echo "WORKSPACE replacements failed!"
       exit 1
     fi

--- a/scripts/touch_deps.sh
+++ b/scripts/touch_deps.sh
@@ -32,10 +32,10 @@ for rootDir in examples e2e internal/e2e ; do
         cd ${subDir}
         if [[ -e 'package.json' ]] ; then
           DEPS=()
-          # Check for file:../../dist/npm_bazel_foobar dependencies in package.json
-          LINES=$(egrep -oh "file:../../dist/npm_bazel_([a-z_]+)" package.json || echo "")
+          # Check for file:../../release/npm_bazel_foobar dependencies in package.json
+          LINES=$(egrep -oh "file:../../release/npm_bazel_([a-z_]+)" package.json || echo "")
           for line in ${LINES[@]} ; do
-            # Trim the match from `file:../../dist/npm_bazel_foobar` to `foobar`
+            # Trim the match from `file:../../release/npm_bazel_foobar` to `foobar`
             DEP=$(echo $line | cut -c 27-)
             DEPS+=(${DEP})
           done
@@ -53,7 +53,7 @@ for rootDir in examples e2e internal/e2e ; do
                   # rule. Since package.json didn't change, yarn_install would
                   # not otherwise know that it has to re-run to re-install the @bazel/foobar
                   # npm package.
-                  echo_and_run sedi "s#/dist/npm_bazel_${package}\\\$\{0,1\}[0-9]\{0,10\}#/dist/npm_bazel_${package}\$${RANDOM}#" yarn.lock
+                  echo_and_run sedi "s#/release/npm_bazel_${package}\\\$\{0,1\}[0-9]\{0,10\}#/release/npm_bazel_${package}\$${RANDOM}#" yarn.lock
                 fi
               done
             done


### PR DESCRIPTION
Simplifies circleci config so individual `/dist/npm_bazel_foo` folders no longer need to be listed as this allows for persisting the entire `/release` folder