### PR TITLE
refactor: simpler examples and e2e BUILD file

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -228,7 +228,7 @@ tasks:
     build_targets:
     - "//..."
     test_flags:
-    - "--test_tag_filters=examples"
+    - "--test_tag_filters=-manual,examples"
     - "--local_resources=792,1.0,1.0"
     # test_args will be passed to the nested bazel process
     # TODO(gregmagolan): fix frequent flake with multiple cores in nested bazel (osx buildkite & local)
@@ -311,7 +311,7 @@ tasks:
     build_targets:
     - "//..."
     test_flags:
-    - "--test_tag_filters=examples,-fix-windows,-no-bazelci-windows"
+    - "--test_tag_filters=-manual,examples,-fix-windows,-no-bazelci-windows"
     - "--local_resources=792,1.0,1.0"
     # test_args will be passed to the nested bazel process
     - "--test_arg=--test_tag_filters=-no-bazelci,-no-bazelci-windows,-fix-windows"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -321,28 +321,12 @@ k8s_defaults(
 # Setup bazel_integration_test repositories
 #
 
+load("//e2e:index.bzl", "ALL_E2E")
+
 [local_repository(
     name = "e2e_%s" % name,
     path = "e2e/%s" % name,
-) for name in [
-    "bazel_managed_deps",
-    "fine_grained_symlinks",
-    "jasmine",
-    "karma",
-    "karma_stack_trace",
-    "karma_typescript",
-    "less",
-    "node_loader_no_preserve_symlinks",
-    "node_loader_preserve_symlinks",
-    "packages",
-    "stylus",
-    "symlinked_node_modules_npm",
-    "symlinked_node_modules_yarn",
-    "ts_auto_deps",
-    "ts_devserver",
-    "typescript",
-    "webpack",
-]]
+) for name in ALL_E2E]
 
 load("@e2e_packages//:setup_workspace.bzl", "e2e_packages_setup_workspace")
 
@@ -360,19 +344,9 @@ local_repository(
     path = "tools/mock_npm_angular_bazel",
 )
 
+load("//examples:index.bzl", "ALL_EXAMPLES")
+
 [local_repository(
     name = "examples_%s" % name,
     path = "examples/%s" % name,
-) for name in [
-    "app",
-    "nestjs",
-    "parcel",
-    "program",
-    "protocol_buffers",
-    "user_managed_deps",
-    "vendored_node",
-    "vendored_node_and_yarn",
-    "web_testing",
-    "webapp",
-    "worker",
-]]
+) for name in ALL_EXAMPLES]

--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -12,99 +12,118 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@build_bazel_rules_nodejs//internal/bazel_integration_test:bazel_integration_test.bzl", "bazel_integration_test")
-load("@build_bazel_rules_nodejs//packages:index.bzl", "NPM_PACKAGES")
+load(":test.bzl", "e2e_integration_test")
 
-# Mappings of integration tests workspaces to their required npm packages
-# This mapping optimizes development so when making changes to files under packages
-# only affected e2e tests are run.
-E2E_TESTS = {
-    "e2e_bazel_managed_deps": {
+e2e_integration_test(
+    name = "e2e_bazel_managed_deps",
+    npm_packages = {
         "//packages/jasmine:npm_package": "@bazel/jasmine",
     },
-    "e2e_fine_grained_symlinks": {
-    },
-    "e2e_jasmine": {
+)
+
+e2e_integration_test(
+    name = "e2e_fine_grained_symlinks",
+)
+
+e2e_integration_test(
+    name = "e2e_jasmine",
+    npm_packages = {
         "//packages/jasmine:npm_package": "@bazel/jasmine",
     },
-    "e2e_karma": {
+)
+
+e2e_integration_test(
+    name = "e2e_karma",
+    npm_packages = {
         "//packages/karma:npm_package": "@bazel/karma",
     },
-    "e2e_karma_stack_trace": {
+)
+
+e2e_integration_test(
+    name = "e2e_karma_stack_trace",
+    npm_packages = {
         "//packages/karma:npm_package": "@bazel/karma",
         "//packages/typescript:npm_package": "@bazel/typescript",
     },
-    "e2e_karma_typescript": {
+)
+
+e2e_integration_test(
+    name = "e2e_karma_typescript",
+    npm_packages = {
         "//packages/jasmine:npm_package": "@bazel/jasmine",
         "//packages/karma:npm_package": "@bazel/karma",
         "//packages/typescript:npm_package": "@bazel/typescript",
     },
-    "e2e_less": {
+)
+
+e2e_integration_test(
+    name = "e2e_less",
+    npm_packages = {
         "//packages/less:npm_package": "@bazel/less",
     },
-    "e2e_node_loader_no_preserve_symlinks": {
-    },
-    "e2e_node_loader_preserve_symlinks": {
-    },
-    "e2e_packages": {
-    },
-    "e2e_stylus": {
+)
+
+e2e_integration_test(
+    name = "e2e_node_loader_no_preserve_symlinks",
+)
+
+e2e_integration_test(
+    name = "e2e_node_loader_preserve_symlinks",
+)
+
+e2e_integration_test(
+    name = "e2e_packages",
+)
+
+e2e_integration_test(
+    name = "e2e_stylus",
+    npm_packages = {
         "//packages/stylus:npm_package": "@bazel/stylus",
     },
-    "e2e_symlinked_node_modules_npm": {
+)
+
+e2e_integration_test(
+    name = "e2e_symlinked_node_modules_npm",
+    npm_packages = {
         "//packages/hide-bazel-files:npm_package": "@bazel/hide-bazel-files",
     },
-    "e2e_symlinked_node_modules_yarn": {
+)
+
+e2e_integration_test(
+    name = "e2e_symlinked_node_modules_yarn",
+    npm_packages = {
         "//packages/hide-bazel-files:npm_package": "@bazel/hide-bazel-files",
     },
-    "e2e_ts_devserver": {
+)
+
+e2e_integration_test(
+    name = "e2e_ts_devserver",
+    npm_packages = {
         "//packages/hide-bazel-files:npm_package": "@bazel/hide-bazel-files",
         "//packages/protractor:npm_package": "@bazel/protractor",
         "//packages/typescript:npm_package": "@bazel/typescript",
     },
-    "e2e_webpack": {
+)
+
+e2e_integration_test(
+    name = "e2e_webpack",
+    npm_packages = {
         "//packages/jasmine:npm_package": "@bazel/jasmine",
         "//packages/labs:npm_package": "@bazel/labs",
     },
-}
+)
 
-[bazel_integration_test(
-    name = wksp_name,
-    # some bazelrc imports are outside of the nested workspace so
-    # the test runner will handle these as special cases
-    bazelrc_imports = {
-        "//:common.bazelrc": "import %workspace%/../../common.bazelrc",
+e2e_integration_test(
+    name = "e2e_typescript",
+    npm_packages = {
+        "//packages/jasmine:npm_package": "@bazel/jasmine",
+        "//packages/typescript:npm_package": "@bazel/typescript",
     },
-    check_npm_packages = NPM_PACKAGES,
-    # package.json will be updated with `file:` links to the absolute paths
-    # of the generated npm packages in runfiles
-    npm_packages = E2E_TESTS[wksp_name],
-    # replace the following repositories with the generated archives
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-    },
-    tags = [
-        "e2e",
-        # exclusive keyword will force the test to be run in the "exclusive" mode,
-        # ensuring that no other tests are running at the same time. Such tests
-        # will be executed in serial fashion after all build activity and non-exclusive
-        # tests have been completed. Remote execution is disabled for such tests
-        # because Bazel doesn't have control over what's running on a remote machine.
-        "exclusive",
-    ],
-    workspace_files = "@%s//:all_files" % wksp_name,
-) for wksp_name in E2E_TESTS]
+    workspace_files = "@e2e_typescript//:all_files",
+)
 
-[bazel_integration_test(
+[e2e_integration_test(
     name = "e2e_typescript_%s" % tsc_version.replace(".", "_"),
-    # some bazelrc imports are outside of the nested workspace so
-    # the test runner will handle these as special cases
-    bazelrc_imports = {
-        "//:common.bazelrc": "import %workspace%/../../common.bazelrc",
-    },
-    check_npm_packages = NPM_PACKAGES,
-    # package.json will be updated with `file:` links to the absolute paths
-    # of the generated npm packages in runfiles
     npm_packages = {
         "//packages/jasmine:npm_package": "@bazel/jasmine",
         "//packages/typescript:npm_package": "@bazel/typescript",
@@ -113,19 +132,6 @@ E2E_TESTS = {
     package_json_replacements = {
         "typescript": tsc_version,
     },
-    # replace the following repositories with the generated archives
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-    },
-    tags = [
-        "e2e",
-        # exclusive keyword will force the test to be run in the "exclusive" mode,
-        # ensuring that no other tests are running at the same time. Such tests
-        # will be executed in serial fashion after all build activity and non-exclusive
-        # tests have been completed. Remote execution is disabled for such tests
-        # because Bazel doesn't have control over what's running on a remote machine.
-        "exclusive",
-    ],
     workspace_files = "@e2e_typescript//:all_files",
 ) for tsc_version in [
     "2.7.x",
@@ -139,73 +145,40 @@ E2E_TESTS = {
     "3.5.x",
 ]]
 
-bazel_integration_test(
+e2e_integration_test(
     name = "e2e_ts_auto_deps",
     bazel_commands = [
         "run @nodejs//:yarn",
         "run @nodejs//:bin/yarn -- generate_build_file",
         "build //simple:simple",
     ],
-    # some bazelrc imports are outside of the nested workspace so
-    # the test runner will handle these as special cases
-    bazelrc_imports = {
-        "//:common.bazelrc": "import %workspace%/../../common.bazelrc",
-    },
-    check_npm_packages = NPM_PACKAGES,
-    # package.json will be updated with `file:` links to the absolute paths
-    # of the generated npm packages in runfiles
     npm_packages = {
         "//packages/typescript:npm_package": "@bazel/typescript",
     },
-    # replace the following repositories with the generated archives
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-    },
-    tags = [
-        "e2e",
-        # exclusive keyword will force the test to be run in the "exclusive" mode,
-        # ensuring that no other tests are running at the same time. Such tests
-        # will be executed in serial fashion after all build activity and non-exclusive
-        # tests have been completed. Remote execution is disabled for such tests
-        # because Bazel doesn't have control over what's running on a remote machine.
-        "exclusive",
-    ],
-    workspace_files = "@e2e_ts_auto_deps//:all_files",
 )
 
-bazel_integration_test(
+e2e_integration_test(
     name = "e2e_angular_bazel_example",
     size = "enormous",
     timeout = "eternal",
     # to reduce the chance of depleting all available system memory locally
     # and on CI, limit the Bazel JVM memory usage for the nested bazel process
     bazelrc_append = "startup --host_jvm_args=-Xms256m --host_jvm_args=-Xmx2g",
-    # package.json will be updated with `file:` links to the absolute paths
-    # of the generated npm packages in runfiles
-    check_npm_packages = NPM_PACKAGES,
     npm_packages = {
         "//packages/karma:npm_package": "@bazel/karma",
         "//packages/protractor:npm_package": "@bazel/protractor",
         "//packages/typescript:npm_package": "@bazel/typescript",
     },
-    # replace the following repositories with the generated archives
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-    },
-    tags = [
-        "e2e",
-        # exclusive keyword will force the test to be run in the "exclusive" mode,
-        # ensuring that no other tests are running at the same time. Such tests
-        # will be executed in serial fashion after all build activity and non-exclusive
-        # tests have been completed. Remote execution is disabled for such tests
-        # because Bazel doesn't have control over what's running on a remote machine.
-        "exclusive",
-        # manual keyword will force the test target to not be included in target
-        # pattern wildcards (..., :*, :all, etc); the test target will be neither
-        # built nor run. It will also be ignored by the test_suite rules that do
-        # not mention this test explicitly. The only way to build or run such a test
-        # is to specify it via an explicit target pattern on the command line.
-        "manual",
-    ],
+    # TODO(gregmagolan): why is this tagged manual?
+    tags = ["manual"],
     workspace_files = "@e2e_angular_bazel_example//:bazel_integration_test_files",
+)
+
+load(":index.bzl", "ALL_E2E")
+
+# Ensure that all e2e directories have a test target
+# Otherwise it would be easy to add a new one, but not have a test registered for it
+test_suite(
+    name = "all_e2e",
+    tests = [":e2e_%s" % t for t in ALL_E2E],
 )

--- a/e2e/index.bzl
+++ b/e2e/index.bzl
@@ -1,0 +1,20 @@
+"Listing of all e2e tests, used to set up their repositories in /WORKSPACE"
+ALL_E2E = [
+    "bazel_managed_deps",
+    "fine_grained_symlinks",
+    "jasmine",
+    "karma",
+    "karma_stack_trace",
+    "karma_typescript",
+    "less",
+    "node_loader_no_preserve_symlinks",
+    "node_loader_preserve_symlinks",
+    "packages",
+    "stylus",
+    "symlinked_node_modules_npm",
+    "symlinked_node_modules_yarn",
+    "ts_auto_deps",
+    "ts_devserver",
+    "typescript",
+    "webpack",
+]

--- a/e2e/test.bzl
+++ b/e2e/test.bzl
@@ -1,0 +1,8 @@
+"Define a convenience macro for e2e integration testing"
+
+load("@build_bazel_rules_nodejs//internal/bazel_integration_test:bazel_integration_test.bzl", "rules_nodejs_integration_test")
+
+def e2e_integration_test(**kwargs):
+    "Set defaults for the bazel_integration_test common to our e2e"
+    tags = kwargs.pop("tags", []) + ["e2e"]
+    rules_nodejs_integration_test(tags = tags, **kwargs)

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -12,224 +12,103 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@build_bazel_rules_nodejs//internal/bazel_integration_test:bazel_integration_test.bzl", "bazel_integration_test")
-load("@build_bazel_rules_nodejs//packages:index.bzl", "NPM_PACKAGES")
+load(":test.bzl", "example_integration_test")
 
-# Mappings of integration tests workspaces to their required npm packages
-# This mapping optimizes development so when making changes to files under packages
-# only affected examples tests are run.
-EXAMPLES_TESTS = {
-    "examples_app": {
+example_integration_test(
+    name = "examples_app",
+    npm_packages = {
         "//packages/hide-bazel-files:npm_package": "@bazel/hide-bazel-files",
         "//packages/protractor:npm_package": "@bazel/protractor",
         "//packages/typescript:npm_package": "@bazel/typescript",
     },
-    "examples_parcel": {
+)
+
+example_integration_test(
+    name = "examples_parcel",
+    npm_packages = {
         "//packages/jasmine:npm_package": "@bazel/jasmine",
     },
-    "examples_web_testing": {
+)
+
+example_integration_test(
+    name = "examples_web_testing",
+    npm_packages = {
         "//packages/karma:npm_package": "@bazel/karma",
         "//packages/typescript:npm_package": "@bazel/typescript",
     },
-    "examples_webapp": {
+)
+
+example_integration_test(
+    name = "examples_webapp",
+    npm_packages = {
         "//packages/protractor:npm_package": "@bazel/protractor",
     },
-}
+)
 
-[bazel_integration_test(
-    name = wksp_name,
-    # some bazelrc imports are outside of the nested workspace so
-    # the test runner will handle these as special cases
-    bazelrc_imports = {
-        "//:common.bazelrc": "import %workspace%/../../common.bazelrc",
-    },
-    check_npm_packages = NPM_PACKAGES,
-    # package.json will be updated with `file:` links to the absolute paths
-    # of the generated npm packages in runfiles
-    npm_packages = EXAMPLES_TESTS[wksp_name],
-    # replace the following repositories with the generated archives
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-    },
-    tags = [
-        "examples",
-        # exclusive keyword will force the test to be run in the "exclusive" mode,
-        # ensuring that no other tests are running at the same time. Such tests
-        # will be executed in serial fashion after all build activity and non-exclusive
-        # tests have been completed. Remote execution is disabled for such tests
-        # because Bazel doesn't have control over what's running on a remote machine.
-        "exclusive",
-    ],
-    workspace_files = "@%s//:all_files" % wksp_name,
-) for wksp_name in EXAMPLES_TESTS]
-
-bazel_integration_test(
+example_integration_test(
     name = "examples_nestjs",
     bazel_commands = [
         "build ...",
         # Test cross-platform build
         "build --platforms=@build_bazel_rules_nodejs//toolchains/node:linux_amd64 //src:docker",
     ],
-    # some bazelrc imports are outside of the nested workspace so
-    # the test runner will handle these as special cases
-    bazelrc_imports = {
-        "//:common.bazelrc": "import %workspace%/../../common.bazelrc",
-    },
-    check_npm_packages = NPM_PACKAGES,
-    # package.json will be updated with `file:` links to the absolute paths
-    # of the generated npm packages in runfiles
     npm_packages = {
         "//packages/typescript:npm_package": "@bazel/typescript",
     },
-    # replace the following repositories with the generated archives
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-    },
-    tags = [
-        # Breaks on Windows with `rules_docker requires a python interpreter installed. Please set
-        # BAZEL_PYTHON, or put it on your path.`
-        "fix-windows",
-        "examples",
-        # exclusive keyword will force the test to be run in the "exclusive" mode,
-        # ensuring that no other tests are running at the same time. Such tests
-        # will be executed in serial fashion after all build activity and non-exclusive
-        # tests have been completed. Remote execution is disabled for such tests
-        # because Bazel doesn't have control over what's running on a remote machine.
-        "exclusive",
-    ],
-    workspace_files = "@examples_nestjs//:all_files",
+    # Breaks on Windows with `rules_docker requires a python interpreter installed. Please set
+    # BAZEL_PYTHON, or put it on your path.`
+    tags = ["fix-windows"],
 )
 
-bazel_integration_test(
+example_integration_test(
     name = "examples_protocol_buffers",
-    # some bazelrc imports are outside of the nested workspace so
-    # the test runner will handle these as special cases
-    bazelrc_imports = {
-        "//:common.bazelrc": "import %workspace%/../../common.bazelrc",
-    },
-    check_npm_packages = NPM_PACKAGES,
-    # package.json will be updated with `file:` links to the absolute paths
-    # of the generated npm packages in runfiles
     npm_packages = {
         "//packages/hide-bazel-files:npm_package": "@bazel/hide-bazel-files",
         "//packages/karma:npm_package": "@bazel/karma",
         "//packages/protractor:npm_package": "@bazel/protractor",
         "//packages/typescript:npm_package": "@bazel/typescript",
     },
-    # replace the following repositories with the generated archives
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-    },
-    tags = [
-        # Runs out of memory on bazelci windows
-        # TODO(gregmagolan): fix on bazelci windows
-        "no-bazelci-windows",
-        "examples",
-        # exclusive keyword will force the test to be run in the "exclusive" mode,
-        # ensuring that no other tests are running at the same time. Such tests
-        # will be executed in serial fashion after all build activity and non-exclusive
-        # tests have been completed. Remote execution is disabled for such tests
-        # because Bazel doesn't have control over what's running on a remote machine.
-        "exclusive",
-    ],
-    workspace_files = "@examples_protocol_buffers//:all_files",
+    # Runs out of memory on bazelci windows
+    # TODO(gregmagolan): fix on bazelci windows
+    tags = ["no-bazelci-windows"],
 )
 
-bazel_integration_test(
+example_integration_test(
     name = "examples_user_managed_deps",
     # This test requires calling `bazel run @nodejs//:yarn` before `bazel test ...`
     bazel_commands = [
         "run @nodejs//:yarn",
         "test ...",
     ],
-    # some bazelrc imports are outside of the nested workspace so
-    # the test runner will handle these as special cases
-    bazelrc_imports = {
-        "//:common.bazelrc": "import %workspace%/../../common.bazelrc",
-    },
-    check_npm_packages = NPM_PACKAGES,
     # replace the following repositories with the generated archives
     repositories = {
         "//:release": "build_bazel_rules_nodejs",
         "@npm_bazel_jasmine//:release": "npm_bazel_jasmine",
     },
-    tags = [
-        "examples",
-        # exclusive keyword will force the test to be run in the "exclusive" mode,
-        # ensuring that no other tests are running at the same time. Such tests
-        # will be executed in serial fashion after all build activity and non-exclusive
-        # tests have been completed. Remote execution is disabled for such tests
-        # because Bazel doesn't have control over what's running on a remote machine.
-        "exclusive",
-    ],
-    workspace_files = "@examples_user_managed_deps//:all_files",
 )
 
-bazel_integration_test(
+example_integration_test(
     name = "examples_vendored_node",
-    # some bazelrc imports are outside of the nested workspace so
-    # the test runner will handle these as special cases
-    bazelrc_imports = {
-        "//:common.bazelrc": "import %workspace%/../../common.bazelrc",
-    },
-    check_npm_packages = NPM_PACKAGES,
-    # package.json will be updated with `file:` links to the absolute paths
-    # of the generated npm packages in runfiles
     npm_packages = {
         "//packages/jasmine:npm_package": "@bazel/jasmine",
     },
-    # replace the following repositories with the generated archives
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-    },
-    tags = [
-        # This example only works on linux as it downloads the linux node distribution
-        # TODO(gregmagolan): make node_repositories acccept different archives for different platforms
-        "manual",
-        "examples",
-        # exclusive keyword will force the test to be run in the "exclusive" mode,
-        # ensuring that no other tests are running at the same time. Such tests
-        # will be executed in serial fashion after all build activity and non-exclusive
-        # tests have been completed. Remote execution is disabled for such tests
-        # because Bazel doesn't have control over what's running on a remote machine.
-        "exclusive",
-    ],
-    workspace_files = "@examples_vendored_node//:all_files",
+    # This example only works on linux as it downloads the linux node distribution
+    # TODO(gregmagolan): make node_repositories acccept different archives for different platforms
+    tags = ["manual"],
 )
 
-bazel_integration_test(
+example_integration_test(
     name = "examples_vendored_node_and_yarn",
-    # some bazelrc imports are outside of the nested workspace so
-    # the test runner will handle these as special cases
-    bazelrc_imports = {
-        "//:common.bazelrc": "import %workspace%/../../common.bazelrc",
-    },
-    check_npm_packages = NPM_PACKAGES,
-    # package.json will be updated with `file:` links to the absolute paths
-    # of the generated npm packages in runfiles
     npm_packages = {
         "//packages/jasmine:npm_package": "@bazel/jasmine",
     },
-    # replace the following repositories with the generated archives
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-    },
-    tags = [
-        # This example only works on linux as it downloads the linux node distribution
-        # TODO(gregmagolan): make node_repositories acccept different archives for different platforms
-        "manual",
-        "examples",
-        # exclusive keyword will force the test to be run in the "exclusive" mode,
-        # ensuring that no other tests are running at the same time. Such tests
-        # will be executed in serial fashion after all build activity and non-exclusive
-        # tests have been completed. Remote execution is disabled for such tests
-        # because Bazel doesn't have control over what's running on a remote machine.
-        "exclusive",
-    ],
+    # This example only works on linux as it downloads the linux node distribution
+    # TODO(gregmagolan): make node_repositories acccept different archives for different platforms
+    tags = ["manual"],
     workspace_files = "@examples_vendored_node//:all_files",
 )
 
-bazel_integration_test(
+example_integration_test(
     name = "examples_worker",
     # There are no tests in this example
     bazel_commands = [
@@ -238,14 +117,14 @@ bazel_integration_test(
         # Build again without the worker
         "build --define=cache_bust=true --strategy=DoWork=standalone //:do_work",
     ],
-    bazelrc_imports = {
-        "//:common.bazelrc": "import %workspace%/../../common.bazelrc",
-    },
-    check_npm_packages = NPM_PACKAGES,
     npm_packages = {"//packages/worker:npm_package": "@bazel/worker"},
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-    },
-    tags = ["examples"],
-    workspace_files = "@examples_worker//:all_files",
+)
+
+load(":index.bzl", "ALL_EXAMPLES")
+
+# Ensure that all e2e directories have a test target
+# Otherwise it would be easy to add a new one, but not have a test registered for it
+test_suite(
+    name = "all_examples",
+    tests = [":examples_%s" % t for t in ALL_EXAMPLES],
 )

--- a/examples/index.bzl
+++ b/examples/index.bzl
@@ -1,0 +1,13 @@
+"Used to reference the nested workspaces for examples in /WORKSPACE"
+ALL_EXAMPLES = [
+    "app",
+    "nestjs",
+    "parcel",
+    "protocol_buffers",
+    "user_managed_deps",
+    "vendored_node",
+    "vendored_node_and_yarn",
+    "web_testing",
+    "webapp",
+    "worker",
+]

--- a/examples/test.bzl
+++ b/examples/test.bzl
@@ -1,0 +1,8 @@
+"Define a convenience macro for examples integration testing"
+
+load("@build_bazel_rules_nodejs//internal/bazel_integration_test:bazel_integration_test.bzl", "rules_nodejs_integration_test")
+
+def example_integration_test(**kwargs):
+    "Set defaults for the bazel_integration_test common to our examples"
+    tags = kwargs.pop("tags", []) + ["examples"]
+    rules_nodejs_integration_test(tags = tags, **kwargs)


### PR DESCRIPTION
Instead of looping over a dict, make a macro that allows shorter declarations so each test can be declared at top-level
Reduces a bunch of duplication.
