### PR TITLE
fix(builtin): fix localWorkspacePath logic

### DIFF
--- a/internal/node/node_loader.js
+++ b/internal/node/node_loader.js
@@ -107,6 +107,7 @@ function loadRunfilesManifest(manifestPath) {
   const runfilesManifest = Object.create(null);
   const reverseRunfilesManifest = Object.create(null);
   const input = fs.readFileSync(manifestPath, {encoding: 'utf-8'});
+  const outputBase = manifestPath.substring(0, manifestPath.indexOf('/execroot/'));
 
   // Absolute path that refers to the local workspace path. We need to determine the absolute
   // path to the local workspace because it allows us to support absolute path resolving
@@ -124,7 +125,7 @@ function loadRunfilesManifest(manifestPath) {
     // runfile refers to a different workspace, or the current runfile resolves to a file
     // in the bazel-out directory (bin/genfiles directory).
     if (localWorkspacePath || !runfilesPath.startsWith(USER_WORKSPACE_NAME) ||
-        realPath.includes(BIN_DIR) || realPath.includes(GEN_DIR)) {
+        realPath.startsWith(outputBase)) {
       continue;
     }
 
@@ -149,6 +150,7 @@ function loadRunfilesManifest(manifestPath) {
     genRoot = `${execRoot}${GEN_DIR}/`;
   }
 
+  log_verbose(`using outputBase ${outputBase}`);
   log_verbose(`using binRoot ${binRoot}`);
   log_verbose(`using genRoot ${genRoot}`);
   log_verbose(`using localWorkspacePath ${localWorkspacePath}`);


### PR DESCRIPTION
If the manifest has an entry in the output_base but not in the binDir or genDir, we get a wrong path for later resolutions

Fixes #1087
