### PR TITLE
Add ability to ignore peer depdenencies from package.json

### DIFF
--- a/internal/npm_install/generate_build_file.js
+++ b/internal/npm_install/generate_build_file.js
@@ -696,7 +696,7 @@ def _maybe(repo_rule, name, **kwargs):
             });
         }
         findDeps(dep.dependencies, true, 'dependency');
-        findDeps(dep.peerDependencies, true, 'peer dependency');
+        findDeps(dep.peerDependencies, false, 'peer dependency');
         // `optionalDependencies` that are missing should be silently
         // ignored since the npm/yarn will not fail if these dependencies
         // fail to install. Packages should handle the cases where these

--- a/internal/npm_install/generate_build_file.ts
+++ b/internal/npm_install/generate_build_file.ts
@@ -779,7 +779,7 @@ function flattenPkgDependencies(pkg: Dep, dep: Dep, pkgsMap: Map<string, Dep>) {
   }
 
   findDeps(dep.dependencies, true, 'dependency');
-  findDeps(dep.peerDependencies, true, 'peer dependency');
+  findDeps(dep.peerDependencies, false, 'peer dependency');
   // `optionalDependencies` that are missing should be silently
   // ignored since the npm/yarn will not fail if these dependencies
   // fail to install. Packages should handle the cases where these


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [x] Feature (please, look at the "Scope of the project" section in the README.md file)

## What is the current behavior?

Issue Number: #1162


## What is the new behavior?

Ability to pass a `canIgnore` list of strings containing peer dependency names that can be ignored.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is one implementation, we could make it so we can pass it via the `*_install` rule instead if it might be cleaner.