### PR TITLE
refactor(builtin): improve node toolchain

### DIFF
--- a/toolchains/node/BUILD.bazel
+++ b/toolchains/node/BUILD.bazel
@@ -56,6 +56,33 @@ filegroup(
 # node toolchain type
 toolchain_type(name = "toolchain_type")
 
+# Allow targets to use a toolchains attribute, such as sh_binary and genrule
+# This way they can reference the NODE_PATH make variable.
+alias(
+    name = "toolchain",
+    actual = select({
+        "@bazel_tools//src/conditions:darwin": "@nodejs_darwin_amd64_config//:toolchain",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@nodejs_darwin_amd64_config//:toolchain",
+        "@bazel_tools//src/conditions:linux_x86_64": "@nodejs_linux_amd64_config//:toolchain",
+        "@bazel_tools//src/conditions:windows": "@nodejs_windows_amd64_config//:toolchain",
+        "//conditions:default": "@nodejs_linux_amd64_config//:toolchain",
+    }),
+    visibility = ["//visibility:public"],
+)
+
+# Allow targets to declare a dependency on the node binary for the current host platform
+alias(
+    name = "node_bin",
+    actual = select({
+        "@bazel_tools//src/conditions:darwin": "@nodejs_darwin_amd64//:node_bin",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@nodejs_darwin_amd64//:node_bin",
+        "@bazel_tools//src/conditions:linux_x86_64": "@nodejs_linux_amd64//:node_bin",
+        "@bazel_tools//src/conditions:windows": "@nodejs_windows_amd64//:node_bin",
+        "//conditions:default": "@nodejs_linux_amd64//:node_bin",
+    }),
+    visibility = ["//visibility:public"],
+)
+
 toolchain(
     name = "node_linux_toolchain",
     target_compatible_with = [

--- a/toolchains/node/node_toolchain.bzl
+++ b/toolchains/node/node_toolchain.bzl
@@ -18,35 +18,56 @@ This module implements the node toolchain rule.
 NodeInfo = provider(
     doc = "Information about how to invoke the node executable.",
     fields = {
-        "target_tool": "A hermetically downloaded nodejs executable target for the target platform.",
-        "target_tool_path": "Path to an existing nodejs executable for the target platform..",
+        "target_tool_path": "Path to the nodejs executable for the target platform.",
+        "tool_files": """Files required in runfiles to make the nodejs executable available.
+
+May be empty if the target_tool_path points to a locally installed node binary.""",
     },
 )
 
+def _to_manifest_path(ctx, file):
+    if file.short_path.startswith("../"):
+        return file.short_path[3:]
+    else:
+        return ctx.workspace_name + "/" + file.short_path
+
 def _node_toolchain_impl(ctx):
     if ctx.attr.target_tool and ctx.attr.target_tool_path:
-        fail("Can only set one of target_tool or target_tool_path but both where set.")
+        fail("Can only set one of target_tool or target_tool_path but both were set.")
     if not ctx.attr.target_tool and not ctx.attr.target_tool_path:
         fail("Must set one of target_tool or target_tool_path.")
 
-    toolchain_info = platform_common.ToolchainInfo(
-        nodeinfo = NodeInfo(
-            target_tool_path = ctx.attr.target_tool_path,
-            target_tool = ctx.attr.target_tool,
+    tool_files = []
+    target_tool_path = ctx.attr.target_tool_path
+
+    if ctx.attr.target_tool:
+        tool_files = ctx.attr.target_tool.files.to_list()
+        target_tool_path = _to_manifest_path(ctx, tool_files[0])
+
+    return [
+        platform_common.ToolchainInfo(
+            nodeinfo = NodeInfo(
+                target_tool_path = target_tool_path,
+                tool_files = tool_files,
+            ),
         ),
-    )
-    return [toolchain_info]
+        # Make the $(NODE_PATH) variable available in places like genrules.
+        # See https://docs.bazel.build/versions/master/be/make-variables.html#custom_variables
+        platform_common.TemplateVariableInfo({
+            "NODE_PATH": target_tool_path,
+        }),
+    ]
 
 node_toolchain = rule(
     implementation = _node_toolchain_impl,
     attrs = {
         "target_tool": attr.label(
-            doc = "A hermetically downloaded nodejs executable target for the target platform..",
+            doc = "A hermetically downloaded nodejs executable target for the target platform.",
             mandatory = False,
             allow_single_file = True,
         ),
         "target_tool_path": attr.string(
-            doc = "Path to an existing nodejs executable for the target platform..",
+            doc = "Path to an existing nodejs executable for the target platform.",
             mandatory = False,
         ),
     },


### PR DESCRIPTION
- Support the toolchains attribute of rules like genrule, so they can get the NODE_PATH
- Expose files and a path to node, rather than whether the node binary is locally installed or came from Bazel fetching it
