### PR TITLE
test: move e2e/ts_auto_deps assertion from circleci to bazelci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,6 @@ jobs:
       # Additional e2e assertions that can only be done with `yarn test`
       - run: cd e2e/symlinked_node_modules_npm && yarn test && bazel clean
       - run: cd e2e/symlinked_node_modules_yarn && yarn test && bazel clean
-      - run: cd e2e/ts_auto_deps && yarn test && bazel clean
 
       - *hide_node_and_yarn_local_binaries
 

--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -57,9 +57,6 @@ E2E_TESTS = {
     "e2e_symlinked_node_modules_yarn": {
         "//packages/hide-bazel-files:npm_package": "@bazel/hide-bazel-files",
     },
-    "e2e_ts_auto_deps": {
-        "//packages/typescript:npm_package": "@bazel/typescript",
-    },
     "e2e_ts_devserver": {
         "//packages/hide-bazel-files:npm_package": "@bazel/hide-bazel-files",
         "//packages/protractor:npm_package": "@bazel/protractor",
@@ -141,6 +138,40 @@ E2E_TESTS = {
     "3.4.x",
     "3.5.x",
 ]]
+
+bazel_integration_test(
+    name = "e2e_ts_auto_deps",
+    bazel_commands = [
+        "run @nodejs//:yarn",
+        "run @nodejs//:bin/yarn <test_args> -- generate_build_file",
+        "build //simple:simple",
+    ],
+    # some bazelrc imports are outside of the nested workspace so
+    # the test runner will handle these as special cases
+    bazelrc_imports = {
+        "//:common.bazelrc": "import %workspace%/../../common.bazelrc",
+    },
+    check_npm_packages = NPM_PACKAGES,
+    # package.json will be updated with `file:` links to the absolute paths
+    # of the generated npm packages in runfiles
+    npm_packages = {
+        "//packages/typescript:npm_package": "@bazel/typescript",
+    },
+    # replace the following repositories with the generated archives
+    repositories = {
+        "//:release": "build_bazel_rules_nodejs",
+    },
+    tags = [
+        "e2e",
+        # exclusive keyword will force the test to be run in the "exclusive" mode,
+        # ensuring that no other tests are running at the same time. Such tests
+        # will be executed in serial fashion after all build activity and non-exclusive
+        # tests have been completed. Remote execution is disabled for such tests
+        # because Bazel doesn't have control over what's running on a remote machine.
+        "exclusive",
+    ],
+    workspace_files = "@e2e_ts_auto_deps//:all_files",
+)
 
 bazel_integration_test(
     name = "e2e_angular_bazel_example",

--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -143,7 +143,7 @@ bazel_integration_test(
     name = "e2e_ts_auto_deps",
     bazel_commands = [
         "run @nodejs//:yarn",
-        "run @nodejs//:bin/yarn <test_args> -- generate_build_file",
+        "run @nodejs//:bin/yarn -- generate_build_file",
         "build //simple:simple",
     ],
     # some bazelrc imports are outside of the nested workspace so

--- a/e2e/ts_auto_deps/BUILD.bazel
+++ b/e2e/ts_auto_deps/BUILD.bazel
@@ -27,9 +27,3 @@ filegroup(
     ),
     visibility = ["//visibility:public"],
 )
-
-# Just a dummy test so that we have a test target for //... with bazel_integration_test
-sh_test(
-    name = "dummy_test",
-    srcs = ["dummy_test.sh"],
-)

--- a/e2e/ts_auto_deps/dummy_test.sh
+++ b/e2e/ts_auto_deps/dummy_test.sh
@@ -1,2 +1,0 @@
-echo "Just a dummy test so that we have a test target for //... with bazel_integration_test"
-exit 0

--- a/e2e/ts_auto_deps/package.json
+++ b/e2e/ts_auto_deps/package.json
@@ -5,6 +5,7 @@
   },
   "scripts": {
     "pretest": "bazel run @nodejs//:yarn",
-    "test": "cd simple && ts_auto_deps && bazel build simple"
+    "generate_build_file": "cd simple && ts_auto_deps",
+    "test": "yarn generate_build_file && bazel build simple"
   }
 }

--- a/e2e/ts_auto_deps/simple/BUILD
+++ b/e2e/ts_auto_deps/simple/BUILD
@@ -1,6 +1,0 @@
-load("@npm_bazel_typescript//:index.bzl", "ts_library")
-
-ts_library(
-    name = "simple",
-    srcs = ["file.ts"],
-)

--- a/internal/bazel_integration_test/bazel_integration_test.bzl
+++ b/internal/bazel_integration_test/bazel_integration_test.bzl
@@ -110,7 +110,11 @@ It is assumed by the test runner that the bazel binary is found at label_workspa
     ),
     "bazel_commands": attr.string_list(
         default = ["test ..."],
-        doc = """The list of bazel commands to run. Defaults to `["test ..."]`.""",
+        doc = """The list of bazel commands to run. Defaults to `["test ..."]`.
+
+`<test_args>` will be replaced with any `--test_args` arguments passed to the `bazel_integration_test` test target. If
+`<test_args>` is not found then any `--test_args` arguments will be added on to the end of the user arguments in the command.
+""",
     ),
     "bazelrc_append": attr.string(
         doc = """String to append to the .bazelrc file in the workspace-under-test.

--- a/internal/bazel_integration_test/bazel_integration_test.bzl
+++ b/internal/bazel_integration_test/bazel_integration_test.bzl
@@ -112,8 +112,7 @@ It is assumed by the test runner that the bazel binary is found at label_workspa
         default = ["test ..."],
         doc = """The list of bazel commands to run. Defaults to `["test ..."]`.
 
-`<test_args>` will be replaced with any `--test_args` arguments passed to the `bazel_integration_test` test target. If
-`<test_args>` is not found then any `--test_args` arguments will be added on to the end of the user arguments in the command.
+Note that if a command contains a bare `--` argument, the --test_arg passed to Bazel will appear before it.
 """,
     ),
     "bazelrc_append": attr.string(

--- a/internal/bazel_integration_test/test_runner.js
+++ b/internal/bazel_integration_test/test_runner.js
@@ -29,8 +29,8 @@ const tmp = require('tmp');
 const config = require(process.argv[2]);
 if (DEBUG) console.log(`config: ${JSON.stringify(config, null, 2)}`);
 
-const args = process.argv.slice(3);
-if (DEBUG) console.log(`args: ${JSON.stringify(args, null, 2)}`);
+const testArgs = process.argv.slice(3);
+if (DEBUG) console.log(`testArgs: ${JSON.stringify(testArgs, null, 2)}`);
 
 /**
  * Helper function to log out the contents of a file.
@@ -277,7 +277,15 @@ if (DEBUG) {
 }
 
 for (const bazelCommand of config.bazelCommands) {
-  const bazelArgs = bazelCommand.split(' ').concat(args);
+  const bazelArgs = bazelCommand.split(' ');
+  // look for `<test_args>` keyword and insert testArgs at that point
+  // if it exists, otherwise push to end of arguments
+  const testArgsPosition = bazelArgs.indexOf('<test_args>');
+  if (testArgsPosition !== -1) {
+    bazelArgs.splice(testArgsPosition, 1, ...testArgs);
+  } else {
+    bazelArgs.push(...testArgs);
+  }
   console.log(`\n\nRunning 'bazel ${bazelArgs.join(' ')}'`);
   spawnedProcess = spawnSync(bazelBinary, bazelArgs, {cwd: workspaceRoot, stdio: 'inherit'});
   if (spawnedProcess.status) {

--- a/internal/bazel_integration_test/test_runner.js
+++ b/internal/bazel_integration_test/test_runner.js
@@ -278,11 +278,11 @@ if (DEBUG) {
 
 for (const bazelCommand of config.bazelCommands) {
   const bazelArgs = bazelCommand.split(' ');
-  // look for `<test_args>` keyword and insert testArgs at that point
+  // look for `--` argument and insert testArgs before it
   // if it exists, otherwise push to end of arguments
-  const testArgsPosition = bazelArgs.indexOf('<test_args>');
-  if (testArgsPosition !== -1) {
-    bazelArgs.splice(testArgsPosition, 1, ...testArgs);
+  const doubleHyphenPos = bazelArgs.indexOf('--');
+  if (doubleHyphenPos !== -1) {
+    bazelArgs.splice(doubleHyphenPos, 0, ...testArgs);
   } else {
     bazelArgs.push(...testArgs);
   }


### PR DESCRIPTION
This e2e test was causing issues in https://github.com/bazelbuild/rules_nodejs/pull/1040 since the circleci assertion was using "latest" for npm packages but local_repository for rules_nodejs.