### PR TITLE
refactor: use deps declared on rollup_bundle

### DIFF
--- a/examples/angular/src/BUILD.bazel
+++ b/examples/angular/src/BUILD.bazel
@@ -127,7 +127,11 @@ rollup_bundle(
         ":main.prod.ts": "index",
     },
     output_dir = True,
-    deps = ["//src"],
+    deps = [
+        "//src",
+        "@npm//rollup-plugin-commonjs",
+        "@npm//rollup-plugin-node-resolve",
+    ],
 )
 
 babel(

--- a/examples/angular_view_engine/src/BUILD.bazel
+++ b/examples/angular_view_engine/src/BUILD.bazel
@@ -125,7 +125,13 @@ rollup_bundle(
         ":main.prod.ts": "index",
     },
     output_dir = True,
-    deps = ["//src"],
+    deps = [
+        "//src",
+        "@npm//rollup-plugin-amd",
+        "@npm//rollup-plugin-commonjs",
+        "@npm//rollup-plugin-node-resolve",
+        "@npm//rollup-plugin-re",
+    ],
 )
 
 babel(

--- a/examples/kotlin/BUILD.bazel
+++ b/examples/kotlin/BUILD.bazel
@@ -42,6 +42,8 @@ rollup_bundle(
     deps = [
         "@npm//kotlin",
         "@npm//kotlinx-html-js",
+        "@npm//rollup-plugin-commonjs",
+        "@npm//rollup-plugin-node-resolve",
     ],
 )
 

--- a/internal/linker/link_node_modules.bzl
+++ b/internal/linker/link_node_modules.bzl
@@ -10,7 +10,7 @@ linker, which uses the mappings to link a node_modules directory for
 runtimes to locate all the first-party packages.
 """
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "NpmPackageInfo")
+load("@build_bazel_rules_nodejs//internal/providers:npm_package_info.bzl", "NpmPackageInfo")
 
 def _debug(vars, *args):
     if "VERBOSE_LOGS" in vars.keys():
@@ -22,13 +22,26 @@ _ASPECT_RESULT_NAME = "link_node_modules__aspect_result"
 # Traverse 'srcs' in addition so that we can go across a genrule
 _MODULE_MAPPINGS_DEPS_NAMES = ["data", "deps", "srcs"]
 
-def register_node_modules_linker(ctx, args, inputs):
+def add_arg(args, arg):
+    """Add an argument
+
+    Args:
+        args: either a list or a ctx.actions.Args object
+        arg: string arg to append on the end
+    """
+    if (type(args) == type([])):
+        args.append(arg)
+    else:
+        args.add(arg)
+
+def register_node_modules_linker(ctx, args, inputs, data = []):
     """Helps an action to run node by setting up the node_modules linker as a pre-process
 
     Args:
       ctx: Bazel's starlark execution context, used to get attributes and actions
       args: Arguments being passed to the program; a linker argument will be appended
       inputs: inputs being passed to the program; a linker input will be appended
+      data: labels to search for npm packages that need to be linked (ctx.attr.deps and ctx.attr.data will always be searched)
     """
 
     mappings = {
@@ -40,7 +53,7 @@ def register_node_modules_linker(ctx, args, inputs):
     node_modules_root = ""
 
     # Look through data/deps attributes to find...
-    for dep in getattr(ctx.attr, "data", []) + getattr(ctx.attr, "deps", []):
+    for dep in data + getattr(ctx.attr, "data", []) + getattr(ctx.attr, "deps", []):
         # ...the root directory for the third-party node_modules; we'll symlink the local "node_modules" to it
         if NpmPackageInfo in dep:
             possible_root = "/".join([dep[NpmPackageInfo].workspace, "node_modules"])
@@ -67,7 +80,7 @@ def register_node_modules_linker(ctx, args, inputs):
         "workspace": ctx.workspace_name,
     }
     ctx.actions.write(modules_manifest, str(content))
-    args.add("--bazel_node_modules_manifest=%s" % modules_manifest.path)
+    add_arg(args, "--bazel_node_modules_manifest=%s" % modules_manifest.path)
     inputs.append(modules_manifest)
 
 def get_module_mappings(label, attrs, vars, rule_kind, srcs = [], workspace_name = None):

--- a/internal/node/bazel_require_script.js
+++ b/internal/node/bazel_require_script.js
@@ -1,0 +1,38 @@
+// Adapt node programs to run under Bazel
+// Meant to be run in a --require hook
+
+const fs = require('fs');
+const path = require('path');
+const orig = {};
+// TODO: more functions need patched like
+// the async and native versions
+orig['realPathSync'] = fs.realpathSync;
+orig['lstatSync'] = fs.lstatSync;
+
+// To fully resolve a symlink requires recursively
+// following symlinks until the target is a file
+// rather than a symlink, so we must make this look
+// like a file.
+function lstatSync(p) {
+  const result = orig.lstatSync(p);
+  result.isSymbolicLink = () => false;
+  result.isFile = () => true;
+  return result;
+}
+
+function realpathSync(...s) {
+  // Realpath returns an absolute path, so we should too
+  return path.resolve(s[0]);
+}
+
+function monkeypatch() {
+  fs.realpathSync = realpathSync;
+  fs.lstatSync = lstatSync;
+}
+
+function unmonkeypatch() {
+  fs.realpathSync = orig.realPathSync;
+  fs.lstatSync = orig.lstatSync;
+}
+
+monkeypatch();

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -134,6 +134,8 @@ def _to_execroot_path(ctx, file):
             # external/npm/node_modules -> node_modules/foo
             # the linker will make sure we can resolve node_modules from npm
             return "/".join(parts[2:])
+    if file.is_source:
+        return file.path
 
     return ("<ERROR> _to_execroot_path not yet implemented for " + file.path)
 
@@ -262,7 +264,7 @@ def _nodejs_binary_impl(ctx):
         # TODO(alexeagle): remove sources and node_modules from the runfiles
         # when downstream usage is ready to rely on linker
         NodeRuntimeDepsInfo(
-            deps = depset(transitive = [node_modules, sources]),
+            deps = depset([ctx.file.entry_point], transitive = [node_modules, sources]),
             pkgs = ctx.attr.data,
         ),
     ]

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -182,6 +182,7 @@ def _nodejs_binary_impl(ctx):
         fail("The node toolchain was not properly configured so %s cannot be executed. Make sure that target_tool_path or target_tool is set." % ctx.attr.name)
 
     node_tool_files.append(ctx.file._link_modules_script)
+    node_tool_files.append(ctx.file._bazel_require_script)
 
     if not ctx.outputs.templated_args_file:
         templated_args = ctx.attr.templated_args
@@ -213,6 +214,7 @@ def _nodejs_binary_impl(ctx):
             expand_location_into_runfiles(ctx, a)
             for a in templated_args
         ]),
+        "TEMPLATED_bazel_require_script": _to_manifest_path(ctx, ctx.file._bazel_require_script),
         "TEMPLATED_env_vars": env_vars,
         "TEMPLATED_expected_exit_code": str(expected_exit_code),
         "TEMPLATED_link_modules_script": _to_manifest_path(ctx, ctx.file._link_modules_script),
@@ -446,6 +448,10 @@ jasmine_node_test(
         """,
     ),
     "_bash_runfile_helpers": attr.label(default = Label("@bazel_tools//tools/bash/runfiles")),
+    "_bazel_require_script": attr.label(
+        default = Label("//internal/node:bazel_require_script.js"),
+        allow_single_file = True,
+    ),
     "_launcher_template": attr.label(
         default = Label("//internal/node:node_launcher.sh"),
         allow_single_file = True,

--- a/internal/node/node_launcher.sh
+++ b/internal/node/node_launcher.sh
@@ -127,7 +127,10 @@ ALL_ARGS=(TEMPLATED_args $NODE_REPOSITORY_ARGS "$@")
 for ARG in "${ALL_ARGS[@]}"; do
   case "$ARG" in
     --bazel_node_modules_manifest=*) MODULES_MANIFEST="${ARG#--bazel_node_modules_manifest=}" ;;
-    --nobazel_patch_module_resolver) MAIN="./TEMPLATED_script_path" ;;
+    --nobazel_patch_module_resolver)
+      MAIN="./TEMPLATED_script_path"
+      NODE_OPTIONS+=( "--require" "./$(rlocation "TEMPLATED_bazel_require_script")" )
+      ;;
     --node_options=*) NODE_OPTIONS+=( "${ARG#--node_options=}" ) ;;
     *) ARGS+=( "$ARG" )
   esac

--- a/internal/node/node_launcher.sh
+++ b/internal/node/node_launcher.sh
@@ -116,7 +116,7 @@ TEMPLATED_env_vars
 
 readonly node=$(rlocation "TEMPLATED_node")
 readonly repository_args=$(rlocation "TEMPLATED_repository_args")
-readonly script=$(rlocation "TEMPLATED_script_path")
+MAIN=$(rlocation "TEMPLATED_loader_path")
 readonly link_modules_script=$(rlocation "TEMPLATED_link_modules_script")
 
 source $repository_args
@@ -127,6 +127,7 @@ ALL_ARGS=(TEMPLATED_args $NODE_REPOSITORY_ARGS "$@")
 for ARG in "${ALL_ARGS[@]}"; do
   case "$ARG" in
     --bazel_node_modules_manifest=*) MODULES_MANIFEST="${ARG#--bazel_node_modules_manifest=}" ;;
+    --nobazel_patch_module_resolver) MAIN="./TEMPLATED_script_path" ;;
     --node_options=*) NODE_OPTIONS+=( "${ARG#--node_options=}" ) ;;
     *) ARGS+=( "$ARG" )
   esac
@@ -147,12 +148,12 @@ if [ "${EXPECTED_EXIT_CODE}" -eq "0" ]; then
   # handled by the node process.
   # If we had merely forked a child process here, we'd be responsible
   # for forwarding those OS interactions.
-  exec "${node}" "${NODE_OPTIONS[@]}" "${script}" "${ARGS[@]}"
+  exec "${node}" "${NODE_OPTIONS[@]}" "${MAIN}" "${ARGS[@]}"
   # exec terminates execution of this shell script, nothing later will run.
 fi
 
 set +e
-"${node}" "${NODE_OPTIONS[@]}" "${script}" "${ARGS[@]}"
+"${node}" "${NODE_OPTIONS[@]}" "${MAIN}" "${ARGS[@]}"
 RESULT="$?"
 set -e
 

--- a/internal/node/npm_package_bin.bzl
+++ b/internal/node/npm_package_bin.bzl
@@ -1,7 +1,7 @@
 "A generic rule to run a tool that appears in node_modules/.bin"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "NpmPackageInfo", "node_modules_aspect")
-load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "module_mappings_aspect", "register_node_modules_linker")
+load("@build_bazel_rules_nodejs//:providers.bzl", "NpmPackageInfo", "node_modules_aspect", "run_node")
+load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "module_mappings_aspect")
 
 # Note: this API is chosen to match nodejs_binary
 # so that we can generate macros that act as either an output-producing tool or an executable
@@ -52,11 +52,12 @@ def _impl(ctx):
         outputs = [ctx.actions.declare_directory(ctx.attr.name)]
     else:
         outputs = ctx.outputs.outs
-    register_node_modules_linker(ctx, args, inputs)
+
     for a in ctx.attr.args:
         args.add(_expand_location(ctx, a))
-    ctx.actions.run(
-        executable = ctx.executable.tool,
+    run_node(
+        ctx,
+        executable = "tool",
         inputs = inputs,
         outputs = outputs,
         arguments = [args],

--- a/internal/npm_install/generate_build_file.js
+++ b/internal/npm_install/generate_build_file.js
@@ -419,9 +419,6 @@ def _maybe(repo_rule, name, **kwargs):
     }
     function addDynamicDependencies(pkgs, dynamic_deps = DYNAMIC_DEPS) {
         function match(name, p) {
-            // Automatically include dynamic dependency on plugins of the form pkg-plugin-foo
-            if (name.startsWith(`${p._moduleName}-plugin-`))
-                return true;
             const value = dynamic_deps[p._moduleName];
             if (name === value)
                 return true;

--- a/internal/npm_install/generate_build_file.ts
+++ b/internal/npm_install/generate_build_file.ts
@@ -459,9 +459,6 @@ function hasRootBuildFile(pkg: Dep, rootPath: string) {
 
 function addDynamicDependencies(pkgs: Dep[], dynamic_deps = DYNAMIC_DEPS) {
   function match(name: string, p: Dep) {
-    // Automatically include dynamic dependency on plugins of the form pkg-plugin-foo
-    if (name.startsWith(`${p._moduleName}-plugin-`)) return true;
-
     const value = dynamic_deps[p._moduleName];
     if (name === value) return true;
 

--- a/internal/npm_install/test/generate_build_file.spec.js
+++ b/internal/npm_install/test/generate_build_file.spec.js
@@ -101,27 +101,6 @@ describe('build file generator', () => {
       expect(pkgs[0]._dynamicDependencies).toEqual(['//bar:bar']);
       expect(printPackageBin(pkgs[0])).toContain('data = ["//some_dir:foo", "//bar:bar"]');
     });
-    it('should automatically include plugins in nodejs_binary data', () => {
-      const pkgs = [
-        {_name: 'foo', bin: 'foobin', _dir: 'some_dir', _moduleName: 'foo'},
-        {_name: 'foo-plugin-bar', _dir: 'bar', _moduleName: 'foo-plugin-bar'}
-      ];
-      addDynamicDependencies(pkgs, {});
-      expect(pkgs[0]._dynamicDependencies).toEqual(['//bar:foo-plugin-bar']);
-      expect(printPackageBin(pkgs[0]))
-          .toContain('data = ["//some_dir:foo", "//bar:foo-plugin-bar"]');
-    });
-    it('should not include nested packages', () => {
-      const pkgs = [
-        {_name: 'foo', bin: 'foobin', _dir: 'some_dir', _moduleName: 'foo'}, {
-          _name: 'foo-plugin-bar',
-          _dir: 'top-level/node_modules/bar',
-          _moduleName: 'foo-plugin-bar'
-        }
-      ];
-      addDynamicDependencies(pkgs, {});
-      expect(pkgs[0]._dynamicDependencies).toEqual([]);
-    });
   });
 
   describe('index.bzl files', () => {

--- a/internal/providers/node_runtime_deps_info.bzl
+++ b/internal/providers/node_runtime_deps_info.bzl
@@ -1,0 +1,69 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Custom provider that mimics the Runfiles, but doesn't incur the expense of creating the runfiles symlink tree"""
+
+load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "add_arg", "register_node_modules_linker")
+
+NodeRuntimeDepsInfo = provider(
+    doc = """Stores runtime dependencies of a nodejs_binary or nodejs_test
+
+These are files that need to be found by the node module resolver at runtime.
+
+Historically these files were passed using the Runfiles mechanism.
+However runfiles has a big performance penalty of creating a symlink forest
+with FS API calls for every file in node_modules.
+It also causes there to be separate node_modules trees under each binary. This
+prevents user-contributed modules passed as deps[] to a particular action from
+being found by node module resolver, which expects everything in one tree.
+
+In node, this resolution is done dynamically by assuming a node_modules
+tree will exist on disk, so we assume node actions/binary/test executions will
+do the same.
+""",
+    fields = {
+        "pkgs": "list of labels of packages that provide NpmPackageInfo",
+        "deps": "depset of runtime dependency labels",
+    },
+)
+
+def run_node(ctx, inputs, arguments, executable, **kwargs):
+    """Helper to replace ctx.actions.run
+    This calls node programs with a node_modules directory in place"""
+    if (type(executable) != "string"):
+        fail("""run_node requires that executable be provided as a string,
+            eg. my_executable rather than ctx.executable.my_executable
+            got %s""" % type(executable))
+    exec_attr = getattr(ctx.attr, executable)
+    exec_exec = getattr(ctx.executable, executable)
+
+    extra_inputs = []
+    link_data = []
+    if (NodeRuntimeDepsInfo in exec_attr):
+        extra_inputs = exec_attr[NodeRuntimeDepsInfo].deps.to_list()
+        link_data = exec_attr[NodeRuntimeDepsInfo].pkgs
+
+    register_node_modules_linker(ctx, arguments, inputs, link_data)
+
+    # By using the run_node helper, you suggest that your program
+    # doesn't implicitly use runfiles to require() things
+    # To access runfiles, youu must use a runfiles helper in the program instead
+    add_arg(arguments, "--nobazel_patch_module_resolver")
+
+    ctx.actions.run(
+        inputs = inputs + extra_inputs,
+        arguments = arguments,
+        executable = exec_exec,
+        **kwargs
+    )

--- a/packages/rollup/src/rollup_bundle.bzl
+++ b/packages/rollup/src/rollup_bundle.bzl
@@ -1,7 +1,6 @@
 "Rules for running Rollup under Bazel"
 
 load("@build_bazel_rules_nodejs//:providers.bzl", "JSEcmaScriptModuleInfo", "NpmPackageInfo", "node_modules_aspect", "run_node")
-load("@build_bazel_rules_nodejs//internal/common:windows_utils.bzl", "is_windows")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "module_mappings_aspect")
 
 _DOC = """Runs the Rollup.js CLI under Bazel.
@@ -287,14 +286,7 @@ def _rollup_bundle(ctx):
         },
     )
 
-    # On platforms with symlinks, we need to avoid the fs.realpathSync call in rollup/bin/rollup
-    # But on windows the slashes would be wrong, and we don't need to avoid the realpathSync
-    # Perhaps we should use a --require script that monkeypatches realpathSync to make all binaries
-    # behave as expected under Bazel execroot/runfiles trees?
-    if is_windows(ctx):
-        args.add_all(["--config", config.path])
-    else:
-        args.add_all(["--config", "node:./" + config.path])
+    args.add_all(["--config", config.path])
     inputs.append(config)
 
     if ctx.version_file:

--- a/packages/rollup/test/integration/BUILD.bazel
+++ b/packages/rollup/test/integration/BUILD.bazel
@@ -27,6 +27,9 @@ _BUNDLE_FORMATS = [
             "//%s/fum:fumlib" % package_name(),
             "//%s/foo:foolib" % package_name(),
             "@npm//hello",
+            "@npm//rollup-plugin-commonjs",
+            "@npm//rollup-plugin-json",
+            "@npm//rollup-plugin-node-resolve",
         ],
     )
     for format in _BUNDLE_FORMATS

--- a/packages/rollup/test/plugins/BUILD.bazel
+++ b/packages/rollup/test/plugins/BUILD.bazel
@@ -7,6 +7,7 @@ rollup_bundle(
     config_file = "rollup.config.js",
     entry_point = "input.js",
     sourcemap = "false",
+    deps = ["@npm//rollup-plugin-json"],
 )
 
 golden_file_test(

--- a/providers.bzl
+++ b/providers.bzl
@@ -31,6 +31,11 @@ load(
     _transitive_js_ecma_script_module_info = "transitive_js_ecma_script_module_info",
 )
 load(
+    "//internal/providers:node_runtime_deps_info.bzl",
+    _NodeRuntimeDepsInfo = "NodeRuntimeDepsInfo",
+    _run_node = "run_node",
+)
+load(
     "//internal/providers:npm_package_info.bzl",
     _NpmPackageInfo = "NpmPackageInfo",
     _node_modules_aspect = "node_modules_aspect",
@@ -45,4 +50,7 @@ js_ecma_script_module_info = _js_ecma_script_module_info
 transitive_js_ecma_script_module_info = _transitive_js_ecma_script_module_info
 NpmPackageInfo = _NpmPackageInfo
 node_modules_aspect = _node_modules_aspect
+
 # TODO: remove transitive_js_ecma_script_module_info alias before 1.0 release
+NodeRuntimeDepsInfo = _NodeRuntimeDepsInfo
+run_node = _run_node


### PR DESCRIPTION
This replaces the dynamic_deps mechanism for pulling user-specified plugins into the node_modules tree
