### PR TITLE
refactor: move flaky_test_attempts to CI config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,7 +34,3 @@ import %workspace%/third_party/github.com/bazelbuild/bazel-toolchains/bazelrc/ba
 # Remote instance, borrow the one used by Angular devs
 build:remote --remote_instance_name=projects/internal-200822/instances/default_instance
 build:remote --project_id=internal-200822
-
-# Our integration tests rely on accessing public registries which can fail
-# Let's give all failing tests a second try to mostly paper over flakiness
-test --flaky_test_attempts=2

--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -14,3 +14,7 @@ build --announce_rc
 # Limit Bazel to consuming resources that fit in CircleCI "xlarge" class
 # https://circleci.com/docs/2.0/configuration-reference/#resource_class
 build --local_resources=14336,8.0,1.0
+
+# Our integration tests rely on accessing public registries which can fail
+# Let's give all failing tests a second try to mostly paper over flakiness
+test --flaky_test_attempts=2


### PR DESCRIPTION
It's annoying when tests are failing locally that they run twice, so I've been adding --flaky_test_attempts=1 manually.
Also BuildKite was already setting --flaky_test_attempts=3 so we really only need to update CircleCI
