### PR TITLE
Reformat the error message for Node loader.js

### DIFF
--- a/internal/node/node_loader.js
+++ b/internal/node/node_loader.js
@@ -468,9 +468,15 @@ module.constructor._resolveFilename = function(request, parent, isMain, options)
   }
 
   const error = new Error(
-      `${TARGET} cannot find module '${request}' required by '${parentFilename}'\n  looked in:\n` +
-      failedResolutions.map(r => `    ${r}`).join('\n') + '\n');
+      `Cannot find module '${request}'. ` +
+      'Please verify that the package.json has a valid "main" entry'
+  );
   error.code = 'MODULE_NOT_FOUND';
+  // todo - error.path = ?;
+  error.requestPath = parentFilename;
+  error.bazelTarget = TARGET;
+  error.failedResolutions = failedResolutions;
+  
   throw error;
 }
 


### PR DESCRIPTION
The format of Node's own error from loader.js is https://github.com/nodejs/node/blob/a49b20d3245dd2a4d890e28582f3c013c07c3136/lib/internal/modules/cjs/loader.js#L264

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [x] Bugfix describe:


## What is the current behavior?

Issue Number: #1015


## What is the new behavior?

The error message reflects the same as Node's error message here: https://github.com/nodejs/node/blob/a49b20d3245dd2a4d890e28582f3c013c07c3136/lib/internal/modules/cjs/loader.js#L264

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Use the new error message format.

## Other information

