### PR TITLE
fix(typescript): add peerDependency on typescript

### DIFF
--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -128,15 +128,13 @@ E2E_TESTS = {
     ],
     workspace_files = "@e2e_typescript//:all_files",
 ) for tsc_version in [
-    "2.7.x",
-    "2.8.x",
-    "2.9.x",
     "3.0.x",
     "3.1.x",
     "3.2.x",
     "3.3.x",
     "3.4.x",
     "3.5.x",
+    "3.6.x",
 ]]
 
 bazel_integration_test(

--- a/packages/typescript/src/package.json
+++ b/packages/typescript/src/package.json
@@ -21,6 +21,10 @@
         "ts_auto_deps": "./ts_auto_deps/ts_auto_deps.js",
         "tsc_wrapped": "./internal/tsc_wrapped/tsc_wrapped.js"
     },
+    "//": "note that typescript doesn't follow semver, so technically anything 3.6 or higher might break us",
+    "peerDependencies": {
+        "typescript": ">=3.0.0 <4.0"
+    },
     "dependencies": {
         "protobufjs": "6.8.8",
         "semver": "5.6.0",


### PR DESCRIPTION
Set it to 3.0 or greater. This lets us drop some e2e testing which was taking a long time on CI.
Note that typescript doesn't do semver so we are conservative about advertising support for versions we don't test on.
