### PR TITLE
fix(README): update "sections below" reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://bazelbuild.github.io/rules_nodejs/
 ## Quickstart
 
 This is the fastest way to get started.
-See sections below for details and alternative methods.
+See the [installation documentation](https://bazelbuild.github.io/rules_nodejs/install.html) for details and alternative methods.
 
 ```sh
 $ npm init @bazel


### PR DESCRIPTION
This PR updates the "sections below" reference to point to the installation docs, since the details and alternatives are not present in the sections below of the README.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The documentation refers to "sections below", but the sections below do not contain additional details or alternatives for installing rules_nodejs.

Issue Number: N/A

## What is the new behavior?

Link to the docs page that contains the additional details and alternatives.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No