### PR TITLE
feat(typescript): add a transitive_js_ecma_script_module_info alias to js_ecma_script_module_info

### DIFF
--- a/examples/angular/patches/@angular+bazel+9.0.0-next.8.patch
+++ b/examples/angular/patches/@angular+bazel+9.0.0-next.8.patch
@@ -32,7 +32,7 @@ index 9b88fbb..68217d0 100755
      "ts_providers_dict_to_struct",
      "tsc_wrapped_tsconfig",
  )
-+load("@build_bazel_rules_nodejs//:providers.bzl", "js_ecma_script_module_info")
++load("@build_bazel_rules_nodejs//:providers.bzl", "transitive_js_ecma_script_module_info")
  
  _FLAT_DTS_FILE_SUFFIX = ".bundle.d.ts"
  _R3_SYMBOLS_DTS_FILE = "src/r3_symbols.d.ts"
@@ -63,7 +63,7 @@ index 9b88fbb..68217d0 100755
 +
 +    # Add in new JS providers
 +    ts_providers["providers"].extend([
-+        js_ecma_script_module_info(
++        transitive_js_ecma_script_module_info(
 +            sources = ts_providers["typescript"]["es6_sources"],
 +            deps = ctx.attr.deps,
 +        ),

--- a/providers.bzl
+++ b/providers.bzl
@@ -50,3 +50,10 @@ Returns a single JSEcmaScriptModuleInfo.
         direct_sources = sources,
         sources = depset(transitive = transitive_depsets),
     )
+
+def transitive_js_ecma_script_module_info(**kwargs):
+    """Alias of js_ecma_script_module_info.
+
+TODO(gregmagolan): Remove this alias before 1.0 release.
+"""
+    return js_ecma_script_module_info(**kwargs)


### PR DESCRIPTION
This will make updating angular/angular much easier. Alias to be removed before 1.0 release.
