### PR TITLE
refactor: replace usages of expand_path_into_runfiles to _to_manifest_path

### DIFF
--- a/internal/common/expand_into_runfiles.bzl
+++ b/internal/common/expand_into_runfiles.bzl
@@ -31,6 +31,8 @@ def expand_location_into_runfiles(ctx, path):
         return path
     return expand_path_into_runfiles(ctx, path)
 
+# TODO(gregmagolan): rename to _expand_path_into_runfiles after angular/angular protractor rule
+#                    is removed and no longer references this function
 def expand_path_into_runfiles(ctx, path):
     """Expand paths into runfiles.
 
@@ -49,11 +51,11 @@ def expand_path_into_runfiles(ctx, path):
     targets = ctx.attr.data if hasattr(ctx.attr, "data") else []
     expanded = ctx.expand_location(path, targets)
 
-    expansion = [resolve_expanded_path(ctx, exp) for exp in expanded.strip().split(" ")]
+    expansion = [_resolve_expanded_path(ctx, exp) for exp in expanded.strip().split(" ")]
 
     return " ".join(expansion)
 
-def resolve_expanded_path(ctx, expanded):
+def _resolve_expanded_path(ctx, expanded):
     """Resolves an expanded path
 
     Given a file path that has been expaned with $(location), resolve the path to include the workspace name,

--- a/internal/node.bzl
+++ b/internal/node.bzl
@@ -22,10 +22,8 @@ NOTE: This file is DEPRECATED and will be removed in a future release.
 load(
     "//internal/common:expand_into_runfiles.bzl",
     _expand_location_into_runfiles = "expand_location_into_runfiles",
-    _expand_path_into_runfiles = "expand_path_into_runfiles",
 )
 load("//internal/common:sources_aspect.bzl", _sources_aspect = "sources_aspect")
 
 sources_aspect = _sources_aspect
 expand_location_into_runfiles = _expand_location_into_runfiles
-expand_path_into_runfiles = _expand_path_into_runfiles

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -21,7 +21,7 @@ a `module_name` attribute can be `require`d by that name.
 """
 
 load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleSources", "collect_node_modules_aspect")
-load("//internal/common:expand_into_runfiles.bzl", "expand_location_into_runfiles", "expand_path_into_runfiles")
+load("//internal/common:expand_into_runfiles.bzl", "expand_location_into_runfiles")
 load("//internal/common:module_mappings.bzl", "module_mappings_runtime_aspect")
 load("//internal/common:sources_aspect.bzl", "sources_aspect")
 load("//internal/common:windows_utils.bzl", "create_windows_native_launcher_script", "is_windows")
@@ -93,7 +93,7 @@ def _write_loader_script(ctx):
     if len(ctx.attr.entry_point.files.to_list()) != 1:
         fail("labels in entry_point must contain exactly one file")
 
-    entry_point_path = expand_path_into_runfiles(ctx, ctx.file.entry_point.short_path)
+    entry_point_path = _to_manifest_path(ctx, ctx.file.entry_point)
 
     # If the entry point specified is a typescript file then set the entry
     # point to the corresponding .js file
@@ -119,7 +119,7 @@ def _write_loader_script(ctx):
         is_executable = True,
     )
 
-# Avoid writing non-normalized paths (workspace/../other_workspace/path)
+# Avoid using non-normalized paths (workspace/../other_workspace/path)
 def _to_manifest_path(ctx, file):
     if file.short_path.startswith("../"):
         return file.short_path[3:]

--- a/toolchains/node/node_toolchain.bzl
+++ b/toolchains/node/node_toolchain.bzl
@@ -25,6 +25,7 @@ May be empty if the target_tool_path points to a locally installed node binary."
     },
 )
 
+# Avoid using non-normalized paths (workspace/../other_workspace/path)
 def _to_manifest_path(ctx, file):
     if file.short_path.startswith("../"):
         return file.short_path[3:]


### PR DESCRIPTION
Now that node entry_point is a label we can do this.

This also makes _to_manifest_path naming consistent in all the rules.

Note: expand_location_into_runfiles is still used for templated_args in nodejs_binary & nodejs_test