### PR TITLE
feat(typescript): add direct_sources field to JSEcmaScriptModuleInfo

### DIFF
--- a/examples/angular/patches/@angular+bazel+9.0.0-next.8.patch
+++ b/examples/angular/patches/@angular+bazel+9.0.0-next.8.patch
@@ -32,7 +32,7 @@ index 9b88fbb..68217d0 100755
      "ts_providers_dict_to_struct",
      "tsc_wrapped_tsconfig",
  )
-+load("@build_bazel_rules_nodejs//:providers.bzl", "transitive_js_ecma_script_module_info")
++load("@build_bazel_rules_nodejs//:providers.bzl", "js_ecma_script_module_info")
  
  _FLAT_DTS_FILE_SUFFIX = ".bundle.d.ts"
  _R3_SYMBOLS_DTS_FILE = "src/r3_symbols.d.ts"
@@ -63,7 +63,7 @@ index 9b88fbb..68217d0 100755
 +
 +    # Add in new JS providers
 +    ts_providers["providers"].extend([
-+        transitive_js_ecma_script_module_info(
++        js_ecma_script_module_info(
 +            sources = ts_providers["typescript"]["es6_sources"],
 +            deps = ctx.attr.deps,
 +        ),

--- a/packages/typescript/src/internal/build_defs.bzl
+++ b/packages/typescript/src/internal/build_defs.bzl
@@ -14,7 +14,7 @@
 
 "TypeScript compilation"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "transitive_js_ecma_script_module_info")
+load("@build_bazel_rules_nodejs//:providers.bzl", "js_ecma_script_module_info")
 load("@build_bazel_rules_nodejs//internal/common:node_module_info.bzl", "NodeModuleSources", "collect_node_modules_aspect")
 
 # pylint: disable=unused-argument
@@ -275,7 +275,7 @@ def _ts_library_impl(ctx):
     # See design doc https://docs.google.com/document/d/1ggkY5RqUkVL4aQLYm7esRW978LgX3GUCnQirrk5E1C0/edit#
     # and issue https://github.com/bazelbuild/rules_nodejs/issues/57 for more details.
     ts_providers["providers"].extend([
-        transitive_js_ecma_script_module_info(
+        js_ecma_script_module_info(
             sources = ts_providers["typescript"]["es6_sources"],
             deps = ctx.attr.deps,
         ),

--- a/providers.bzl
+++ b/providers.bzl
@@ -31,36 +31,22 @@ TODO: should we require that?
 
 Historical note: this was the typescript.es6_sources output""",
     fields = {
+        "direct_sources": "depset of direct JavaScript files and sourcemaps",
         "sources": "depset of direct and transitive JavaScript files and sourcemaps",
     },
 )
 
-def transitive_js_ecma_script_module_info(sources, deps = []):
+def js_ecma_script_module_info(sources, deps = []):
     """Constructs a JSEcmaScriptModuleInfo including all transitive sources from JSEcmaScriptModuleInfo providers in a list of deps.
 
 Returns a single JSEcmaScriptModuleInfo.
 """
-    return combine_js_ecma_script_module_info([JSEcmaScriptModuleInfo(sources = sources)] + collect_js_ecma_script_module_infos(deps))
-
-def combine_js_ecma_script_module_info(modules):
-    """Combines all JavaScript sources and sourcemaps from a list of JSEcmaScriptModuleInfo providers.
-
-Returns a single JSEcmaScriptModuleInfo.
-"""
-    sources_depsets = []
-    for module in modules:
-        sources_depsets.extend([module.sources])
-    return JSEcmaScriptModuleInfo(
-        sources = depset(transitive = sources_depsets),
-    )
-
-def collect_js_ecma_script_module_infos(deps):
-    """Collects all JSEcmaScriptModuleInfo providers from a list of deps.
-
-Returns a list of JSEcmaScriptModuleInfo providers.
-"""
-    modules = []
+    transitive_depsets = [sources]
     for dep in deps:
         if JSEcmaScriptModuleInfo in dep:
-            modules.extend([dep[JSEcmaScriptModuleInfo]])
-    return modules
+            transitive_depsets.append(dep[JSEcmaScriptModuleInfo].sources)
+
+    return JSEcmaScriptModuleInfo(
+        direct_sources = sources,
+        sources = depset(transitive = transitive_depsets),
+    )


### PR DESCRIPTION
Some consumers may only be interested in the javascript sources that are produced directly by a dep and not in the sources produced by transitive deps. This change allows those consumers to select only those sources.

BREAKING CHANGES:
Helper function `transitive_js_ecma_script_module_info` in `//:providers.bzl` renamed to `js_ecma_script_module_info`. It now returns a JSEcmaScriptModule info with both `sources` and `direct_sources` fields populated.
