### PR TITLE
fix(npm_install): dynamic_deps attribute not working for scoped packages

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -217,9 +217,14 @@ yarn_install(
 
 yarn_install(
     name = "fine_grained_goldens",
-    # exercise the dynamic_deps feature, even though it doesn't make sense for a real jasmine binary to depend on zone.js
-    # This will just inject an extra data[] dependency into the jasmine_bin generated target.
-    dynamic_deps = {"jasmine": "zone.js"},
+    # exercise the dynamic_deps feature, even though it doesn't make sense for the targets to
+    # depend on zone.js or Angular core. This will just inject an extra data[] dependency into
+    # the generated binary targets. Note that we also ensure that scoped packages can be properly
+    # modified.
+    dynamic_deps = {
+        "@gregmagolan/test-a": "@angular/core",
+        "jasmine": "zone.js",
+    },
     manual_build_file_contents = """
 filegroup(
   name = "golden_files",

--- a/internal/npm_install/test/check.js
+++ b/internal/npm_install/test/check.js
@@ -18,14 +18,14 @@ function check(file, updateGolden = false) {
           .replace(/[\n]+/g, '\n');
 
   // Load the golden file for comparison
-  const golden = path.posix.join(path.dirname(__filename), 'golden', file + '.golden');
+  const golden = require.resolve('./golden/' + file + '.golden');
 
   if (updateGolden) {
     // Write to golden file
     // TODO(kyliau): Consider calling mkdirp() here, otherwise write operation
     // would fail if directory does not already exist.
     fs.writeFileSync(golden, actualContents);
-    console.error(`Replaced ${path.join(process.cwd(), golden)}`);
+    console.error(`Replaced ${path.join(golden)}`);
   } else {
     const goldenContents = fs.readFileSync(golden, {encoding: 'utf-8'}).replace(/\r\n/g, '\n');
     // Check if actualContents matches golden file

--- a/internal/npm_install/test/generate_build_file.spec.js
+++ b/internal/npm_install/test/generate_build_file.spec.js
@@ -80,20 +80,32 @@ describe('build file generator', () => {
 
   describe('dynamic dependencies', () => {
     it('should include requested dynamic dependencies in nodejs_binary data', () => {
-      const pkgs = [{_name: 'foo', bin: 'foobin', _dir: 'some_dir'}, {_name: 'bar', _dir: 'bar'}];
-      addDynamicDependencies(pkgs, {'foo': 'bar'});
+      const pkgs = [
+        {_name: 'foo', bin: 'foobin', _dir: 'some_dir', _moduleName: 'foo'},
+        {_name: 'bar', _dir: 'bar', _moduleName: 'bar'},
+        {_name: 'typescript', bin: 'tsc_wrapped', _dir: 'a', _moduleName: '@bazel/typescript'},
+        {_name: 'tsickle', _dir: 'b', _moduleName: 'tsickle'},
+      ];
+      addDynamicDependencies(pkgs, {'foo': 'bar', '@bazel/typescript': 'tsickle'});
       expect(pkgs[0]._dynamicDependencies).toEqual(['//bar:bar']);
+      expect(pkgs[2]._dynamicDependencies).toEqual(['//b:tsickle']);
       expect(printPackageBin(pkgs[0])).toContain('data = ["//some_dir:foo", "//bar:bar"]');
+      expect(printPackageBin(pkgs[2])).toContain('data = ["//a:typescript", "//b:tsickle"]');
     });
     it('should support wildcard', () => {
-      const pkgs = [{_name: 'foo', bin: 'foobin', _dir: 'some_dir'}, {_name: 'bar', _dir: 'bar'}];
+      const pkgs = [
+        {_name: 'foo', bin: 'foobin', _dir: 'some_dir', _moduleName: 'foo'},
+        {_name: 'bar', _dir: 'bar', _moduleName: 'bar'}
+      ];
       addDynamicDependencies(pkgs, {'foo': 'b*'});
       expect(pkgs[0]._dynamicDependencies).toEqual(['//bar:bar']);
       expect(printPackageBin(pkgs[0])).toContain('data = ["//some_dir:foo", "//bar:bar"]');
     });
     it('should automatically include plugins in nodejs_binary data', () => {
-      const pkgs =
-          [{_name: 'foo', bin: 'foobin', _dir: 'some_dir'}, {_name: 'foo-plugin-bar', _dir: 'bar'}];
+      const pkgs = [
+        {_name: 'foo', bin: 'foobin', _dir: 'some_dir', _moduleName: 'foo'},
+        {_name: 'foo-plugin-bar', _dir: 'bar', _moduleName: 'foo-plugin-bar'}
+      ];
       addDynamicDependencies(pkgs, {});
       expect(pkgs[0]._dynamicDependencies).toEqual(['//bar:foo-plugin-bar']);
       expect(printPackageBin(pkgs[0]))

--- a/internal/npm_install/test/golden/@gregmagolan/test-a/bin/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/@gregmagolan/test-a/bin/BUILD.bazel.golden
@@ -5,5 +5,5 @@ nodejs_binary(
     name = "test",
     entry_point = "//:node_modules/@gregmagolan/test-a/@bin/test.js",
     install_source_map_support = False,
-    data = ["//@gregmagolan/test-a:test-a"],
+    data = ["//@gregmagolan/test-a:test-a", "//@angular/core:core"],
 )


### PR DESCRIPTION
Currently it's not possible to specify a dynamic dependency for a scoped package. e.g. the default `dynamic_deps` value that adds `tsickle` to `@bazel/typescript` doesn't work because it never matches.

This is because the dynamic dependency logic currently checks against the `pkg._name`, which is just the trailing path segment of the package path. This is incorrect and confusing as it omits the package scope. e.g. `@bazel/typescript` => `typescript`.