### PR TITLE
fix(terser): terser_minified should support .mjs files when running on directory

### DIFF
--- a/packages/terser/src/index.js
+++ b/packages/terser/src/index.js
@@ -110,7 +110,7 @@ function terserDirectory(input, output, residual, terserBinary) {
   }
 
   fs.readdirSync(input).forEach(f => {
-    if (f.endsWith('.js')) {
+    if (path.extname(f) === '.js' || path.extname(f) === '.mjs') {
       const inputFile = path.join(input, path.basename(f));
       const outputFile = path.join(output, path.basename(f));
 


### PR DESCRIPTION
Directory mode should match file mode which already allows .mjs files

```
def _filter_js(files):
    return [f for f in files if f.is_directory or f.extension == "js" or f.extension == "mjs"]
```