### PR TITLE
chore: fix issue in clean_nested_workspaces.sh script

### DIFF
--- a/scripts/clean_nested_workspaces.sh
+++ b/scripts/clean_nested_workspaces.sh
@@ -10,13 +10,13 @@ echo_and_run() { echo "+ $@" ; "$@" ; }
 readonly workspaceRoots=("e2e" "examples" "packages")
 for workspaceRoot in ${workspaceRoots[@]} ; do
   (
-    readonly workspaceFiles=($(find ./${workspaceRoot} -type f -name WORKSPACE -prune))
+    readonly workspaceFiles=($(find ./${workspaceRoot} -type f -name WORKSPACE -prune -maxdepth 2))
     for workspaceFile in ${workspaceFiles[@]} ; do
       (
         readonly workspaceDir=$(dirname ${workspaceFile})
         printf "\n\nCleaning ${workspaceDir}\n"
         cd ${workspaceDir}
-        echo_and_run rm -rf `find . -type d -name node_modules -prune`
+        echo_and_run rm -rf `find . -type d -name node_modules -prune -maxdepth 1`
         echo_and_run bazel clean --expunge
       )
     done


### PR DESCRIPTION
The script gets confused when there a file such as /e2e/e2_karma_stack_trace/node_modules/@bazel/karma/WORKSPACE and when there are nested node_modules such as /e2e/e2_karma_stack_trace/node_modules/@bazel/karma/node_nodules
