### PR TITLE
Default rollup bundle config specifies invalid input option

### DIFF
--- a/internal/rollup/rollup.config.js
+++ b/internal/rollup/rollup.config.js
@@ -150,7 +150,6 @@ const inputs = [TMPL_inputs];
 const multipleInputs = inputs.length > 1;
 
 const config = {
-  resolveBazel,
   onwarn: (warning) => {
     // Always fail on warnings, assuming we don't know which are harmless.
     // We can add exclusions here based on warning.code, if we discover some

--- a/internal/rollup/rollup.config.spec.js
+++ b/internal/rollup/rollup.config.spec.js
@@ -31,9 +31,14 @@ const resolve =
     }
 
 const rollupConfig = require('./rollup.config');
+const resolveBazelPlugin = rollupConfig.plugins.find(p => p.name === 'resolveBazel');
+
+if (!resolveBazelPlugin) {
+  throw new Error('Could not find "resolveBazel" plugin in the rollup config.');
+}
 
 function doResolve(importee, importer) {
-  const resolved = rollupConfig.resolveBazel(importee, importer, baseDir, resolve, rootDir);
+  const resolved = resolveBazelPlugin.resolveId(importee, importer, baseDir, resolve, rootDir);
   if (resolved) {
     return resolved.replace(/\\/g, '/');
   } else {


### PR DESCRIPTION
Apparently the default rollup bundle configuration specifies an invalid option called `resolveBazel`. This causes an error to be thrown as rollup complains about invalid/unknown options.

This is not an issue for the default consumers of the rollup bundle configuration as those specify `--silent`, but it will be an issue if someone uses its own rollup rule that uses this configuration. Specifically I hit this scenario on windows where the arguments for the rollup rule were too long and the "--silent" option got accidentally omitted..