### PR TITLE
fix(karma): error messages truncated due to custom formatter

### DIFF
--- a/packages/karma/src/karma.conf.js
+++ b/packages/karma/src/karma.conf.js
@@ -418,7 +418,7 @@ try {
       // This is a bazel specific formatError that removes the workspace
       // name from stack traces.
       // Look for filenames of the format "(<filename>:<row>:<column>"
-      const FILENAME_REGEX = /\(([^:]+)(:\d+:\d+)/gm;
+      const FILENAME_REGEX = /\(([^:\n\r]+)(:\d+:\d+)/gm;
       msg = msg.replace(FILENAME_REGEX, (_, p1, p2) => {
         if (p1.startsWith('../')) {
           // Remove all leading "../"


### PR DESCRIPTION
Currently error messages printed out by Karma will be truncated
sometimes. This can happen for example if a jasmine test assertion
contains parenthesis characters:

```ts
expect(element.style.transform).toBe('translate3d(...)')
```

If such an assertion fails, the error message from the browser
looks like that:

```
Error: Expected 'translate3d(50px, 100px, 0px)' to be 'translate3d(500px, 100px, 0px)'.
    at <Jasmine>
    at UserContext.eval (../../src/cdk/drag-drop/directives/drag.spec.ts:79:44 <- bin/src/cdk/drag-drop/directives/drag.spec.js:104:57)
```

Currently the format error function that is supposed to clean up paths in the error message, but accidentally matches the first path starting with `(50px, 100px, 0px` and ending with `drag.spec.ts:79:44`). Resulting in a broken error message like:

```
Error: Expected 'translate3d(../src/cdk/drag-drop/directives/drag.spec.ts:79:44 <- bin/src/cdk/drag-drop/directives/drag.spec.js:104:57)
  at UserContext.eval (external/npm/node_modules/zone.js/dist/zone-testing-bundle.js:4954:30)
  at ZoneDelegate.invoke (external/npm/node_modules/zone.js/dist/zone-testing-bundle.js:391:26)
```

[here is a reproduction that shows how the Regex matches incorrectly](https://regexr.com/4jqnl)

Fixes https://github.com/angular/components/issues/16875