### PR TITLE
feat(examples): use closure-templates aka soy in the closure example

### DIFF
--- a/examples/closure/BUILD.bazel
+++ b/examples/closure/BUILD.bazel
@@ -1,6 +1,23 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
 load("@npm//google-closure-compiler:index.bzl", "google_closure_compiler")
 
+java_binary(
+    name = "google_closure_templates_compiler",
+    main_class = "com.google.template.soy.SoyToIncrementalDomSrcCompiler",
+    runtime_deps = ["@maven//:com_google_template_soy"],
+)
+
+genrule(
+    name = "compile_soy",
+    srcs = ["index.soy"],
+    outs = ["index.soy.js"],
+    cmd = """$(location google_closure_templates_compiler) \
+      --srcs $(SRCS) \
+      --outputPathFormat $(@D)/{INPUT_FILE_NAME}.js\
+    """,
+    tools = ["google_closure_templates_compiler"],
+)
+
 google_closure_compiler(
     name = "closure",
     outs = ["bundle.js"],
@@ -9,9 +26,13 @@ google_closure_compiler(
         # --platform native would be faster but is failing on Windows
         "--platform=javascript",
         "--js=$(location hello.js)",
+        "--js=$(location index.soy.js)",
         "--js_output_file=$(location bundle.js)",
     ],
-    data = ["hello.js"],
+    data = [
+        "hello.js",
+        "index.soy.js",
+    ],
 )
 
 nodejs_test(

--- a/examples/closure/BUILD.bazel
+++ b/examples/closure/BUILD.bazel
@@ -18,21 +18,49 @@ genrule(
     tools = ["google_closure_templates_compiler"],
 )
 
+# _CLOSURE_LIB_DEPS = [
+#     "@npm//:node_modules/google-closure-library/closure/goog/soy/data.js",
+#     "@closure-templates//:api_idom.js",
+#     "@closure-templates//:soyutils_velog.js",
+# ]
+
+_CLOSURE_LIB_DEPS = glob([
+    #"@npm//:node_modules/google-closure-library/closure/goog/**/*.js",
+    #"@closure-templates//*.js",
+])
+
+genrule(
+    name = "closure_config",
+    srcs = [
+        "@closure-templates//:all",
+        "@npm//google-closure-library:google-closure-library__files",
+        "@npm//google-protobuf:google-protobuf__files",
+    ],
+    outs = ["closure.conf"],
+    cmd = """echo $(locations @closure-templates//:all) $(locations @npm//google-closure-library:google-closure-library__files) $(locations @npm//google-protobuf:google-protobuf__files) | xargs -n 1 echo "--js " | grep ".js$$" > $@""",
+)
+
 google_closure_compiler(
     name = "closure",
     outs = ["bundle.js"],
     args = [
         # workaround https://github.com/google/closure-compiler-npm/issues/147
         # --platform native would be faster but is failing on Windows
-        "--platform=javascript",
+        #"--platform=javascript",
+        "--platform=native",
+        "--flagfile=$(location :closure_config)",
         "--js=$(location hello.js)",
         "--js=$(location index.soy.js)",
         "--js_output_file=$(location bundle.js)",
-    ],
+    ] + ["--js=$(location %s)" % s for s in _CLOSURE_LIB_DEPS],
     data = [
         "hello.js",
         "index.soy.js",
-    ],
+        ":closure_config",
+        "@closure-templates//:all",
+        "@npm//google-protobuf:google-protobuf__files",
+        "@npm//google-closure-library:google-closure-library__files",
+    ] + _CLOSURE_LIB_DEPS,
 )
 
 nodejs_test(

--- a/examples/closure/WORKSPACE
+++ b/examples/closure/WORKSPACE
@@ -54,3 +54,21 @@ maven_install(
         "https://repo1.maven.org/maven2",
     ],
 )
+
+# Soy distribution is missing the .js code
+http_archive(
+    name = "closure-templates",
+    build_file_content = """
+exports_files(["api_idom.js", "soyutils_velog.js"])
+filegroup(
+    name = "all",
+    srcs = glob(["*.js"]),
+    visibility = ["//visibility:public"],
+)
+""",
+    patch_args = ["-p1"],
+    patches = ["//:closure-templates.patch"],
+    sha256 = "cd8afa4cd8d0524fc595be82a8b2b0eaf6fa36696674c0ba14d95f3eb8504535",
+    strip_prefix = "closure-templates-release-2019-10-08/javascript",
+    urls = ["https://github.com/google/closure-templates/archive/release-2019-10-08.zip"],
+)

--- a/examples/closure/WORKSPACE
+++ b/examples/closure/WORKSPACE
@@ -25,10 +25,32 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.38.3/rules_nodejs-0.38.3.tar.gz"],
 )
 
+http_archive(
+    name = "rules_jvm_external",
+    sha256 = "79c9850690d7614ecdb72d68394f994fef7534b292c4867ce5e7dec0aa7bdfad",
+    strip_prefix = "rules_jvm_external-2.8",
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/2.8.zip",
+)
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(
     name = "npm",
     package_json = "//:package.json",
     yarn_lock = "//:yarn.lock",
+)
+
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+
+# https://www.npmjs.com/package/google-closure-templates is a broken package
+# Working with @iteriani to fix that - in the meantime fetch it from Maven
+maven_install(
+    artifacts = [
+        "com.google.template:soy:2019-10-08",
+    ],
+    repositories = [
+        "https://jcenter.bintray.com/",
+        "https://maven.google.com",
+        "https://repo1.maven.org/maven2",
+    ],
 )

--- a/examples/closure/closure-templates.patch
+++ b/examples/closure/closure-templates.patch
@@ -1,0 +1,37 @@
+diff --git a/shim.js b/shim.js
+index 9ab438ec..cd2681b6 100644
+--- a/shim.js
++++ b/shim.js
+@@ -4,6 +4,6 @@
+ 
+ goog.module('google3.third_party.javascript.incremental_dom.index');
+ 
+-const incrementaldom = goog.require('incrementaldom');
++const incrementaldom = /* @type {?} */(window.incrementaldom.types);//goog.require('incrementaldom');
+ 
+ exports = incrementaldom;
+diff --git a/soyutils_velog.js b/soyutils_velog.js
+index 3d63b079..792d91cf 100644
+--- a/soyutils_velog.js
++++ b/soyutils_velog.js
+@@ -28,7 +28,7 @@
+ goog.module('soy.velog');
+ goog.module.declareLegacyNamespace();
+ 
+-const Message = goog.require('jspb.Message');
++const Message = class {};//goog.require('jspb.Message');
+ const {assert} = goog.require('goog.asserts');
+ const {startsWith} = goog.require('goog.string');
+ 
+diff --git a/types.js b/types.js
+index ae1ff90b..e34e7211 100644
+--- a/types.js
++++ b/types.js
+@@ -4,6 +4,6 @@
+ 
+ goog.module('google3.third_party.javascript.incremental_dom.src.types');
+ 
+-const types = goog.require('incrementaldom.src.types');
++const types = /* @type {?} */(window.incrementaldom); //goog.require('incrementaldom.src.types');
+ 
+ exports = types;

--- a/examples/closure/index.soy
+++ b/examples/closure/index.soy
@@ -1,0 +1,5 @@
+{namespace demo}
+
+/** Example template. */
+{template .template}
+{/template}

--- a/examples/closure/package.json
+++ b/examples/closure/package.json
@@ -1,6 +1,9 @@
 {
     "private": true,
     "dependencies": {
-        "google-closure-compiler": "20190729.0.0"
-    }
+        "google-closure-compiler": "20190729.0.0",
+        "google-closure-library": "^20190929.0.0",
+        "google-protobuf": "^3.10.0"
+    },
+    "devDependencies": {}
 }

--- a/examples/closure/yarn.lock
+++ b/examples/closure/yarn.lock
@@ -105,6 +105,16 @@ google-closure-compiler@20190729.0.0:
     google-closure-compiler-osx "^20190729.0.0"
     google-closure-compiler-windows "^20190729.0.0"
 
+google-closure-library@^20190929.0.0:
+  version "20190929.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-library/-/google-closure-library-20190929.0.0.tgz#a323319d87ec10ebdef8135a0ef539eb07602c5d"
+  integrity sha512-ChL2te1OLBqI7z2FYohjapHxoo2Jd7KsFTBKoNv9TiOlWR+7zcS4z1RxeUgczWAW9sji3q5OhbbtG/fJlbs1lw==
+
+google-protobuf@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.10.0.tgz#f36171128090615049f9b0e42252b1a10a4bc534"
+  integrity sha512-d0cMO8TJ6xtB/WrVHCv5U81L2ulX+aCD58IljyAN6mHwdHHJ2jbcauX5glvivi3s3hx7EYEo7eUA9WftzamMnw==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"


### PR DESCRIPTION
This seems like a nice idea but fails with

```
bazel-out/k8-fastbuild/bin/index.soy.js:13 (JSC_MISSING_NAMESPACE_IMPORT)
Imported Closure namespace "goog.soy.data.SanitizedContentKind" never defined.
var SanitizedContentKind = goog.require('goog.soy.data.SanitizedContentKind');
^

bazel-out/k8-fastbuild/bin/index.soy.js:14 (JSC_MISSING_NAMESPACE_IMPORT)
Imported Closure namespace "google3.javascript.template.soy.api_idom" never defined.
var incrementaldomlib = goog.requireType('google3.javascript.template.soy.api_idom');
^
```

(note the `google3` in there...)
/cc @iteriani