### PR TITLE
feat(typescript): add JSModuleInfo provider to ts_library outputs

### DIFF
--- a/internal/npm_install/node_module_library.bzl
+++ b/internal/npm_install/node_module_library.bzl
@@ -15,7 +15,7 @@
 """Contains the node_module_library which is used by yarn_install & npm_install.
 """
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "NpmPackageInfo", "js_named_module_info")
+load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "NpmPackageInfo", "js_module_info", "js_named_module_info")
 
 def _node_module_library_impl(ctx):
     workspace = ctx.label.workspace_root.split("/")[1] if ctx.label.workspace_root else ctx.workspace_name
@@ -69,6 +69,11 @@ def _node_module_library_impl(ctx):
             DeclarationInfo(
                 declarations = declarations,
                 transitive_declarations = transitive_declarations,
+            ),
+            js_module_info(
+                module_format = "",
+                sources = direct_sources,
+                deps = ctx.attr.deps,
             ),
             js_named_module_info(
                 sources = depset(ctx.files.named_module_srcs),

--- a/internal/pkg_npm/pkg_npm.bzl
+++ b/internal/pkg_npm/pkg_npm.bzl
@@ -6,7 +6,7 @@ If all users of your library code use Bazel, they should just add your library
 to the `deps` of one of their targets.
 """
 
-load("//:providers.bzl", "DeclarationInfo", "JSNamedModuleInfo", "NodeContextInfo")
+load("//:providers.bzl", "DeclarationInfo", "JSModuleInfo", "NodeContextInfo")
 load("//internal/common:path_utils.bzl", "strip_external")
 
 _DOC = """The pkg_npm rule creates a directory containing a publishable npm artifact.
@@ -223,9 +223,8 @@ def _pkg_npm(ctx):
         sources_depsets.append(dep.files)
 
         # All direct & transitive JavaScript-producing deps
-        # TODO: switch to JSModuleInfo when it is available
-        if JSNamedModuleInfo in dep:
-            sources_depsets.append(dep[JSNamedModuleInfo].sources)
+        if JSModuleInfo in dep:
+            sources_depsets.append(dep[JSModuleInfo].sources)
 
         # Include all transitive declerations
         if DeclarationInfo in dep:

--- a/packages/karma/src/karma_web_test.bzl
+++ b/packages/karma/src/karma_web_test.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 "Unit testing with Karma"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo", "NpmPackageInfo", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSModuleInfo", "JSNamedModuleInfo", "NpmPackageInfo", "node_modules_aspect")
 load("@build_bazel_rules_nodejs//internal/js_library:js_library.bzl", "write_amd_names_shim")
 load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_suite")
 load("@io_bazel_rules_webtesting//web/internal:constants.bzl", "DEFAULT_WRAPPED_TEST_TAGS")
@@ -120,9 +120,8 @@ def _write_karma_config(ctx, files, amd_names_shim):
     config_file = None
 
     if ctx.attr.config_file:
-        # TODO: switch to JSModuleInfo when it is available
-        if JSNamedModuleInfo in ctx.attr.config_file:
-            config_file = _filter_js(ctx.attr.config_file[JSNamedModuleInfo].direct_sources.to_list())[0]
+        if JSModuleInfo in ctx.attr.config_file:
+            config_file = _filter_js(ctx.attr.config_file[JSModuleInfo].direct_sources.to_list())[0]
         else:
             config_file = ctx.file.config_file
 
@@ -296,9 +295,8 @@ ${{KARMA}} ${{ARGV[@]}} ${{NODE_OPTIONS[@]}}
     config_sources = []
 
     if ctx.attr.config_file:
-        # TODO: switch to JSModuleInfo when it is available
-        if JSNamedModuleInfo in ctx.attr.config_file:
-            config_sources = ctx.attr.config_file[JSNamedModuleInfo].sources.to_list()
+        if JSModuleInfo in ctx.attr.config_file:
+            config_sources = ctx.attr.config_file[JSModuleInfo].sources.to_list()
         else:
             config_sources = [ctx.file.config_file]
 

--- a/packages/labs/src/protobufjs/ts_proto_library.bzl
+++ b/packages/labs/src/protobufjs/ts_proto_library.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 "Protocol Buffers"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "JSEcmaScriptModuleInfo", "JSNamedModuleInfo")
+load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "JSEcmaScriptModuleInfo", "JSModuleInfo", "JSNamedModuleInfo")
 
 def _run_pbjs(actions, executable, var, output_name, proto_files, suffix = ".js", wrap = "amd", amd_name = ""):
     js_file = actions.declare_file(output_name + suffix)
@@ -122,6 +122,10 @@ def _ts_proto_library(ctx):
             DeclarationInfo(
                 declarations = declarations,
                 transitive_declarations = declarations,
+            ),
+            JSModuleInfo(
+                sources = es5_sources,
+                module_format = "amd",
             ),
             JSNamedModuleInfo(
                 direct_sources = es5_sources,

--- a/packages/protractor/src/protractor_web_test.bzl
+++ b/packages/protractor/src/protractor_web_test.bzl
@@ -14,7 +14,7 @@
 "Run end-to-end tests with Protractor"
 
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo", "NpmPackageInfo", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSModuleInfo", "JSNamedModuleInfo", "NpmPackageInfo", "node_modules_aspect")
 load("@build_bazel_rules_nodejs//internal/common:windows_utils.bzl", "create_windows_native_launcher_script", "is_windows")
 load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_suite")
 load("@io_bazel_rules_webtesting//web/internal:constants.bzl", "DEFAULT_WRAPPED_TEST_TAGS")
@@ -69,10 +69,9 @@ def _protractor_web_test_impl(ctx):
     configuration_sources = []
     configuration_file = None
     if ctx.attr.configuration:
-        # TODO: switch to JSModuleInfo when it is available
-        if JSNamedModuleInfo in ctx.attr.configuration:
-            configuration_sources = ctx.attr.configuration[JSNamedModuleInfo].sources.to_list()
-            configuration_file = _filter_js(ctx.attr.configuration[JSNamedModuleInfo].direct_sources.to_list())[0]
+        if JSModuleInfo in ctx.attr.configuration:
+            configuration_sources = ctx.attr.configuration[JSModuleInfo].sources.to_list()
+            configuration_file = _filter_js(ctx.attr.configuration[JSModuleInfo].direct_sources.to_list())[0]
         else:
             configuration_sources = [ctx.file.configuration]
             configuration_file = ctx.file.configuration
@@ -80,10 +79,9 @@ def _protractor_web_test_impl(ctx):
     on_prepare_sources = []
     on_prepare_file = None
     if ctx.attr.on_prepare:
-        # TODO: switch to JSModuleInfo when it is available
-        if JSNamedModuleInfo in ctx.attr.on_prepare:
-            on_prepare_sources = ctx.attr.on_prepare[JSNamedModuleInfo].sources.to_list()
-            on_prepare_file = _filter_js(ctx.attr.on_prepare[JSNamedModuleInfo].direct_sources.to_list())[0]
+        if JSModuleInfo in ctx.attr.on_prepare:
+            on_prepare_sources = ctx.attr.on_prepare[JSModuleInfo].sources.to_list()
+            on_prepare_file = _filter_js(ctx.attr.on_prepare[JSModuleInfo].direct_sources.to_list())[0]
         else:
             on_prepare_sources = [ctx.file.on_prepare]
             on_prepare_file = ctx.file.on_prepare

--- a/packages/rollup/src/rollup_bundle.bzl
+++ b/packages/rollup/src/rollup_bundle.bzl
@@ -1,6 +1,6 @@
 "Rules for running Rollup under Bazel"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSEcmaScriptModuleInfo", "NodeContextInfo", "NpmPackageInfo", "node_modules_aspect", "run_node")
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSEcmaScriptModuleInfo", "JSModuleInfo", "NodeContextInfo", "NpmPackageInfo", "node_modules_aspect", "run_node")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "module_mappings_aspect")
 
 _DOC = """Runs the Rollup.js CLI under Bazel.
@@ -271,6 +271,8 @@ def _rollup_bundle(ctx):
     for dep in ctx.attr.deps:
         if JSEcmaScriptModuleInfo in dep:
             deps_depsets.append(dep[JSEcmaScriptModuleInfo].sources)
+        elif JSModuleInfo in dep:
+            deps_depsets.append(dep[JSModuleInfo].sources)
         elif hasattr(dep, "files"):
             deps_depsets.append(dep.files)
 
@@ -338,8 +340,11 @@ def _rollup_bundle(ctx):
         arguments = [args],
     )
 
+    outputs_depset = depset(outputs)
+
     return [
-        DefaultInfo(files = depset(outputs)),
+        DefaultInfo(files = outputs_depset),
+        JSModuleInfo(module_format = ctx.attr.format, sources = outputs_depset),
     ]
 
 rollup_bundle = rule(

--- a/packages/terser/test/js_srcs/BUILD.bazel
+++ b/packages/terser/test/js_srcs/BUILD.bazel
@@ -1,19 +1,19 @@
 load("@npm_bazel_jasmine//:index.from_src.bzl", "jasmine_node_test")
 load("@npm_bazel_terser//:index.from_src.bzl", "terser_minified")
 
-jasmine_node_test(
-    name = "test",
-    srcs = ["directory-args.spec.js"],
-    deps = [
-        "@npm//tmp",
-        "@npm_bazel_terser//:index.js",
+# Case 1: optimize InputArtifacts
+filegroup(
+    name = "src1_in",
+    srcs = [
+        "src1.js",
+        "src1b.js",
     ],
 )
 
-# Case 1: optimize an InputArtifact
 terser_minified(
     name = "case1",
-    src = "src1.js",
+    src = ":src1_in",
+    sourcemap = False,
 )
 
 # Case 2: get the JS file from DefaultInfo of a dep
@@ -21,18 +21,17 @@ load(":produces_js_as_defaultinfo.bzl", "produces_js_as_defaultinfo")
 
 produces_js_as_defaultinfo(
     name = "src2_in",
-    src = "src2.js",
+    srcs = ["src2.js"],
 )
 
 terser_minified(
     name = "case2",
     src = ":src2_in",
+    sourcemap = False,
 )
 
-# Case 3: Use the JS provider to find inputs from *_bundle rule
-
 jasmine_node_test(
-    name = "terser_test",
+    name = "test",
     srcs = [
         "terser_spec.js",
     ],
@@ -42,5 +41,3 @@ jasmine_node_test(
         ":case2",
     ],
 )
-
-# TODO(gregmagolan): Case 4: test that terser also outputs a JS provider

--- a/packages/terser/test/js_srcs/produces_js_as_defaultinfo.bzl
+++ b/packages/terser/test/js_srcs/produces_js_as_defaultinfo.bzl
@@ -1,0 +1,9 @@
+"test fixture"
+
+def _produces_js_as_defaultinfo(ctx):
+    return DefaultInfo(files = depset(ctx.files.srcs))
+
+produces_js_as_defaultinfo = rule(
+    _produces_js_as_defaultinfo,
+    attrs = {"srcs": attr.label_list(allow_files = True)},
+)

--- a/packages/terser/test/js_srcs/src1.js
+++ b/packages/terser/test/js_srcs/src1.js
@@ -1,0 +1,5 @@
+/**
+ * @fileoverview Description of this file.
+ */
+
+console.error('here is non-optimized JS');

--- a/packages/terser/test/js_srcs/src1b.js
+++ b/packages/terser/test/js_srcs/src1b.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/packages/terser/test/js_srcs/src2.js
+++ b/packages/terser/test/js_srcs/src2.js
@@ -1,0 +1,1 @@
+console.log('src2');

--- a/packages/terser/test/js_srcs/terser_spec.js
+++ b/packages/terser/test/js_srcs/terser_spec.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const DIR = 'build_bazel_rules_nodejs/packages/terser/test/js_srcs';
+
+describe('terser rule', () => {
+  it('should accept InputArtifact (file in project)', () => {
+    const file = require.resolve(DIR + '/case1.js');
+    const expected = process.env['DEBUG'] ?
+        'console.error("here is non-optimized JS");\n\nexport const a = 1;' :
+        'console.error("here is non-optimized JS");export const a=1;';
+    expect(fs.readFileSync(file, 'utf-8')).toBe(expected);
+  });
+  it('should accept a rule that produces JS files in DefaultInfo', () => {
+    const file = require.resolve(DIR + '/case2.js');
+    expect(fs.readFileSync(file, 'utf-8')).toBe('console.log("src2");');
+  });
+});

--- a/packages/terser/test/jsinfo_srcs/BUILD.bazel
+++ b/packages/terser/test/jsinfo_srcs/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@npm_bazel_jasmine//:index.from_src.bzl", "jasmine_node_test")
+load("@npm_bazel_terser//:index.from_src.bzl", "terser_minified")
+load(":consumes_jsinfo.bzl", "consumes_jsinfo")
+
+# Use the JS providers to find inputs from *_bundle rule
+load(":produces_jsinfo.bzl", "produces_jsinfo")
+
+produces_jsinfo(
+    name = "in",
+    srcs = ["esnext.mjs"],
+    format = "esm",
+)
+
+terser_minified(
+    name = "terser",
+    src = ":in",
+    sourcemap = False,
+)
+
+consumes_jsinfo(
+    name = "out",
+    src = ":terser",
+)
+
+jasmine_node_test(
+    name = "test",
+    srcs = [
+        "terser_spec.js",
+    ],
+    # TODO(alexeagle): fix this up
+    tags = ["manual"],
+    deps = [
+        ":out",
+        ":terser.js",
+    ],
+)
+
+# Case 4: test that terser also outputs a JS provider

--- a/packages/terser/test/jsinfo_srcs/consumes_jsinfo.bzl
+++ b/packages/terser/test/jsinfo_srcs/consumes_jsinfo.bzl
@@ -1,0 +1,28 @@
+"fixture for testing terser"
+
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSModuleInfo")
+
+def _consume(ctx):
+    if not JSModuleInfo in ctx.attr.src:
+        fail("Cannot consume %s because it doesn't provide JSModuleInfo" % ctx.attr.src.label)
+
+    module_srcs = ctx.attr.src[JSModuleInfo].sources.to_list()
+
+    if len(module_srcs) != 1:
+        fail("expected to consume a single file")
+
+    ctx.actions.expand_template(
+        template = module_srcs[0],
+        output = ctx.outputs.js,
+        substitutions = {},
+    )
+
+    return []
+
+consumes_jsinfo = rule(
+    _consume,
+    attrs = {"src": attr.label()},
+    outputs = {
+        "js": "%{name}.js",
+    },
+)

--- a/packages/terser/test/jsinfo_srcs/esnext.mjs
+++ b/packages/terser/test/jsinfo_srcs/esnext.mjs
@@ -1,0 +1,1 @@
+import * as dep from './dep';

--- a/packages/terser/test/jsinfo_srcs/named.umd.js
+++ b/packages/terser/test/jsinfo_srcs/named.umd.js
@@ -1,0 +1,12 @@
+(function(factory) {
+if (typeof module === 'object' && typeof module.exports === 'object') {
+  var v = factory(require, exports);
+  if (v !== undefined) module.exports = v;
+} else if (typeof define === 'function' && define.amd) {
+  define('some_module_name', ['require', 'exports', './dep'], factory);
+}
+})(function(require, exports) {
+'use strict';
+Object.defineProperty(exports, '__esModule', {value: true});
+const dep = require('./dep');
+});

--- a/packages/terser/test/jsinfo_srcs/produces_jsinfo.bzl
+++ b/packages/terser/test/jsinfo_srcs/produces_jsinfo.bzl
@@ -1,0 +1,19 @@
+"Mock for testing terser interop"
+
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSModuleInfo")
+
+def _produces_jsinfo(ctx):
+    return [
+        DefaultInfo(
+            files = depset(ctx.files.srcs),
+        ),
+        JSModuleInfo(
+            sources = depset(ctx.files.srcs),
+            module_format = ctx.attr.format,
+        ),
+    ]
+
+produces_jsinfo = rule(_produces_jsinfo, attrs = {
+    "srcs": attr.label_list(allow_files = True),
+    "format": attr.string(mandatory = True),
+})

--- a/packages/terser/test/jsinfo_srcs/terser_spec.js
+++ b/packages/terser/test/jsinfo_srcs/terser_spec.js
@@ -1,0 +1,20 @@
+/**
+ * @fileoverview Description of this file.
+ */
+const fs = require('fs');
+const DIR = 'build_bazel_rules_nodejs/packages/terser/test/jsinfo_srcs';
+
+describe('JSModuleInfo provider in the srcs', () => {
+  it('should produce the esnext as the default output', () => {
+    const file = require.resolve(DIR + '/terser.js');
+    expect(fs.readFileSync(file, 'utf-8')).toBe('import*as dep from"./dep";')
+  });
+  it('should output a JSModuleInfo provider if one is input', () => {
+    const esnextFile = require.resolve(DIR + '/out.mjs');
+    expect(fs.readFileSync(esnextFile, 'utf-8')).toBe('import*as dep from"./dep";');
+    const namedFile = require.resolve(DIR + '/out.umd.js');
+    expect(fs.readFileSync(namedFile, 'utf-8'))
+        .toBe(
+            '!function(e){if("object"==typeof module&&"object"==typeof module.exports){var o=e(require,exports);void 0!==o&&(module.exports=o)}else"function"==typeof define&&define.amd&&define("some_module_name",["require","exports","./dep"],e)}(function(e,o){"use strict";Object.defineProperty(o,"__esModule",{value:!0}),e("./dep")});');
+  });
+});

--- a/packages/terser/test/produces_js_as_defaultinfo.bzl
+++ b/packages/terser/test/produces_js_as_defaultinfo.bzl
@@ -1,0 +1,9 @@
+"test fixure"
+
+def _produces_js_as_defaultinfo(ctx):
+    return DefaultInfo(files = depset([ctx.file.src]))
+
+produces_js_as_defaultinfo = rule(
+    _produces_js_as_defaultinfo,
+    attrs = {"src": attr.label(allow_single_file = True)},
+)

--- a/packages/terser/test/produces_jsinfo.bzl
+++ b/packages/terser/test/produces_jsinfo.bzl
@@ -1,0 +1,33 @@
+"Mock for testing terser interop"
+
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSModuleInfo")
+
+def _produces_jsinfo(ctx):
+    named_js = ctx.actions.declare_file(ctx.name + ".js")
+    esnext_js = ctx.actions.declare_file(ctx.name + ".mjs")
+    ctx.actions.write(named_js, """
+    (function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define("some_module_name", ["require", "exports", "./dep"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    const dep = require("./dep");
+});
+""")
+
+    ctx.actions.write(esnext_js, """import * as dep from './dep';""")
+
+    return [
+        JSModuleInfo(
+            sources = depset(named_js),
+            module_format = "umd",
+        ),
+    ]
+
+produces_jsinfo = rule(_produces_jsinfo)

--- a/packages/terser/test/src1.js
+++ b/packages/terser/test/src1.js
@@ -1,0 +1,5 @@
+/**
+ * @fileoverview Description of this file.
+ */
+
+console.error('here is non-optimized JS');

--- a/packages/terser/test/src2.js
+++ b/packages/terser/test/src2.js
@@ -1,0 +1,1 @@
+console.log('src2');

--- a/packages/terser/test/terser_spec.js
+++ b/packages/terser/test/terser_spec.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const DIR = 'build_bazel_rules_nodejs/packages/terser/test';
+
+describe('terser rule', () => {
+  it('should accept InputArtifact (file in project)', () => {
+    const file = require.resolve(DIR + '/case1.js');
+    expect(fs.readFileSync(file, 'utf-8'))
+        .toBe('console.error("here is non-optimized JS");\n//# sourceMappingURL=case1.js.map');
+  });
+  it('should accept a rule that produces a JS file in DefaultInfo', () => {
+    const file = require.resolve(DIR + '/case2.js');
+    expect(fs.readFileSync(file, 'utf-8'))
+        .toBe('console.log("src2");\n//# sourceMappingURL=case2.js.map');
+  });
+});

--- a/packages/typescript/src/internal/build_defs.bzl
+++ b/packages/typescript/src/internal/build_defs.bzl
@@ -14,7 +14,7 @@
 
 "TypeScript compilation"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "NpmPackageInfo", "js_ecma_script_module_info", "js_named_module_info", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "NpmPackageInfo", "js_ecma_script_module_info", "js_module_info", "js_named_module_info", "node_modules_aspect")
 
 # pylint: disable=unused-argument
 # pylint: disable=missing-docstring
@@ -275,6 +275,11 @@ def _ts_library_impl(ctx):
     # See design doc https://docs.google.com/document/d/1ggkY5RqUkVL4aQLYm7esRW978LgX3GUCnQirrk5E1C0/edit#
     # and issue https://github.com/bazelbuild/rules_nodejs/issues/57 for more details.
     ts_providers["providers"].extend([
+        js_module_info(
+            module_format = "umd",
+            sources = ts_providers["typescript"]["es5_sources"],
+            deps = ctx.attr.deps,
+        ),
         js_named_module_info(
             sources = ts_providers["typescript"]["es5_sources"],
             deps = ctx.attr.deps,
@@ -283,8 +288,7 @@ def _ts_library_impl(ctx):
             sources = ts_providers["typescript"]["es6_sources"],
             deps = ctx.attr.deps,
         ),
-        # TODO: Add remaining shared JS provider from design doc
-        # (JSModuleInfo) and remove legacy "typescript" provider
+        # TODO: remove legacy "typescript" provider
         # once it is no longer needed.
     ])
 

--- a/providers.bzl
+++ b/providers.bzl
@@ -25,8 +25,10 @@ load(
 load(
     "//internal/providers:js_providers.bzl",
     _JSEcmaScriptModuleInfo = "JSEcmaScriptModuleInfo",
+    _JSModuleInfo = "JSModuleInfo",
     _JSNamedModuleInfo = "JSNamedModuleInfo",
     _js_ecma_script_module_info = "js_ecma_script_module_info",
+    _js_module_info = "js_module_info",
     _js_named_module_info = "js_named_module_info",
 )
 load(
@@ -42,6 +44,8 @@ load(
 
 provide_declarations = _provide_declarations
 DeclarationInfo = _DeclarationInfo
+JSModuleInfo = _JSModuleInfo
+js_module_info = _js_module_info
 JSNamedModuleInfo = _JSNamedModuleInfo
 js_named_module_info = _js_named_module_info
 JSEcmaScriptModuleInfo = _JSEcmaScriptModuleInfo


### PR DESCRIPTION
@alexeagle and I worked on this over the last week to prototype how a new set of JS providers would behave in all of the nodejs rules. This also includes the start of new simplified rollup and terser rules based on our discussions with @jbedard.

Also depends on provider changes to ts_library found here: https://github.com/gregmagolan/rules_typescript/commit/125d40b070cdd6fc2d465115976b8b67f5afa6c0

Open to comments and suggestions. We're aiming to get new JS providers as a breaking change for 1.0.

//cc @jbedard @Toxicable @mgechev @filipesilva @soldair @josephperrott @alan-agius4 @Globegitter 