### PR TITLE
Jasmine custom config

### DIFF
--- a/packages/jasmine/src/jasmine_runner.js
+++ b/packages/jasmine/src/jasmine_runner.js
@@ -69,6 +69,9 @@ function main(args) {
   const cwd = process.cwd()
 
   const jrunner = new JasmineRunner({jasmineCore: jasmineCore});
+  if (args.length == 3) {
+    jrunner.loadConfigFile(args[2]);
+  }
   const allFiles = fs.readFileSync(manifest, UTF8)
                        .split('\n')
                        .filter(l => l.length > 0)

--- a/packages/jasmine/test/BUILD.bazel
+++ b/packages/jasmine/test/BUILD.bazel
@@ -63,3 +63,16 @@ jasmine_node_test(
         "--node_options=--experimental-modules",
     ],
 )
+
+# We have no srcs[] here because we set specs in the config file
+jasmine_node_test(
+    name = "config_file_test",
+    config_file = "test_config_file.json",
+    # The file isn't named following our usual conventions
+    # but since it's configured in the json config file
+    # Jasmine will still load it
+    data = ["test_config_file.js"],
+    # TODO(alexeagle): on Windows CI we get no specs found
+    # Maybe Jasmine doesn't normalize the slashes in the config
+    tags = ["fix-windows"],
+)

--- a/packages/jasmine/test/test_config_file.js
+++ b/packages/jasmine/test/test_config_file.js
@@ -1,0 +1,6 @@
+describe('configuring Jasmine', () => {
+  it('should accept a config file', () => {
+    // the config_file.json has random: false
+    expect(jasmine.getEnv().configuration().random).toBeFalsy();
+  });
+});

--- a/packages/jasmine/test/test_config_file.json
+++ b/packages/jasmine/test/test_config_file.json
@@ -1,0 +1,6 @@
+{
+    "random": false,
+    "spec_files": [
+        "**/test_config_*.js"
+    ]
+}


### PR DESCRIPTION
Finally chose an approach to fix this.

- Accept a config file like in #744 
- now the user can have their spec files named anything, doesn't need to follow our conventions