### PR TITLE
refactor: reduce some duplication in npm_package rules

### DIFF
--- a/packages/create/BUILD.bazel
+++ b/packages/create/BUILD.bazel
@@ -1,12 +1,4 @@
-load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_test", "npm_package")
-
-# Copy the license from our parent folder
-genrule(
-    name = "copy_LICENSE",
-    srcs = ["@build_bazel_rules_nodejs//:LICENSE"],
-    outs = ["LICENSE"],
-    cmd = "cp $< $@",
-)
+load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "nodejs_test", "npm_package")
 
 # Copy common bazelrc file to be included in this package
 genrule(
@@ -24,7 +16,6 @@ npm_package(
         "package.json",
     ],
     deps = [
-        ":copy_LICENSE",
         ":copy_bazelrc",
     ],
 )

--- a/packages/hide-bazel-files/BUILD.bazel
+++ b/packages/hide-bazel-files/BUILD.bazel
@@ -12,15 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package")
-
-# Copy the license from our parent folder
-genrule(
-    name = "copy_LICENSE",
-    srcs = ["@build_bazel_rules_nodejs//:LICENSE"],
-    outs = ["LICENSE"],
-    cmd = "cp $< $@",
-)
+load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "npm_package")
 
 npm_package(
     name = "npm_package",
@@ -28,12 +20,5 @@ npm_package(
         ":README.md",
         ":index.js",
         ":package.json",
-    ],
-    visibility = [
-        "//e2e:__pkg__",
-        "//examples:__pkg__",
-    ],
-    deps = [
-        ":copy_LICENSE",
     ],
 )

--- a/packages/jasmine/BUILD.bazel
+++ b/packages/jasmine/BUILD.bazel
@@ -12,15 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "COMMON_REPLACEMENTS", "npm_package")
-
-# Copy the license from our parent folder
-genrule(
-    name = "copy_LICENSE",
-    srcs = ["@build_bazel_rules_nodejs//:LICENSE"],
-    outs = ["LICENSE"],
-    cmd = "cp $< $@",
-)
+load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "npm_package")
 
 # Ugly genrule depending on local linux environment to build the README out of skylark doc generation.
 # Only referenced when we do a release.
@@ -41,16 +33,10 @@ npm_package(
     srcs = [
         "@npm_bazel_jasmine//:package_contents",
     ],
-    replacements = COMMON_REPLACEMENTS,
     vendor_external = [
         "npm_bazel_jasmine",
     ],
-    visibility = [
-        "//e2e:__pkg__",
-        "//examples:__pkg__",
-    ],
     deps = [
-        ":copy_LICENSE",
         ":generate_README",
     ],
 )

--- a/packages/karma/BUILD.bazel
+++ b/packages/karma/BUILD.bazel
@@ -12,14 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "COMMON_REPLACEMENTS", "npm_package")
-
-genrule(
-    name = "copy_LICENSE",
-    srcs = ["@build_bazel_rules_nodejs//:LICENSE"],
-    outs = ["LICENSE"],
-    cmd = "cp $< $@",
-)
+load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "npm_package")
 
 # Ugly genrule depending on local linux environment to build the README out of skylark doc generation.
 # Only referenced when we do a release.
@@ -40,16 +33,10 @@ npm_package(
     srcs = [
         "@npm_bazel_karma//:package_contents",
     ],
-    replacements = COMMON_REPLACEMENTS,
     vendor_external = [
         "npm_bazel_karma",
     ],
-    visibility = [
-        "//e2e:__pkg__",
-        "//examples:__pkg__",
-    ],
     deps = [
-        ":copy_LICENSE",
         ":generate_README",
         "@npm_bazel_karma//:bazel_karma_lib",
     ],

--- a/packages/labs/BUILD.bazel
+++ b/packages/labs/BUILD.bazel
@@ -1,29 +1,16 @@
-load("@build_bazel_rules_nodejs//:defs.bzl", "COMMON_REPLACEMENTS", "npm_package")
+load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "npm_package")
 
 exports_files(["tsconfig.json"])
-
-genrule(
-    name = "copy_LICENSE",
-    srcs = ["@build_bazel_rules_nodejs//:LICENSE"],
-    outs = ["LICENSE"],
-    cmd = "cp $< $@",
-)
 
 npm_package(
     name = "npm_package",
     srcs = [
         "@npm_bazel_labs//:package_contents",
     ],
-    replacements = COMMON_REPLACEMENTS,
     vendor_external = [
         "npm_bazel_labs",
     ],
-    visibility = [
-        "//e2e:__pkg__",
-        "//examples:__pkg__",
-    ],
     deps = [
-        ":copy_LICENSE",
         "@npm_bazel_labs//webpack:cli_lib",
     ],
 )

--- a/packages/protractor/BUILD.bazel
+++ b/packages/protractor/BUILD.bazel
@@ -12,15 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "COMMON_REPLACEMENTS", "npm_package")
-
-# Copy the license from our parent folder
-genrule(
-    name = "copy_LICENSE",
-    srcs = ["@build_bazel_rules_nodejs//:LICENSE"],
-    outs = ["LICENSE"],
-    cmd = "cp $< $@",
-)
+load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "npm_package")
 
 # Ugly genrule depending on local linux environment to build the README out of skylark doc generation.
 # Only referenced when we do a release.
@@ -41,16 +33,10 @@ npm_package(
     srcs = [
         "@npm_bazel_protractor//:package_contents",
     ],
-    replacements = COMMON_REPLACEMENTS,
     vendor_external = [
         "npm_bazel_protractor",
     ],
-    visibility = [
-        "//e2e:__pkg__",
-        "//examples:__pkg__",
-    ],
     deps = [
-        ":copy_LICENSE",
         ":generate_README",
         "@npm_bazel_protractor//:utils_lib",
     ],

--- a/packages/stylus/BUILD.bazel
+++ b/packages/stylus/BUILD.bazel
@@ -12,15 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "COMMON_REPLACEMENTS", "npm_package")
-
-# Copy the license from our parent folder
-genrule(
-    name = "copy_LICENSE",
-    srcs = ["@build_bazel_rules_nodejs//:LICENSE"],
-    outs = ["LICENSE"],
-    cmd = "cp $< $@",
-)
+load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "npm_package")
 
 # Ugly genrule depending on local linux environment to build the README out of skylark doc generation.
 # Only referenced when we do a release.
@@ -41,16 +33,10 @@ npm_package(
     srcs = [
         "@npm_bazel_stylus//:package_contents",
     ],
-    replacements = COMMON_REPLACEMENTS,
     vendor_external = [
         "npm_bazel_stylus",
     ],
-    visibility = [
-        "//e2e:__pkg__",
-        "//examples:__pkg__",
-    ],
     deps = [
-        ":copy_LICENSE",
         ":generate_README",
     ],
 )

--- a/packages/typescript/BUILD.bazel
+++ b/packages/typescript/BUILD.bazel
@@ -12,15 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package")
+load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "npm_package")
 load(":replacements.bzl", "TYPESCRIPT_REPLACEMENTS")
-
-genrule(
-    name = "copy_LICENSE",
-    srcs = ["@build_bazel_rules_nodejs//:LICENSE"],
-    outs = ["LICENSE"],
-    cmd = "cp $< $@",
-)
 
 # Ugly genrule depending on local linux environment to build the README out of skylark doc generation.
 # Only referenced when we do a release.
@@ -49,12 +42,7 @@ npm_package(
         "npm_bazel_typescript",
         "build_bazel_rules_typescript",
     ],
-    visibility = [
-        "//e2e:__pkg__",
-        "//examples:__pkg__",
-    ],
     deps = [
-        ":copy_LICENSE",
         ":generate_README",
         "@npm_bazel_typescript//internal:BUILD",
     ],

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -1,0 +1,44 @@
+"""Wrappers around build rules
+
+These set common default attributes and behaviors for our local repo
+"""
+
+load(
+    "@build_bazel_rules_nodejs//:defs.bzl",
+    _COMMON_REPLACEMENTS = "COMMON_REPLACEMENTS",
+    _nodejs_test = "nodejs_test",
+    _npm_package = "npm_package",
+)
+
+nodejs_test = _nodejs_test
+
+def npm_package(**kwargs):
+    "Set some defaults for the npm_package rule"
+
+    # Every package should have a copy of the root LICENSE file
+    native.genrule(
+        name = "copy_LICENSE",
+        srcs = ["@build_bazel_rules_nodejs//:LICENSE"],
+        outs = ["LICENSE"],
+        cmd = "cp $< $@",
+    )
+
+    deps = kwargs.pop("deps", [])
+    deps.append(":copy_LICENSE")
+
+    # Make every package visible to tests
+    visibility = kwargs.pop("visibility", [
+        "//e2e:__pkg__",
+        "//examples:__pkg__",
+    ])
+
+    # Default replacements to scrub things like skylib references
+    replacements = kwargs.pop("replacements", _COMMON_REPLACEMENTS)
+
+    # Finally call through to the rule with our defaults set
+    _npm_package(
+        deps = deps,
+        replacements = replacements,
+        visibility = visibility,
+        **kwargs
+    )


### PR DESCRIPTION
Would like to reduce the boilerplate as we make more and more packages