### PR TITLE
build: fix on release script & BAZEL_VERSION

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -93,7 +93,7 @@ VERSION = "0.36.0"
 # we will test against multiple versions.
 # This version should be updated together with the version of the @bazel/bazel
 # package in package.json. This is asserted in //internal:package_json_test.
-BAZEL_VERSION = "0.36.0"
+BAZEL_VERSION = "0.28.1"
 
 def check_rules_nodejs_version(minimum_version_string):
     """

--- a/scripts/on-version.js
+++ b/scripts/on-version.js
@@ -4,4 +4,4 @@
 const shell = require('shelljs');
 const version = require('../package.json').version;
 
-shell.sed('-i', 'VERSION \= \"[0-9\.]*\"', `VERSION = "${version}"`, 'defs.bzl');
+shell.sed('-i', /^VERSION \= \"[0-9\.]*\"/, `VERSION = "${version}"`, 'defs.bzl');


### PR DESCRIPTION
Fix on release script from clobbering BAZEL_VERSION in //:defs.bzl