### PR TITLE
feat(terser): introduce @bazel/terser package

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -18,6 +18,7 @@ module.exports = {
         'protractor',
         'stylus',
         'rollup',
+        'terser',
         'typescript',
         'worker',
       ]

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -41,6 +41,7 @@ _PACKAGE_READMES = {
     "Less": "//packages/less:README.md",
     "Protractor": "//packages/protractor:README.md",
     "Stylus": "//packages/stylus:README.md",
+    "Terser": "//packages/terser:README.md",
     "TypeScript": "//packages/typescript:README.md",
 }
 

--- a/docs/Terser.md
+++ b/docs/Terser.md
@@ -1,0 +1,113 @@
+---
+title: Terser
+layout: default
+stylesheet: docs
+---
+# Terser rules for Bazel
+
+**WARNING: this is beta-quality software. Breaking changes are likely. Not recommended for production use without expert support.**
+
+The Terser rules run the Terser JS minifier with Bazel.
+
+Wraps the Terser CLI documented at https://github.com/terser-js/terser#command-line-usage
+
+
+## Installation
+
+Add the `@bazel/terser` npm package to your `devDependencies` in `package.json`.
+
+Your `WORKSPACE` should declare a `yarn_install` or `npm_install` rule named `npm`.
+It should then install the rules found in the npm packages using the `install_bazel_dependencies` function.
+See https://github.com/bazelbuild/rules_nodejs/#quickstart
+
+This causes the `@bazel/terser` package to be installed as a Bazel workspace named `npm_bazel_terser`.
+
+
+## Installing with self-managed dependencies
+
+If you didn't use the `yarn_install` or `npm_install` rule to create an `npm` workspace, you'll have to declare a rule in your root `BUILD.bazel` file to execute terser:
+
+```python
+# Create a terser rule to use in terser_minified#terser_bin
+# attribute when using self-managed dependencies
+nodejs_binary(
+    name = "terser_bin",
+    entry_point = "//:node_modules/terser/bin/uglifyjs",
+    # Point bazel to your node_modules to find the entry point
+    node_modules = ["//:node_modules"],
+)
+```
+
+[name]: https://bazel.build/docs/build-ref.html#name
+[label]: https://bazel.build/docs/build-ref.html#labels
+[labels]: https://bazel.build/docs/build-ref.html#labels
+
+
+## terser_minified
+
+Run the terser minifier.
+    
+Typical example:
+```python
+load("@npm_bazel_terser//:index.bzl", "terser_minified")
+
+terser_minified(
+    name = "out.min",
+    src = "input.js",
+    config_file = "terser_config.json",
+)
+```
+
+Note that the `name` attribute determines what the resulting files will be called.
+
+
+
+### Usage
+
+```
+terser_minified(name, config_file, debug, sourcemap, src, terser_bin)
+```
+
+
+
+#### `name`
+(*[name], mandatory*): A unique name for this target.
+
+
+#### `config_file`
+(*[label]*): A JSON file containing Terser minify() options.
+
+This is the file you would pass to the --config-file argument in terser's CLI.
+https://github.com/terser-js/terser#minify-options documents the content of the file.
+
+Bazel will make a copy of your config file, treating it as a template.
+If you use the magic strings `bazel_debug` or `bazel_no_debug`, these will be
+replaced with `true` and `false` respecting the value of the `debug` attribute
+or the `--define=DEBUG=true` bazel flag.
+
+If this isn't supplied, Bazel will use a default config file.
+
+
+#### `debug`
+(*Boolean*): Configure terser to produce more readable output.
+
+Instead of setting this attribute, consider setting the DEBUG variable instead
+bazel build --define=DEBUG=true //my/terser:target
+so that it only affects the current build.
+
+
+#### `sourcemap`
+(*Boolean*): Whether to produce a .js.map file for each .js output
+
+
+#### `src`
+(*[label], mandatory*): A JS file, or a rule producing .js as its default output
+
+Note that you can pass multiple files to terser, which it will bundle together.
+If you want to do this, you can pass a filegroup here.
+
+
+#### `terser_bin`
+(*[label]*): An executable target that runs Terser
+
+

--- a/docs/_includes/drawer.html
+++ b/docs/_includes/drawer.html
@@ -41,6 +41,12 @@
           </ul>
         </li>
         <li>
+          <span class="drawer-nav-title">Optimizers</span>
+          <ul>
+            <li><a href="Terser.html">Terser</a></li>
+          </ul>
+        </li>
+        <li>
           <span class="drawer-nav-title">Deployment</span>
           <ul>
             <li><a href="https://github.com/bazelbuild/rules_docker#nodejs_image">Docker <i class="material-icons">launch</i></a></li>

--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -97,6 +97,13 @@ e2e_integration_test(
 )
 
 e2e_integration_test(
+    name = "e2e_terser",
+    npm_packages = {
+        "//packages/terser:npm_package": "@bazel/terser",
+    },
+)
+
+e2e_integration_test(
     name = "e2e_ts_devserver",
     npm_packages = {
         "//packages/hide-bazel-files:npm_package": "@bazel/hide-bazel-files",

--- a/e2e/index.bzl
+++ b/e2e/index.bzl
@@ -13,6 +13,7 @@ ALL_E2E = [
     "stylus",
     "symlinked_node_modules_npm",
     "symlinked_node_modules_yarn",
+    "terser",
     "ts_auto_deps",
     "ts_devserver",
     "typescript",

--- a/e2e/terser/.bazelrc
+++ b/e2e/terser/.bazelrc
@@ -1,0 +1,1 @@
+import %workspace%/../../common.bazelrc

--- a/e2e/terser/BUILD.bazel
+++ b/e2e/terser/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_test")
+load("@npm_bazel_terser//:index.bzl", "terser_minified")
+
+terser_minified(
+    name = "out.min",
+    src = "input.js",
+)
+
+nodejs_test(
+    name = "test",
+    data = ["out.min.js"],
+    entry_point = ":test.js",
+)
+
+# For testing from the root workspace of this repository with bazel_integration_test.
+filegroup(
+    name = "all_files",
+    srcs = glob(
+        include = ["**/*"],
+        exclude = [
+            "bazel-out/**/*",
+            "dist/**/*",
+            "node_modules/**/*",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)

--- a/e2e/terser/WORKSPACE
+++ b/e2e/terser/WORKSPACE
@@ -1,0 +1,38 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+workspace(
+    name = "e2e_terser",
+    managed_directories = {"@npm": ["node_modules"]},
+)
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "build_bazel_rules_nodejs",
+    sha256 = "3356c6b767403392bab018ce91625f6d15ff8f11c6d772dc84bc9cada01c669a",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.36.1/rules_nodejs-0.36.1.tar.gz"],
+)
+
+load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")
+
+yarn_install(
+    name = "npm",
+    package_json = "//:package.json",
+    yarn_lock = "//:yarn.lock",
+)
+
+load("@npm//:install_bazel_dependencies.bzl", "install_bazel_dependencies")
+
+install_bazel_dependencies()

--- a/e2e/terser/input.js
+++ b/e2e/terser/input.js
@@ -1,0 +1,2 @@
+const somelongname = 1;
+console.error(somelongname);

--- a/e2e/terser/package.json
+++ b/e2e/terser/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "e2e-terser",
+    "private": true,
+    "devDependencies": {
+        "@bazel/terser": "latest"
+    },
+    "scripts": {
+      "test": "bazel test ..."
+    }
+}

--- a/e2e/terser/test.js
+++ b/e2e/terser/test.js
@@ -1,0 +1,5 @@
+const fs = require('fs');
+const content = fs.readFileSync(require.resolve(__dirname + '/out.min.js'), 'utf-8');
+if (content.indexOf('console.error(1)') < 1) {
+  console.error(content), process.exitCode = 1;
+}

--- a/internal/golden_file_test/BUILD.bazel
+++ b/internal/golden_file_test/BUILD.bazel
@@ -1,0 +1,3 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["bin.js"])

--- a/internal/golden_file_test/bin.js
+++ b/internal/golden_file_test/bin.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const unidiff = require('unidiff');
+
+function main(args) {
+  const [mode, golden, actual] = args;
+  const actualContents = fs.readFileSync(require.resolve(actual), 'utf-8').replace(/\r\n/g, '\n');
+  const goldenContents = fs.readFileSync(require.resolve(golden), 'utf-8').replace(/\r\n/g, '\n');
+
+  if (actualContents !== goldenContents) {
+    if (mode === '--out') {
+      // Write to golden file
+      fs.writeFileSync(require.resolve(golden), actualContents);
+      console.error(`Replaced ${path.join(process.cwd(), golden)}`);
+    } else if (mode === '--verify') {
+      // Generated does not match golden
+      const diff = unidiff.diffLines(goldenContents, actualContents);
+      const prettyDiff = unidiff.formatLines(diff, {aname: golden, bname: actual});
+      throw new Error(`Actual output doesn't match golden file:
+      
+${prettyDiff}
+      
+Update the golden file:
+
+            bazel run ${process.env['BAZEL_TARGET'].replace(/_bin$/, '')}.accept
+`);
+    } else {
+      throw new Error('unknown mode', mode);
+    }
+  }
+}
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}

--- a/internal/golden_file_test/golden_file_test.bzl
+++ b/internal/golden_file_test/golden_file_test.bzl
@@ -1,0 +1,24 @@
+"Convenience for testing that an output matches a file"
+
+load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary", "nodejs_test")
+
+def golden_file_test(name, golden, actual, **kwargs):
+    data = [golden, actual, "@npm//unidiff"]
+
+    loc = "$(location %s)"
+    nodejs_test(
+        name = name,
+        entry_point = "@build_bazel_rules_nodejs//internal/golden_file_test:bin.js",
+        templated_args = ["--verify", loc % golden, loc % actual],
+        data = data,
+        **kwargs
+    )
+
+    nodejs_binary(
+        name = name + ".accept",
+        testonly = True,
+        entry_point = "@build_bazel_rules_nodejs//internal/golden_file_test:bin.js",
+        templated_args = ["--out", loc % golden, loc % actual],
+        data = data,
+        **kwargs
+    )

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "semver": "5.6.0",
         "shelljs": "0.8.3",
         "sinon": "^7.3.2",
+        "source-map": "^0.7.3",
         "source-map-support": "0.5.9",
         "stylus": "~0.54.5",
         "terser": "3.17.0",

--- a/packages/terser/BUILD.bazel
+++ b/packages/terser/BUILD.bazel
@@ -1,0 +1,42 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "npm_package")
+
+# Ugly genrule depending on local linux environment to build the README out of skylark doc generation.
+# Only referenced when we do a release.
+# TODO: This ought to be possible with stardoc alone. Need to coordinate with Chris Parsons.
+genrule(
+    name = "generate_README",
+    srcs = [
+        "//packages/terser/docs:index.md",
+        "//packages/terser/docs:install.md",
+    ],
+    outs = ["README.md"],
+    cmd = """cat $(location //packages/terser/docs:install.md) $(location //packages/terser/docs:index.md) | sed 's/^##/\\\n##/' > $@""",
+    visibility = ["//docs:__pkg__"],
+)
+
+npm_package(
+    name = "npm_package",
+    srcs = [
+        "@npm_bazel_terser//:package_contents",
+    ],
+    vendor_external = [
+        "npm_bazel_terser",
+    ],
+    deps = [
+        ":generate_README",
+    ],
+)

--- a/packages/terser/docs/BUILD.bazel
+++ b/packages/terser/docs/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//tools/stardoc:index.bzl", "stardoc")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["install.md"])
+
+stardoc(
+    name = "docs",
+    testonly = True,
+    out = "index.md",
+    input = "@npm_bazel_terser//:index.bzl",
+    deps = ["@npm_bazel_terser//:bzl"],
+)

--- a/packages/terser/docs/install.md
+++ b/packages/terser/docs/install.md
@@ -1,0 +1,33 @@
+# Terser rules for Bazel
+
+**WARNING: this is beta-quality software. Breaking changes are likely. Not recommended for production use without expert support.**
+
+The Terser rules run the Terser JS minifier with Bazel.
+
+Wraps the Terser CLI documented at https://github.com/terser-js/terser#command-line-usage
+
+## Installation
+
+Add the `@bazel/terser` npm package to your `devDependencies` in `package.json`.
+
+Your `WORKSPACE` should declare a `yarn_install` or `npm_install` rule named `npm`.
+It should then install the rules found in the npm packages using the `install_bazel_dependencies` function.
+See https://github.com/bazelbuild/rules_nodejs/#quickstart
+
+This causes the `@bazel/terser` package to be installed as a Bazel workspace named `npm_bazel_terser`.
+
+## Installing with self-managed dependencies
+
+If you didn't use the `yarn_install` or `npm_install` rule to create an `npm` workspace, you'll have to declare a rule in your root `BUILD.bazel` file to execute terser:
+
+```python
+# Create a terser rule to use in terser_minified#terser_bin
+# attribute when using self-managed dependencies
+nodejs_binary(
+    name = "terser_bin",
+    entry_point = "//:node_modules/terser/bin/uglifyjs",
+    # Point bazel to your node_modules to find the entry point
+    node_modules = ["//:node_modules"],
+)
+```
+

--- a/packages/terser/src/BUILD.bazel
+++ b/packages/terser/src/BUILD.bazel
@@ -1,0 +1,40 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["terser_config.default.json"])
+
+bzl_library(
+    name = "bzl",
+    srcs = glob(["*.bzl"]),
+    deps = [
+        "@build_bazel_rules_nodejs//:bzl",
+        "@build_bazel_rules_nodejs//internal/common:bzl",
+    ],
+)
+
+filegroup(
+    name = "package_contents",
+    srcs = [
+        "BUILD.bazel",
+        "index.bzl",
+        "index.js",
+        "package.json",
+        "terser_config.default.json",
+        "terser_minified.bzl",
+    ],
+)

--- a/packages/terser/src/WORKSPACE
+++ b/packages/terser/src/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "npm_bazel_terser")

--- a/packages/terser/src/index.bzl
+++ b/packages/terser/src/index.bzl
@@ -1,4 +1,4 @@
-# Copyright 2017 The Bazel Authors. All rights reserved.
+# Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,23 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Index file for packages.
-"""
+"Public API for terser rules"
 
-# packages that have nested workspaces in `src` folder
-NESTED_PACKAGES = [
-    "jasmine",
-    "karma",
-    "labs",
-    "less",
-    "protractor",
-    "stylus",
-    "terser",
-    "typescript",
-]
+load(":terser_minified.bzl", _terser_minified = "terser_minified")
 
-NPM_PACKAGES = [
-    "@bazel/create",
-    "@bazel/hide-bazel-files",
-    "@bazel/worker",
-] + ["@bazel/%s" % pkg for pkg in NESTED_PACKAGES]
+terser_minified = _terser_minified

--- a/packages/terser/src/index.from_src.bzl
+++ b/packages/terser/src/index.from_src.bzl
@@ -1,4 +1,4 @@
-# Copyright 2017 The Bazel Authors. All rights reserved.
+# Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,23 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Index file for packages.
+""" Defaults for usage without @npm//@bazel/terser
 """
 
-# packages that have nested workspaces in `src` folder
-NESTED_PACKAGES = [
-    "jasmine",
-    "karma",
-    "labs",
-    "less",
-    "protractor",
-    "stylus",
-    "terser",
-    "typescript",
-]
+load(
+    ":index.bzl",
+    _terser_minified = "terser_minified",
+)
 
-NPM_PACKAGES = [
-    "@bazel/create",
-    "@bazel/hide-bazel-files",
-    "@bazel/worker",
-] + ["@bazel/%s" % pkg for pkg in NESTED_PACKAGES]
+def terser_minified(**kwargs):
+    _terser_minified(
+        # Override to point to the one installed by build_bazel_rules_nodejs in the root
+        terser_bin = "@npm//terser/bin:terser",
+        **kwargs
+    )

--- a/packages/terser/src/index.js
+++ b/packages/terser/src/index.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+// Pass-through require, ensures that the nodejs_binary will load the version of terser
+// from @bazel/terser package.json, not some other version the user depends on.
+require('terser/bin/uglifyjs');
+
+// TODO: add support for minifying multiple files (eg. a TreeArtifact) in a single execution
+// Under Node 12 it should use the worker threads API to saturate all local cores

--- a/packages/terser/src/package.json
+++ b/packages/terser/src/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "@bazel/terser",
+    "dependencies": {
+        "terser": "4.1.2"
+    },
+    "description": "Run Terser JS optimizer under Bazel",
+    "license": "Apache-2.0",
+    "version": "0.0.0-PLACEHOLDER",
+    "repository": {
+        "type" : "git",
+        "url" : "https://github.com/bazelbuild/rules_nodejs.git",
+        "directory": "packages/terser"
+    },
+    "bugs": {
+        "url": "https://github.com/bazelbuild/rules_nodejs/issues"
+    },
+    "keywords": [
+        "terser",
+        "bazel"
+    ],
+    "bin": {
+        "terser": "index.js"
+    },
+    "bazelWorkspaces": {
+        "npm_bazel_terser": {
+            "rootPath": "."
+        }
+    }
+}

--- a/packages/terser/src/terser_config.default.json
+++ b/packages/terser/src/terser_config.default.json
@@ -1,0 +1,12 @@
+{
+    "compress": {
+        "global_defs": {"ngDevMode": false, "ngI18nClosureMode": false},
+        "keep_fnames": "bazel_no_debug",
+        "passes": 3,
+        "pure_getters": true,
+        "reduce_funcs": "bazel_no_debug",
+        "reduce_vars": "bazel_no_debug",
+        "sequences": "bazel_no_debug"
+    },
+    "mangle": "bazel_no_debug"
+}

--- a/packages/terser/src/terser_minified.bzl
+++ b/packages/terser/src/terser_minified.bzl
@@ -1,0 +1,153 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"Rule to run the terser binary under bazel"
+
+_TERSER_ATTRS = {
+    "src": attr.label(
+        doc = """A JS file, or a rule producing .js as its default output
+
+Note that you can pass multiple files to terser, which it will bundle together.
+If you want to do this, you can pass a filegroup here.""",
+        allow_files = [".js"],
+        mandatory = True,
+    ),
+    "config_file": attr.label(
+        doc = """A JSON file containing Terser minify() options.
+
+This is the file you would pass to the --config-file argument in terser's CLI.
+https://github.com/terser-js/terser#minify-options documents the content of the file.
+
+Bazel will make a copy of your config file, treating it as a template.
+
+> Run bazel with `--subcommands` to see the path to the copied file.
+
+If you use the magic strings `"bazel_debug"` or `"bazel_no_debug"`, these will be
+replaced with `true` and `false` respecting the value of the `debug` attribute
+or the `--define=DEBUG=true` bazel flag.
+
+For example,
+
+```
+{
+    "compress": {
+        "arrows": "bazel_no_debug"
+    }
+}
+```
+Will disable the `arrows` compression setting when debugging.
+
+If `config_file` isn't supplied, Bazel will use a default config file.
+""",
+        allow_single_file = True,
+        # These defaults match how terser was run in the legacy built-in rollup_bundle rule.
+        # We keep them the same so it's easier for users to migrate.
+        default = Label("@npm_bazel_terser//:terser_config.default.json"),
+    ),
+    "debug": attr.bool(
+        doc = """Configure terser to produce more readable output.
+
+Instead of setting this attribute, consider setting the DEBUG variable instead
+bazel build --define=DEBUG=true //my/terser:target
+so that it only affects the current build.
+""",
+    ),
+    "sourcemap": attr.bool(
+        doc = "Whether to produce a .js.map output",
+        default = True,
+    ),
+    "terser_bin": attr.label(
+        doc = "An executable target that runs Terser",
+        default = Label("@npm//@bazel/terser/bin:terser"),
+        executable = True,
+        cfg = "host",
+    ),
+}
+
+def _terser_outs(sourcemap):
+    result = {"minified": "%{name}.js"}
+    if sourcemap:
+        result["sourcemap"] = "%{name}.js.map"
+    return result
+
+def _terser(ctx):
+    "Generate actions to create terser config run terser"
+
+    # CLI arguments; see https://www.npmjs.com/package/terser#command-line-usage
+    args = ctx.actions.args()
+    args.add_all([src.path for src in ctx.files.src])
+
+    outputs = [ctx.outputs.minified]
+    args.add_all(["--output", ctx.outputs.minified.path])
+
+    debug = ctx.attr.debug or "DEBUG" in ctx.var.keys()
+    if debug:
+        args.add("--debug")
+        args.add("--beautify")
+
+    if ctx.attr.sourcemap:
+        outputs.append(ctx.outputs.sourcemap)
+
+        # Source mapping options are comma-packed into one argv
+        # see https://github.com/terser-js/terser#command-line-usage
+        source_map_opts = ["includeSources", "base=" + ctx.bin_dir.path]
+
+        # We support only inline sourcemaps for now.
+        # It's hard to pair up the .js inputs with corresponding .map files
+        source_map_opts.append("content=inline")
+
+        # This option doesn't work in the config file, only on the CLI
+        args.add_all(["--source-map", ",".join(source_map_opts)])
+
+    opts = ctx.actions.declare_file("_%s.minify_options.json" % ctx.label.name)
+    ctx.actions.expand_template(
+        template = ctx.file.config_file,
+        output = opts,
+        substitutions = {
+            "\"bazel_debug\"": str(debug).lower(),
+            "\"bazel_no_debug\"": str(not debug).lower(),
+        },
+    )
+
+    args.add_all(["--config-file", opts.path])
+
+    ctx.actions.run(
+        inputs = ctx.files.src + [opts],
+        outputs = outputs,
+        executable = ctx.executable.terser_bin,
+        arguments = [args],
+        progress_message = "Minifying JavaScript %s [terser]" % (ctx.outputs.minified.short_path),
+    )
+
+terser_minified = rule(
+    doc = """Run the terser minifier.
+    
+Typical example:
+```python
+load("@npm_bazel_terser//:index.bzl", "terser_minified")
+
+terser_minified(
+    name = "out.min",
+    src = "input.js",
+    config_file = "terser_config.json",
+)
+```
+
+Note that the `name` attribute determines what the resulting files will be called.
+So the example above will output `out.min.js` and `out.min.js.map` (since `sourcemap` defaults to `true`).
+""",
+    implementation = _terser,
+    attrs = _TERSER_ATTRS,
+    outputs = _terser_outs,
+)

--- a/packages/terser/test/debug/BUILD.bazel
+++ b/packages/terser/test/debug/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@build_bazel_rules_nodejs//internal/golden_file_test:golden_file_test.bzl", "golden_file_test")
+load("@npm_bazel_terser//:index.from_src.bzl", "terser_minified")
+
+terser_minified(
+    name = "out.min",
+    src = "input.js",
+    debug = True,
+    # Turn off sourcemap so we get only one output
+    sourcemap = False,
+)
+
+golden_file_test(
+    name = "test",
+    # Assert that the default output is a .js file
+    # by omitting the ".js" extension here
+    actual = "out.min",
+    golden = "output.golden.js_",
+)
+
+terser_minified(
+    name = "debug_from_env",
+    src = "input.js",
+    # Don't specify debug = True
+    # Instead we'll run the test with --define=DEBUG=true
+)
+
+golden_file_test(
+    name = "test_define_DEBUG",
+    actual = "debug_from_env.js",
+    golden = "output.golden.js_",
+    tags = ["manual"],  # Only passes when --define=DEBUG=true is set
+)

--- a/packages/terser/test/debug/input.js
+++ b/packages/terser/test/debug/input.js
@@ -1,0 +1,6 @@
+// This will be pretty printed since we run terser with debug settings
+class A {
+  doThing() {
+    console.error('thing');
+  }
+}

--- a/packages/terser/test/debug/output.golden.js_
+++ b/packages/terser/test/debug/output.golden.js_
@@ -1,0 +1,5 @@
+class A {
+    doThing() {
+        console.error("thing");
+    }
+}

--- a/packages/terser/test/inline_sourcemap/BUILD.bazel
+++ b/packages/terser/test/inline_sourcemap/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@npm_bazel_jasmine//:index.from_src.bzl", "jasmine_node_test")
+load("@npm_bazel_terser//:index.from_src.bzl", "terser_minified")
+
+# Check that filegroups work
+filegroup(
+    name = "srcs",
+    srcs = ["input.js"],
+)
+
+terser_minified(
+    name = "out.min",
+    src = ":srcs",
+)
+
+jasmine_node_test(
+    name = "test",
+    srcs = ["spec.js"],
+    data = ["@npm//source-map"],
+    deps = [":out.min"],
+)

--- a/packages/terser/test/inline_sourcemap/input.js
+++ b/packages/terser/test/inline_sourcemap/input.js
@@ -1,0 +1,11 @@
+'use strict';
+exports.__esModule = true;
+// clang-format off
+var MyClass = /** @class */ (function () {
+    function MyClass(something) {
+        console.log(something);
+    }
+    return MyClass;
+}());
+exports.MyClass = MyClass;
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiaW5wdXQuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJpbnB1dC50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztBQUFBLG1CQUFtQjtBQUNuQjtJQUNFLGlCQUFZLFNBQWlCO1FBQzNCLE9BQU8sQ0FBQyxHQUFHLENBQUMsU0FBUyxDQUFDLENBQUM7SUFDekIsQ0FBQztJQUVILGNBQUM7QUFBRCxDQUFDLEFBTEQsSUFLQztBQUxZLDBCQUFPIn0=

--- a/packages/terser/test/inline_sourcemap/input.ts
+++ b/packages/terser/test/inline_sourcemap/input.ts
@@ -1,0 +1,7 @@
+// clang-format off
+export class MyClass {
+  constructor(something: string) {
+    console.log(something);
+  }
+  field: string|undefined;
+}

--- a/packages/terser/test/inline_sourcemap/spec.js
+++ b/packages/terser/test/inline_sourcemap/spec.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const sm = require('source-map');
+
+describe('terser sourcemap handling', () => {
+  it('should produce a sourcemap output', async () => {
+    const file = require.resolve(__dirname + '/out.min.js.map');
+    const rawSourceMap = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    await sm.SourceMapConsumer.with(rawSourceMap, null, consumer => {
+      const pos = consumer.originalPositionFor({line: 1, column: 89});
+      expect(pos.name).toBe('something');
+      expect(pos.line).toBe(3);
+      expect(pos.column).toBe(14);
+    });
+  });
+});

--- a/packages/terser/test/user_config/BUILD.bazel
+++ b/packages/terser/test/user_config/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@build_bazel_rules_nodejs//internal/golden_file_test:golden_file_test.bzl", "golden_file_test")
+load("@npm_bazel_terser//:index.from_src.bzl", "terser_minified")
+
+terser_minified(
+    name = "out.min",
+    src = "input.js",
+    config_file = "terser_config.json",
+)
+
+golden_file_test(
+    name = "test",
+    actual = "out.min.js",
+    golden = "output.golden.js_",
+)

--- a/packages/terser/test/user_config/input.js
+++ b/packages/terser/test/user_config/input.js
@@ -1,0 +1,6 @@
+// Assert that the terser_config.json was used. It disables the arrows setting:
+//   arrows (default: true) -- Converts ()=>{return x} to ()=>x.
+// The output.golden.js_ has the braces and return keyword still present
+const a = () => {
+  return 'hello'
+};

--- a/packages/terser/test/user_config/output.golden.js_
+++ b/packages/terser/test/user_config/output.golden.js_
@@ -1,0 +1,1 @@
+const a=()=>{return"hello"};

--- a/packages/terser/test/user_config/terser_config.json
+++ b/packages/terser/test/user_config/terser_config.json
@@ -1,0 +1,5 @@
+{
+    "compress": {
+        "arrows": false
+    }
+}


### PR DESCRIPTION
This is a clean implementation starting from what we were running in the built-in rollup_bundle rule.
It doesn't yet incorporate our new JS Providers design; that will come next. For now it just understands immediate .js inputs
