### PR TITLE
chore: rename duplicate CircleCI variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ var_10: &restore_cache
     keys:
       - *cache_key
 
-var_8: &attach_workspace
+var_11: &attach_workspace
   attach_workspace:
     at: ~/
 


### PR DESCRIPTION
Strangely, CircleCI works on this repo but does not work on a cloned
repo because of a duplicate variable name. Fixes #1138.
