### PR TITLE
docs: fix “setup” typos

### DIFF
--- a/docs/Karma.md
+++ b/docs/Karma.md
@@ -33,7 +33,7 @@ This installs the `io_bazel_rules_webtesting` repository, if you haven't install
 Finally, configure the rules_webtesting:
 
 ```python
-# Setup web testing, choose browsers we can test on
+# Set up web testing, choose browsers we can test on
 load("@io_bazel_rules_webtesting//web:repositories.bzl", "browser_repositories", "web_test_repositories")
 
 web_test_repositories()

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -32,7 +32,7 @@ See https://github.com/bazelbuild/rules_nodejs/#quickstart
 Add to your `WORKSPACE` file, after `install_bazel_dependencies()`:
 
 ```python
-# Setup TypeScript toolchain
+# Set up TypeScript toolchain
 load("@npm_bazel_typescript//:index.bzl", "ts_setup_workspace")
 ts_setup_workspace()
 ```

--- a/packages/karma/docs/install.md
+++ b/packages/karma/docs/install.md
@@ -27,7 +27,7 @@ This installs the `io_bazel_rules_webtesting` repository, if you haven't install
 Finally, configure the rules_webtesting:
 
 ```python
-# Setup web testing, choose browsers we can test on
+# Set up web testing, choose browsers we can test on
 load("@io_bazel_rules_webtesting//web:repositories.bzl", "browser_repositories", "web_test_repositories")
 
 web_test_repositories()

--- a/packages/typescript/docs/install.md
+++ b/packages/typescript/docs/install.md
@@ -26,7 +26,7 @@ See https://github.com/bazelbuild/rules_nodejs/#quickstart
 Add to your `WORKSPACE` file, after `install_bazel_dependencies()`:
 
 ```python
-# Setup TypeScript toolchain
+# Set up TypeScript toolchain
 load("@npm_bazel_typescript//:index.bzl", "ts_setup_workspace")
 ts_setup_workspace()
 ```


### PR DESCRIPTION
As a phrasal verb, [*set up* is two words.][set-up]

[set-up]: https://en.wiktionary.org/wiki/setup#Verb

wchargin-branch: set-up
