### PR TITLE
feat(builtin): add browser to rollup mainFields

### DIFF
--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -179,7 +179,7 @@ const config = {
       resolveId: resolveBazel,
     },
     nodeResolve({
-      mainFields: ['es2015', 'module', 'jsnext:main', 'main'],
+      mainFields: ['browser', 'es2015', 'module', 'jsnext:main', 'main'],
       jail: process.cwd(),
       customResolveOptions: {moduleDirectory: nodeModulesRoot}
     }),


### PR DESCRIPTION
Allows rollup to resolve browser mainFields in prod the same as we added for umd mainFields for dev.

Not too sure how to test this