### PR TITLE
WIP: feat(rollup): Added ability to bundle ts_libraries that use module_root

### DIFF
--- a/internal/linker/link_node_modules.bzl
+++ b/internal/linker/link_node_modules.bzl
@@ -147,8 +147,8 @@ def get_module_mappings(label, attrs, vars, rule_kind, srcs = [], workspace_name
                 if short_path.startswith("../"):
                     short_path = "external/" + short_path[3:]
                 if not short_path.startswith(mr):
-                    fail(("all sources must be under module root: %s, but found: %s" % 
-                        (mr, short_path)))
+                    fail(("all sources must be under module root: %s, but found: %s" %
+                          (mr, short_path)))
 
     # since our module mapping is currently based on attribute names,
     # allow a special one to instruct the linker that the package has no output

--- a/internal/linker/link_node_modules.bzl
+++ b/internal/linker/link_node_modules.bzl
@@ -122,6 +122,34 @@ def get_module_mappings(label, attrs, vars, rule_kind, srcs = [], workspace_name
     elif label.workspace_root:
         mr = "%s/%s" % (label.workspace_root, mr)
 
+    # Consider the module_root attribute when resolving mappings to allow for ts_libraries compiled with it set.
+
+    if attrs.module_root and attrs.module_root != ".":
+        mr = "%s/%s" % (mr, attrs.module_root)
+        if attrs.module_root.endswith(".ts"):
+            if workspace_name:
+                mr = mr.replace(".d.ts", "")
+
+            # Validate that sources are underneath the module root.
+            # module_roots ending in .ts are a special case, they are used to
+            # restrict what's exported from a build rule, e.g. only exports from a
+            # specific index.d.ts file. For those, not every source must be under the
+            # given module root.
+
+        else:
+            for s in srcs:
+                short_path = s.short_path
+
+                # Execroot paths for external repositories should start with external/
+                # But the short_path property of file gives the relative path from our workspace
+                # instead. We must correct this to compare with the module_root which is an
+                # execroot path.
+                if short_path.startswith("../"):
+                    short_path = "external/" + short_path[3:]
+                if not short_path.startswith(mr):
+                    fail(("all sources must be under module root: %s, but found: %s" % 
+                        (mr, short_path)))
+
     # since our module mapping is currently based on attribute names,
     # allow a special one to instruct the linker that the package has no output
     # directory and is therefore meant to be used as sources.

--- a/packages/rollup/test/integration/foo/BUILD.bazel
+++ b/packages/rollup/test/integration/foo/BUILD.bazel
@@ -22,6 +22,7 @@ ts_library(
     module_name = "foolib",
     # Don't allow deep imports under here,
     # and give it the AMD name "foolib", not "foolib/index"
-    module_root = "index.d.ts",
+    # TODO: We currently cannot set module_root to a file name for rollup usage
+    # module_root = "index.d.ts",
     deps = ["@npm//date-fns"],
 )

--- a/packages/rollup/test/integration/fum/BUILD.bazel
+++ b/packages/rollup/test/integration/fum/BUILD.bazel
@@ -7,7 +7,4 @@ js_library(
     srcs = ["index.js"],
     module_from_src = True,
     module_name = "fumlib",
-    # Don't allow deep imports under here,
-    # and give it the AMD name "fumlib", not "fumlib/index"
-    module_root = "index.d.ts",
 )


### PR DESCRIPTION
## PR Checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently a `rollup_bundle` task that references a `ts_library` wont be able to link if the `ts_library` depends on the `module_root` attribute being correctly parsed. A showcase can be found here: https://github.com/Kolpa/bazel_rollup_module_root

## What is the new behavior?
The `module_root` attribute is applied to the `module_mappings` in the same way as the `rules_typescript`'s approach allowing for compilation that follows directories.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

if `module_root` is set to a specific file linking will currently fail.