### PR TITLE
build: update to latest rules_webtesting commit to pickup windows fixes

### DIFF
--- a/rules_webtesting.patch
+++ b/rules_webtesting.patch
@@ -11,3 +11,161 @@ index 384d018..2cbbb4a 100644
          },
      }),
      visibility = ["//browsers:__subpackages__"],
+-- 
+2.20.1
+
+From a7c1f6b825640a95e687adc884a442fde23ccd95 Mon Sep 17 00:00:00 2001
+From: Yun Peng <pcloudy@google.com>
+Date: Tue, 3 Sep 2019 19:24:02 +0200
+Subject: [PATCH] Update rlocation funciton in windows_utils.bzl (#387)
+
+---
+ web/internal/windows_utils.bzl | 76 ++++++++++++++++++++++++++--------
+ 1 file changed, 59 insertions(+), 17 deletions(-)
+
+diff --git a/web/internal/windows_utils.bzl b/web/internal/windows_utils.bzl
+index 429a01a..576053a 100644
+--- a/web/internal/windows_utils.bzl
++++ b/web/internal/windows_utils.bzl
+@@ -17,6 +17,49 @@
+ These functions help making rules work on Windows.
+ """
+ 
++BATCH_RLOCATION_FUNCTION = r"""
++rem Usage of rlocation function:
++rem        call :rlocation <runfile_path> <abs_path>
++rem        The rlocation function maps the given <runfile_path> to its absolute
++rem        path and stores the result in a variable named <abs_path>.
++rem        This function fails if the <runfile_path> doesn't exist in mainifest
++rem        file.
++:: Start of rlocation
++goto :rlocation_end
++:rlocation
++if "%~2" equ "" (
++  echo>&2 ERROR: Expected two arguments for rlocation function.
++  exit 1
++)
++if "%RUNFILES_MANIFEST_ONLY%" neq "1" (
++  set %~2=%~1
++  exit /b 0
++)
++if "%RUNFILES_MANIFEST_FILE%" equ "" (
++  set RUNFILES_MANIFEST_FILE=%~f0.runfiles\MANIFEST
++)
++if not exist "%RUNFILES_MANIFEST_FILE%" (
++  set RUNFILES_MANIFEST_FILE=%~f0.runfiles_manifest
++)
++set MF=%RUNFILES_MANIFEST_FILE:/=\%
++if not exist "%MF%" (
++  echo>&2 ERROR: Manifest file %MF% does not exist.
++  exit 1
++)
++set runfile_path=%~1
++for /F "tokens=2* usebackq" %%i in (`%SYSTEMROOT%\system32\findstr.exe /l /c:"!runfile_path! " "%MF%"`) do (
++  set abs_path=%%i
++)
++if "!abs_path!" equ "" (
++  echo>&2 ERROR: !runfile_path! not found in runfiles manifest
++  exit 1
++)
++set %~2=!abs_path!
++exit /b 0
++:rlocation_end
++:: End of rlocation
++"""
++
+ def is_windows(ctx):
+     """
+     Check if we are building for Windows.
+@@ -27,6 +70,14 @@ def is_windows(ctx):
+     # https://github.com/bazelbuild/bazel/issues/9209 is resolved.
+     return ctx.configuration.host_path_separator == ";"
+ 
++# Helper function to convert a file to a path in the MANIFEST file
++def _file_to_manifest_path(ctx, f):
++    p = f.short_path
++    if p.startswith("../"):
++        return p[3:]
++    else:
++        return ctx.workspace_name + "/" + p
++
+ def create_windows_native_launcher_script(ctx, shell_script):
+     """
+     Create a Windows Batch file to launch the given shell script.
+@@ -41,25 +92,16 @@ def create_windows_native_launcher_script(ctx, shell_script):
+         content = r"""@echo off
+ SETLOCAL ENABLEEXTENSIONS
+ SETLOCAL ENABLEDELAYEDEXPANSION
+-if "%RUNFILES_MANIFEST_ONLY%" neq "1" (
+-  set run_script={sh_script}
+-  goto :run
+-)
+-set MF=%RUNFILES_MANIFEST_FILE:/=\%
+-set script={sh_script}
+-if "!script:~0,9!" equ "external/" (set script=!script:~9!) else (set script=!TEST_WORKSPACE!/!script!)
+-for /F "tokens=2* usebackq" %%i in (`findstr.exe /l /c:"!script! " "%MF%"`) do (
+-  set run_script=%%i
+-)
+-if "!run_script!" equ "" (
+-  echo>&2 ERROR: !script! not found in runfiles manifest
+-  exit /b 1
+-)
+-:run
+-{bash_bin} -c "!run_script!"
++set RUNFILES_MANIFEST_ONLY=1
++{rlocation_function}
++call :rlocation "{sh_script}" run_script
++for %%a in ("{bash_bin}") do set "bash_bin_dir=%%~dpa"
++set PATH=%bash_bin_dir%;%PATH%
++{bash_bin} -c "!run_script! %*"
+ """.format(
+             bash_bin = ctx.toolchains["@bazel_tools//tools/sh:toolchain_type"].path,
+-            sh_script = shell_script.short_path,
++            sh_script = _file_to_manifest_path(ctx, shell_script),
++            rlocation_function = BATCH_RLOCATION_FUNCTION,
+         ),
+         is_executable = True,
+     )
+-- 
+2.20.1
+
+From 9c1e6ce41e458f41654fe609d76220770562c9b4 Mon Sep 17 00:00:00 2001
+From: Paul Gschwendtner <paulgschwendtner@gmail.com>
+Date: Mon, 9 Sep 2019 20:43:49 +0200
+Subject: [PATCH] web test not launching on windows if shell toolchain path
+ contains whitespace (#389)
+
+The windows launcher code does currently break if the path to the bash binary contains
+a whitespace. This is common on windows where programs are stored under `C:\Program Files`.
+
+e.g.
+
+```
+:run
+C:/Program Files/msys2/usr/bin/bash.exe -c "!run_script!"
+```
+
+The path needs to be quoted so that it won't be incorrectly picked up as two separate commands. Resulting in an
+exception like:
+
+```
+'C:/Program' is not recognized as an internal or external command,
+operable program or batch file.
+```
+---
+ web/internal/windows_utils.bzl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/web/internal/windows_utils.bzl b/web/internal/windows_utils.bzl
+index 576053a..4bec20e 100644
+--- a/web/internal/windows_utils.bzl
++++ b/web/internal/windows_utils.bzl
+@@ -97,7 +97,7 @@ set RUNFILES_MANIFEST_ONLY=1
+ call :rlocation "{sh_script}" run_script
+ for %%a in ("{bash_bin}") do set "bash_bin_dir=%%~dpa"
+ set PATH=%bash_bin_dir%;%PATH%
+-{bash_bin} -c "!run_script! %*"
++"{bash_bin}" -c "!run_script! %*"
+ """.format(
+             bash_bin = ctx.toolchains["@bazel_tools//tools/sh:toolchain_type"].path,
+             sh_script = _file_to_manifest_path(ctx, shell_script),


### PR DESCRIPTION
Updates to latest rules_webtesting commit to pick up two Windows fixes.

1) https://github.com/bazelbuild/rules_webtesting/commit/e082ffd85190a9573b2367ef2ee7dadc87dc21c7
2) https://github.com/bazelbuild/rules_webtesting/commit/e7e838126b64c9a51dc06078e2f491b9a07b144e

We are using a patch to pull in (1) at the moment so this PR also removes the patch.

Not having (2) is blocking the rules_nodejs update in angular/angular: https://github.com/angular/angular/pull/32151

Other options are:

1) wait for rules_webtesting cuts the next release so we can update to the released version
2) explicitly pull this rules_webtesting commit into https://github.com/angular/angular/pull/32151 for now so it can land