### PR TITLE
test: examples/angular ts_devserver does not need to included @ngrx/store/bundles/store.umd.min.js

### DIFF
--- a/examples/angular/src/BUILD.bazel
+++ b/examples/angular/src/BUILD.bazel
@@ -103,7 +103,6 @@ ts_devserver(
     # These scripts will be included in the JS bundle after require.js
     # They should have only named UMD modules, or require.js will throw.
     scripts = [
-        "@npm//:node_modules/@ngrx/store/bundles/store.umd.min.js",
         "@npm//:node_modules/tslib/tslib.js",
         ":rxjs_umd_modules",
         # We are manaully adding the bazel generated named-UMD date-fns bundle here as


### PR DESCRIPTION
store.umd.js will be automatically added by yarn_install via APF detection. Also store.umd.min.js breaks with Ivy as ivy-ngcc does not transform store.umd.min.js file (only store.umd.js)
