### PR TITLE
refactor: all providers exported from //:providers.bzl

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -38,6 +38,7 @@ bzl_library(
         "//internal/jasmine_node_test:bzl",
         "//internal/linker:bzl",
         "//internal/npm_package:bzl",
+        "//internal/providers:bzl",
         "//internal/rollup:bzl",
         "//toolchains/node:bzl",
     ],
@@ -93,6 +94,7 @@ npm_package(
         "//internal/npm_install:package_contents",
         "//internal/npm_package:package_contents",
         "//internal/web_package:package_contents",
+        "//internal/providers:package_contents",
         "//toolchains/node:package_contents",
     ],
 )

--- a/declaration_provider.bzl
+++ b/declaration_provider.bzl
@@ -1,28 +1,26 @@
-"""This module contains a provider for TypeScript typings files (.d.ts)"""
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-def provide_declarations(**kwargs):
-    """Factory function for creating checked declarations with externs.
+"""Legacy load point for DeclarationInfo
+"""
 
-    Do not directly construct DeclarationInfo()
-    """
-
-    # TODO: add some checking actions to ensure the declarations are well-formed
-    return DeclarationInfo(**kwargs)
-
-DeclarationInfo = provider(
-    doc = """The DeclarationInfo provider allows JS rules to communicate typing information.
-TypeScript's .d.ts files are used as the interop format for describing types.
-
-Do not create DeclarationInfo instances directly, instead use the provide_declarations factory function.
-
-TODO(alexeagle): The ts_library#deps attribute should require that this provider is attached.
-
-Note: historically this was a subset of the string-typed "typescript" provider.
-""",
-    # TODO: if we ever enable --declarationMap we will have .d.ts.map files too
-    fields = {
-        "declarations": "A depset of .d.ts files produced by this rule",
-        "transitive_declarations": """A depset of .d.ts files produced by this rule and all its transitive dependencies.
-This prevents needing an aspect in rules that consume the typings, which improves performance.""",
-    },
+load(
+    "//:providers.bzl",
+    _DeclarationInfo = "DeclarationInfo",
+    _provide_declarations = "provide_declarations",
 )
+
+provide_declarations = _provide_declarations
+DeclarationInfo = _DeclarationInfo
+# TODO: remove this file before 1.0 release

--- a/internal/linker/link_node_modules.bzl
+++ b/internal/linker/link_node_modules.bzl
@@ -10,7 +10,7 @@ linker, which uses the mappings to link a node_modules directory for
 runtimes to locate all the first-party packages.
 """
 
-load("@build_bazel_rules_nodejs//internal/common:npm_package_info.bzl", "NpmPackageInfo")
+load("@build_bazel_rules_nodejs//:providers.bzl", "NpmPackageInfo")
 
 def _debug(vars, *args):
     if "VERBOSE_LOGS" in vars.keys():

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -20,8 +20,7 @@ They support module mapping: any targets in the transitive dependencies with
 a `module_name` attribute can be `require`d by that name.
 """
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo")
-load("@build_bazel_rules_nodejs//internal/common:npm_package_info.bzl", "NpmPackageInfo", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo", "NpmPackageInfo", "node_modules_aspect")
 load("//internal/common:expand_into_runfiles.bzl", "expand_location_into_runfiles")
 load("//internal/common:module_mappings.bzl", "module_mappings_runtime_aspect")
 load("//internal/common:windows_utils.bzl", "create_windows_native_launcher_script", "is_windows")

--- a/internal/node/npm_package_bin.bzl
+++ b/internal/node/npm_package_bin.bzl
@@ -1,6 +1,6 @@
 "A generic rule to run a tool that appears in node_modules/.bin"
 
-load("@build_bazel_rules_nodejs//internal/common:npm_package_info.bzl", "NpmPackageInfo", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "NpmPackageInfo", "node_modules_aspect")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "module_mappings_aspect", "register_node_modules_linker")
 
 # Note: this API is chosen to match nodejs_binary

--- a/internal/npm_install/node_module_library.bzl
+++ b/internal/npm_install/node_module_library.bzl
@@ -15,9 +15,7 @@
 """Contains the node_module_library which is used by yarn_install & npm_install.
 """
 
-load("@build_bazel_rules_nodejs//:declaration_provider.bzl", "DeclarationInfo")
-load("@build_bazel_rules_nodejs//:providers.bzl", "js_named_module_info")
-load("@build_bazel_rules_nodejs//internal/common:npm_package_info.bzl", "NpmPackageInfo")
+load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "NpmPackageInfo", "js_named_module_info")
 
 def _node_module_library_impl(ctx):
     workspace = ctx.label.workspace_root.split("/")[1] if ctx.label.workspace_root else ctx.workspace_name

--- a/internal/npm_install/npm_umd_bundle.bzl
+++ b/internal/npm_install/npm_umd_bundle.bzl
@@ -17,7 +17,7 @@
 For use by yarn_install and npm_install. Not meant to be part of the public API.
 """
 
-load("@build_bazel_rules_nodejs//internal/common:npm_package_info.bzl", "NpmPackageInfo", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "NpmPackageInfo", "node_modules_aspect")
 
 def _npm_umd_bundle(ctx):
     if len(ctx.attr.entry_point.files.to_list()) != 1:

--- a/internal/npm_package/npm_package.bzl
+++ b/internal/npm_package/npm_package.bzl
@@ -6,8 +6,7 @@ If all users of your library code use Bazel, they should just add your library
 to the `deps` of one of their targets.
 """
 
-load("@build_bazel_rules_nodejs//:declaration_provider.bzl", "DeclarationInfo")
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo")
+load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "JSNamedModuleInfo")
 
 # Takes a depset of files and returns a corresponding list of file paths without any files
 # that aren't part of the specified package path. Also include files from external repositories

--- a/internal/providers/BUILD.bazel
+++ b/internal/providers/BUILD.bazel
@@ -12,15 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Legacy load point for NpmPackageInfo
-"""
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-load(
-    "//:providers.bzl",
-    _NpmPackageInfo = "NpmPackageInfo",
-    _node_modules_aspect = "node_modules_aspect",
+bzl_library(
+    name = "bzl",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
 )
 
-NpmPackageInfo = _NpmPackageInfo
-node_modules_aspect = _node_modules_aspect
-# TODO: remove this file before 1.0 release
+filegroup(
+    name = "package_contents",
+    srcs = glob(["*.bzl"]) + [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__pkg__"],
+)

--- a/internal/providers/declaration_info.bzl
+++ b/internal/providers/declaration_info.bzl
@@ -1,0 +1,42 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module contains a provider for TypeScript typings files (.d.ts)"""
+
+def provide_declarations(**kwargs):
+    """Factory function for creating checked declarations with externs.
+
+    Do not directly construct DeclarationInfo()
+    """
+
+    # TODO: add some checking actions to ensure the declarations are well-formed
+    return DeclarationInfo(**kwargs)
+
+DeclarationInfo = provider(
+    doc = """The DeclarationInfo provider allows JS rules to communicate typing information.
+TypeScript's .d.ts files are used as the interop format for describing types.
+
+Do not create DeclarationInfo instances directly, instead use the provide_declarations factory function.
+
+TODO(alexeagle): The ts_library#deps attribute should require that this provider is attached.
+
+Note: historically this was a subset of the string-typed "typescript" provider.
+""",
+    # TODO: if we ever enable --declarationMap we will have .d.ts.map files too
+    fields = {
+        "declarations": "A depset of .d.ts files produced by this rule",
+        "transitive_declarations": """A depset of .d.ts files produced by this rule and all its transitive dependencies.
+This prevents needing an aspect in rules that consume the typings, which improves performance.""",
+    },
+)

--- a/internal/providers/js_providers.bzl
+++ b/internal/providers/js_providers.bzl
@@ -1,0 +1,104 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Providers for interop between JS rules.
+
+This file has to live in the built-in so that all rules can load() the providers
+even if users haven't installed any of the packages/*
+
+These providers allows rules to interoperate without knowledge
+of each other.
+
+You can think of a provider as a message bus.
+A rule "publishes" a message as an instance of the provider, and some other rule
+subscribes to these by having a (possibly transitive) dependency on the publisher.
+
+## Debugging
+
+Debug output is considered orthogonal to these providers.
+Any output may or may not have user debugging affordances provided, such as
+readable minification.
+We expect that rules will have a boolean `debug` attribute, and/or accept the `DEBUG`
+environment variable.
+Note that this means a given build either produces debug or non-debug output.
+If users really need to produce both in a single build, they'll need two rules with
+differing 'debug' attributes.
+"""
+
+JSNamedModuleInfo = provider(
+    doc = """JavaScript files whose module name is self-contained.
+
+For example named AMD/UMD or goog.module format.
+These files can be efficiently served with the concatjs bundler.
+These outputs should be named "foo.umd.js"
+(note that renaming it from "foo.js" doesn't affect the module id)
+
+Historical note: this was the typescript.es5_sources output.
+""",
+    fields = {
+        "direct_sources": "Depset of direct JavaScript files and sourcemaps",
+        "sources": "Depset of direct and transitive JavaScript files and sourcemaps",
+    },
+)
+
+def js_named_module_info(sources, deps = []):
+    """Constructs a JSNamedModuleInfo including all transitive sources from JSNamedModuleInfo providers in a list of deps.
+
+Returns a single JSNamedModuleInfo.
+"""
+    transitive_depsets = [sources]
+    for dep in deps:
+        if JSNamedModuleInfo in dep:
+            transitive_depsets.append(dep[JSNamedModuleInfo].sources)
+
+    return JSNamedModuleInfo(
+        direct_sources = sources,
+        sources = depset(transitive = transitive_depsets),
+    )
+
+JSEcmaScriptModuleInfo = provider(
+    doc = """JavaScript files (and sourcemaps) that are intended to be consumed by downstream tooling.
+
+They should use modern syntax and ESModules.
+These files should typically be named "foo.mjs"
+TODO: should we require that?
+
+Historical note: this was the typescript.es6_sources output""",
+    fields = {
+        "direct_sources": "Depset of direct JavaScript files and sourcemaps",
+        "sources": "Depset of direct and transitive JavaScript files and sourcemaps",
+    },
+)
+
+def js_ecma_script_module_info(sources, deps = []):
+    """Constructs a JSEcmaScriptModuleInfo including all transitive sources from JSEcmaScriptModuleInfo providers in a list of deps.
+
+Returns a single JSEcmaScriptModuleInfo.
+"""
+    transitive_depsets = [sources]
+    for dep in deps:
+        if JSEcmaScriptModuleInfo in dep:
+            transitive_depsets.append(dep[JSEcmaScriptModuleInfo].sources)
+
+    return JSEcmaScriptModuleInfo(
+        direct_sources = sources,
+        sources = depset(transitive = transitive_depsets),
+    )
+
+def transitive_js_ecma_script_module_info(**kwargs):
+    """Alias of js_ecma_script_module_info.
+
+TODO(gregmagolan): Remove this alias before 1.0 release.
+"""
+    return js_ecma_script_module_info(**kwargs)

--- a/internal/providers/npm_package_info.bzl
+++ b/internal/providers/npm_package_info.bzl
@@ -1,0 +1,52 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NpmPackageInfo providers and apsect to collect node_modules from deps.
+"""
+
+# NpmPackageInfo provider is provided by targets that are npm dependencies by the
+# `node_module_library` rule as well as other targets that have direct or transitive deps on
+# `node_module_library` targets via the `node_modules_aspect` below.
+NpmPackageInfo = provider(
+    doc = "Provides information about npm dependencies",
+    fields = {
+        "direct_sources": "Depset of direct source files in this npm package",
+        "sources": "Depset of direct & transitive source files in this npm package and in its dependencies",
+        "workspace": "The workspace name that this npm package is provided from",
+    },
+)
+
+def _node_modules_aspect_impl(target, ctx):
+    providers = []
+
+    # provide NpmPackageInfo if it is not already provided there are NpmPackageInfo deps
+    if not NpmPackageInfo in target:
+        sources_depsets = []
+        workspace = None
+        if hasattr(ctx.rule.attr, "deps"):
+            for dep in ctx.rule.attr.deps:
+                if NpmPackageInfo in dep:
+                    if workspace and dep[NpmPackageInfo].workspace != workspace:
+                        fail("All npm dependencies need to come from a single workspace. Found '%s' and '%s'." % (workspace, dep[NpmPackageInfo].workspace))
+                    workspace = dep[NpmPackageInfo].workspace
+                    sources_depsets.append(dep[NpmPackageInfo].sources)
+            if workspace:
+                providers.extend([NpmPackageInfo(direct_sources = depset(), sources = depset(transitive = sources_depsets), workspace = workspace)])
+
+    return providers
+
+node_modules_aspect = aspect(
+    _node_modules_aspect_impl,
+    attr_aspects = ["deps"],
+)

--- a/internal/rollup/rollup_bundle.bzl
+++ b/internal/rollup/rollup_bundle.bzl
@@ -18,7 +18,7 @@ The versions of Rollup and terser are controlled by the Bazel toolchain.
 You do not need to install them into your project.
 """
 
-load("@build_bazel_rules_nodejs//internal/common:npm_package_info.bzl", "NpmPackageInfo", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "NpmPackageInfo", "node_modules_aspect")
 load("//internal/common:collect_es6_sources.bzl", _collect_es2015_sources = "collect_es6_sources")
 load("//internal/common:module_mappings.bzl", "get_module_mappings")
 

--- a/packages/karma/src/karma_web_test.bzl
+++ b/packages/karma/src/karma_web_test.bzl
@@ -13,8 +13,7 @@
 # limitations under the License.
 "Unit testing with Karma"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo")
-load("@build_bazel_rules_nodejs//internal/common:npm_package_info.bzl", "NpmPackageInfo", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo", "NpmPackageInfo", "node_modules_aspect")
 load("@build_bazel_rules_nodejs//internal/js_library:js_library.bzl", "write_amd_names_shim")
 load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_suite")
 load("@io_bazel_rules_webtesting//web/internal:constants.bzl", "DEFAULT_WRAPPED_TEST_TAGS")

--- a/packages/karma/src/web_test.bzl
+++ b/packages/karma/src/web_test.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 "Common web_test attributes"
 
-load("@build_bazel_rules_nodejs//internal/common:npm_package_info.bzl", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "node_modules_aspect")
 
 # Attributes shared by any web_test rule (ts_web_test, karma_web_test, protractor_web_test)
 COMMON_WEB_TEST_ATTRS = {

--- a/packages/labs/src/protobufjs/ts_proto_library.bzl
+++ b/packages/labs/src/protobufjs/ts_proto_library.bzl
@@ -13,8 +13,7 @@
 # limitations under the License.
 "Protocol Buffers"
 
-load("@build_bazel_rules_nodejs//:declaration_provider.bzl", "DeclarationInfo")
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSEcmaScriptModuleInfo", "JSNamedModuleInfo")
+load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "JSEcmaScriptModuleInfo", "JSNamedModuleInfo")
 
 def _run_pbjs(actions, executable, output_name, proto_files, suffix = ".js", wrap = "amd", amd_name = ""):
     js_file = actions.declare_file(output_name + suffix)

--- a/packages/protractor/src/protractor_web_test.bzl
+++ b/packages/protractor/src/protractor_web_test.bzl
@@ -14,8 +14,7 @@
 "Run end-to-end tests with Protractor"
 
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo")
-load("@build_bazel_rules_nodejs//internal/common:npm_package_info.bzl", "NpmPackageInfo", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo", "NpmPackageInfo", "node_modules_aspect")
 load("@build_bazel_rules_nodejs//internal/common:windows_utils.bzl", "create_windows_native_launcher_script", "is_windows")
 load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_suite")
 load("@io_bazel_rules_webtesting//web/internal:constants.bzl", "DEFAULT_WRAPPED_TEST_TAGS")

--- a/packages/rollup/src/rollup_bundle.bzl
+++ b/packages/rollup/src/rollup_bundle.bzl
@@ -1,7 +1,6 @@
 "Rules for running Rollup under Bazel"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSEcmaScriptModuleInfo")
-load("@build_bazel_rules_nodejs//internal/common:npm_package_info.bzl", "NpmPackageInfo", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSEcmaScriptModuleInfo", "NpmPackageInfo", "node_modules_aspect")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "module_mappings_aspect", "register_node_modules_linker")
 
 _DOC = """Runs the Rollup.js CLI under Bazel.

--- a/packages/typescript/src/internal/build_defs.bzl
+++ b/packages/typescript/src/internal/build_defs.bzl
@@ -14,8 +14,7 @@
 
 "TypeScript compilation"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "js_ecma_script_module_info", "js_named_module_info")
-load("@build_bazel_rules_nodejs//internal/common:npm_package_info.bzl", "NpmPackageInfo", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "NpmPackageInfo", "js_ecma_script_module_info", "js_named_module_info", "node_modules_aspect")
 
 # pylint: disable=unused-argument
 # pylint: disable=missing-docstring

--- a/packages/typescript/src/internal/devserver/ts_devserver.bzl
+++ b/packages/typescript/src/internal/devserver/ts_devserver.bzl
@@ -14,8 +14,7 @@
 
 "Simple development server"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo")
-load("@build_bazel_rules_nodejs//internal/common:npm_package_info.bzl", "NpmPackageInfo", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo", "NpmPackageInfo", "node_modules_aspect")
 load(
     "@build_bazel_rules_nodejs//internal/js_library:js_library.bzl",
     "write_amd_names_shim",

--- a/providers.bzl
+++ b/providers.bzl
@@ -1,90 +1,48 @@
-"""Providers for interop between JS rules.
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-This file has to live in the built-in so that all rules can load() the providers
-even if users haven't installed any of the packages/*
+"""Public providers, aspects and helper surface is re-exported here.
 
-These providers allows rules to interoperate without knowledge
-of each other.
-
-You can think of a provider as a message bus.
-A rule "publishes" a message as an instance of the provider, and some other rule
-subscribes to these by having a (possibly transitive) dependency on the publisher.
-
-## Debugging
-
-Debug output is considered orthogonal to these providers.
-Any output may or may not have user debugging affordances provided, such as
-readable minification.
-We expect that rules will have a boolean `debug` attribute, and/or accept the `DEBUG`
-environment variable.
-Note that this means a given build either produces debug or non-debug output.
-If users really need to produce both in a single build, they'll need two rules with
-differing 'debug' attributes.
+Users should not load files under "/internal"
 """
 
-JSNamedModuleInfo = provider(
-    doc = """JavaScript files whose module name is self-contained.
-
-For example named AMD/UMD or goog.module format.
-These files can be efficiently served with the concatjs bundler.
-These outputs should be named "foo.umd.js"
-(note that renaming it from "foo.js" doesn't affect the module id)
-
-Historical note: this was the typescript.es5_sources output.
-""",
-    fields = {
-        "direct_sources": "Depset of direct JavaScript files and sourcemaps",
-        "sources": "Depset of direct and transitive JavaScript files and sourcemaps",
-    },
+load(
+    "//internal/providers:declaration_info.bzl",
+    _DeclarationInfo = "DeclarationInfo",
+    _provide_declarations = "provide_declarations",
+)
+load(
+    "//internal/providers:js_providers.bzl",
+    _JSEcmaScriptModuleInfo = "JSEcmaScriptModuleInfo",
+    _JSNamedModuleInfo = "JSNamedModuleInfo",
+    _js_ecma_script_module_info = "js_ecma_script_module_info",
+    _js_named_module_info = "js_named_module_info",
+    _transitive_js_ecma_script_module_info = "transitive_js_ecma_script_module_info",
+)
+load(
+    "//internal/providers:npm_package_info.bzl",
+    _NpmPackageInfo = "NpmPackageInfo",
+    _node_modules_aspect = "node_modules_aspect",
 )
 
-def js_named_module_info(sources, deps = []):
-    """Constructs a JSNamedModuleInfo including all transitive sources from JSNamedModuleInfo providers in a list of deps.
-
-Returns a single JSNamedModuleInfo.
-"""
-    transitive_depsets = [sources]
-    for dep in deps:
-        if JSNamedModuleInfo in dep:
-            transitive_depsets.append(dep[JSNamedModuleInfo].sources)
-
-    return JSNamedModuleInfo(
-        direct_sources = sources,
-        sources = depset(transitive = transitive_depsets),
-    )
-
-JSEcmaScriptModuleInfo = provider(
-    doc = """JavaScript files (and sourcemaps) that are intended to be consumed by downstream tooling.
-
-They should use modern syntax and ESModules.
-These files should typically be named "foo.mjs"
-TODO: should we require that?
-
-Historical note: this was the typescript.es6_sources output""",
-    fields = {
-        "direct_sources": "Depset of direct JavaScript files and sourcemaps",
-        "sources": "Depset of direct and transitive JavaScript files and sourcemaps",
-    },
-)
-
-def js_ecma_script_module_info(sources, deps = []):
-    """Constructs a JSEcmaScriptModuleInfo including all transitive sources from JSEcmaScriptModuleInfo providers in a list of deps.
-
-Returns a single JSEcmaScriptModuleInfo.
-"""
-    transitive_depsets = [sources]
-    for dep in deps:
-        if JSEcmaScriptModuleInfo in dep:
-            transitive_depsets.append(dep[JSEcmaScriptModuleInfo].sources)
-
-    return JSEcmaScriptModuleInfo(
-        direct_sources = sources,
-        sources = depset(transitive = transitive_depsets),
-    )
-
-def transitive_js_ecma_script_module_info(**kwargs):
-    """Alias of js_ecma_script_module_info.
-
-TODO(gregmagolan): Remove this alias before 1.0 release.
-"""
-    return js_ecma_script_module_info(**kwargs)
+provide_declarations = _provide_declarations
+DeclarationInfo = _DeclarationInfo
+JSNamedModuleInfo = _JSNamedModuleInfo
+js_named_module_info = _js_named_module_info
+JSEcmaScriptModuleInfo = _JSEcmaScriptModuleInfo
+js_ecma_script_module_info = _js_ecma_script_module_info
+transitive_js_ecma_script_module_info = _transitive_js_ecma_script_module_info
+NpmPackageInfo = _NpmPackageInfo
+node_modules_aspect = _node_modules_aspect
+# TODO: remove transitive_js_ecma_script_module_info alias before 1.0 release


### PR DESCRIPTION
Put all shared provider code into .bzl files in /providers folder and re-export all from //:providers.bzl so that users have a consistent load location. Legacy load locations kept around so dependency sandwich with angular/angular is simpler to resolve. Should be able to remove them by 1.0.