### PR TITLE
fix: node_loader windows fix

### DIFF
--- a/internal/node/node_loader.js
+++ b/internal/node/node_loader.js
@@ -101,6 +101,9 @@ function resolveToModuleRoot(path) {
  * See https://github.com/bazelbuild/bazel/issues/3726
  */
 function loadRunfilesManifest(manifestPath) {
+  // Normalize slashes in manifestPath so they match slashes in manifest file
+  manifestPath = manifestPath.replace(/\\/g, '/');
+
   log_verbose(`using manifest ${manifestPath}`);
 
   // Create the manifest and reverse manifest maps.


### PR DESCRIPTION
I can't reproduce this locally on my Windows machine so something must be different on buildkite Windows CI in how it sets `process.env.RUNFILES_MANIFEST_FILE` as it looks like it has mixed slashes when passed into `loadRunfilesManifest(process.env.RUNFILES_MANIFEST_FILE)`