### PR TITLE
docs: add instructions for multiple sets of npm deps

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -265,6 +265,34 @@ jasmine_node_test(
 )
 ```
 
+#### Multiple sets of npm dependencies
+
+If your workspace has multiple applications, each with their own `package.json`
+and npm deps, `yarn_install` (or `npm_install`) can be called separately for
+each.
+
+```python
+workspace(
+    name = "my_wksp",
+    managed_directories = {"@app1_npm": ["app1/node_modules"],
+                           "@app2_npm": ["app2/node_modules"]}},
+)
+
+yarn_install(
+    name = "app1_npm",
+    package_json = "//app1:package.json",
+    yarn_lock = "//app1:yarn.lock",
+)
+
+yarn_install(
+    name = "app2_npm",
+    package_json = "//app2:package.json",
+    yarn_lock = "//app2:yarn.lock",
+)
+```
+
+Your application would then reference its deps as (for example) `@app1//lodash`, or `@app2//jquery`.
+
 #### Fine-grained npm package nodejs_binary targets
 
 If an npm package lists one or more `bin` entry points in its `package.json`,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The question of how to manage multiple independent sets of npm deps has come up on slack several times now, and it was something I was confused by initially. Hopefully this makes things a little clearer, especially for folks migrating existing code bases.

Issue Number: N/A


## What is the new behavior?
The install document now describes how to use separate `yarn_install` calls for each `package.json`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

