### PR TITLE
fix: dont generate build files in symlinked node_modules

### DIFF
--- a/internal/npm_install/generate_build_file.js
+++ b/internal/npm_install/generate_build_file.js
@@ -458,7 +458,12 @@ def _maybe(repo_rule, name, **kwargs):
             .filter(f => !f.startsWith('.'))
             .map(f => path.posix.join(p, f))
             .filter(f => isDirectory(f));
-        packages.forEach(f => pkgs.push(parsePackage(f), ...findPackages(path.posix.join(f, 'node_modules'))));
+        packages.forEach(f => {
+            if (fs.lstatSync(f).isSymbolicLink()) {
+                return;
+            }
+            pkgs.push(parsePackage(f), ...findPackages(path.posix.join(f, 'node_modules')));
+        });
         const scopes = listing.filter(f => f.startsWith('@'))
             .map(f => path.posix.join(p, f))
             .filter(f => isDirectory(f));

--- a/internal/npm_install/generate_build_file.js
+++ b/internal/npm_install/generate_build_file.js
@@ -459,10 +459,11 @@ def _maybe(repo_rule, name, **kwargs):
             .map(f => path.posix.join(p, f))
             .filter(f => isDirectory(f));
         packages.forEach(f => {
+            let hide = true;
             if (fs.lstatSync(f).isSymbolicLink()) {
-                return;
+                hide = false;
             }
-            pkgs.push(parsePackage(f), ...findPackages(path.posix.join(f, 'node_modules')));
+            pkgs.push(parsePackage(f, hide), ...findPackages(path.posix.join(f, 'node_modules')));
         });
         const scopes = listing.filter(f => f.startsWith('@'))
             .map(f => path.posix.join(p, f))
@@ -491,7 +492,7 @@ def _maybe(repo_rule, name, **kwargs):
      * package json and return it as an object along with
      * some additional internal attributes prefixed with '_'.
      */
-    function parsePackage(p) {
+    function parsePackage(p, hide = true) {
         // Parse the package.json file of this package
         const packageJson = path.posix.join(p, 'package.json');
         const pkg = isFile(packageJson) ? JSON.parse(fs.readFileSync(packageJson, { encoding: 'utf8' })) :
@@ -514,7 +515,8 @@ def _maybe(repo_rule, name, **kwargs):
         // Hide bazel files in this package. We do this before parsing
         // the next package to prevent issues caused by symlinks between
         // package and nested packages setup by the package manager.
-        hideBazelFiles(pkg);
+        if (hide)
+            hideBazelFiles(pkg);
         return pkg;
     }
     /**

--- a/internal/npm_install/generate_build_file.ts
+++ b/internal/npm_install/generate_build_file.ts
@@ -504,8 +504,12 @@ function findPackages(p = 'node_modules') {
                        .map(f => path.posix.join(p, f))
                        .filter(f => isDirectory(f));
 
-  packages.forEach(
-      f => pkgs.push(parsePackage(f), ...findPackages(path.posix.join(f, 'node_modules'))));
+  packages.forEach(f => {
+    if (fs.lstatSync(f).isSymbolicLink()) {
+      return;
+    }
+    pkgs.push(parsePackage(f), ...findPackages(path.posix.join(f, 'node_modules')))
+  });
 
   const scopes = listing.filter(f => f.startsWith('@'))
                      .map(f => path.posix.join(p, f))

--- a/internal/npm_install/generate_build_file.ts
+++ b/internal/npm_install/generate_build_file.ts
@@ -505,10 +505,11 @@ function findPackages(p = 'node_modules') {
                        .filter(f => isDirectory(f));
 
   packages.forEach(f => {
+    let hide = true;
     if (fs.lstatSync(f).isSymbolicLink()) {
-      return;
+      hide = false;
     }
-    pkgs.push(parsePackage(f), ...findPackages(path.posix.join(f, 'node_modules')))
+    pkgs.push(parsePackage(f, hide), ...findPackages(path.posix.join(f, 'node_modules')))
   });
 
   const scopes = listing.filter(f => f.startsWith('@'))
@@ -545,7 +546,7 @@ function findScopes() {
  * package json and return it as an object along with
  * some additional internal attributes prefixed with '_'.
  */
-function parsePackage(p: string): Dep {
+function parsePackage(p: string, hide: boolean = true): Dep {
   // Parse the package.json file of this package
   const packageJson = path.posix.join(p, 'package.json');
   const pkg = isFile(packageJson) ? JSON.parse(fs.readFileSync(packageJson, {encoding: 'utf8'})) :
@@ -575,7 +576,7 @@ function parsePackage(p: string): Dep {
   // Hide bazel files in this package. We do this before parsing
   // the next package to prevent issues caused by symlinks between
   // package and nested packages setup by the package manager.
-  hideBazelFiles(pkg);
+  if (hide) hideBazelFiles(pkg);
 
   return pkg;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

when local packages already managed with build files are linked into node_modules they may be erroneously re-exported causing directory has a BUILD file failures. 

this should be a fix for #871 

## What is the new behavior?

when searching for packages under a given path if one is a symlink it'll be skipped.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

