### PR TITLE
chore: make defs.bzl error

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -12,77 +12,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Public API surface is re-exported here.
-
-Users should not load files under "/internal"
+"""No longer usable - you must load from index.bzl
 """
 
-load("//internal/common:check_bazel_version.bzl", _check_bazel_version = "check_bazel_version")
-load("//internal/common:check_version.bzl", "check_version")
-load("//internal/jasmine_node_test:jasmine_node_test.bzl", _jasmine_node_test = "jasmine_node_test")
-load(
-    "//internal/node:node.bzl",
-    _nodejs_binary = "nodejs_binary",
-    _nodejs_test = "nodejs_test",
-)
-load("//internal/node:node_repositories.bzl", _node_repositories = "node_repositories")
-load("//internal/node:npm_package_bin.bzl", _npm_bin = "npm_package_bin")
-load("//internal/npm_install:npm_install.bzl", _npm_install = "npm_install", _yarn_install = "yarn_install")
-load("//internal/npm_package:npm_package.bzl", _npm_package = "npm_package")
-load(":index.bzl", "VERSION")
+def _error(*args, **kwargs):
+    fail("""
+ERROR: defs.bzl has been removed from build_bazel_rules_nodejs
+    
+Please update your load statements to use index.bzl instead.
 
-check_bazel_version = _check_bazel_version
-nodejs_binary = _nodejs_binary
-nodejs_test = _nodejs_test
-node_repositories = _node_repositories
-jasmine_node_test = _jasmine_node_test
-npm_package = _npm_package
-npm_package_bin = _npm_bin
+If you depend on another ruleset that still depends on defs.bzl, you must update:
+
+http_archive(
+    name = "io_bazel_rules_sass",
+    sha256 = "617e444f47a1f3e25eb1b6f8e88a2451d54a2afdc7c50518861d9f706fc8baaa",
+    urls = [
+        "https://github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
+    ],
+    strip_prefix = "rules_sass-1.23.7",
+)
+
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "c9b298ec18157fc8ada915bb958dfd1c3d98ec247b5aca29efb1d222b5f9e7df",
+    # TODO: update to next release after 17 December 2019 that includes this commit
+    strip_prefix = "rules_docker-8c28cb910f1b93d0fa3289a11ec62ef1710172d5",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/8c28cb910f1b93d0fa3289a11ec62ef1710172d5.zip"],
+)
+""")
+
+check_bazel_version = _error
+nodejs_binary = _error
+nodejs_test = _error
+node_repositories = _error
+jasmine_node_test = _error
+npm_package = _error
+npm_package_bin = _error
 # ANY RULES ADDED HERE SHOULD BE DOCUMENTED, see index.for_docs.bzl
 
 def node_modules_filegroup(packages, patterns = [], **kwargs):
-    native.filegroup(
-        srcs = native.glob(["/".join([
-            "node_modules",
-            pkg,
-            "**",
-            ext,
-        ]) for pkg in packages for ext in [
-            "*.js",
-            "*.json",
-            "*.d.ts",
-        ]] + patterns),
-        **kwargs
-    )
+    _error()
 
 def npm_install(**kwargs):
-    # Just in case the user didn't install nodejs, do it now
-    _node_repositories()
-    _npm_install(**kwargs)
+    _error()
 
 def yarn_install(**kwargs):
-    # Just in case the user didn't install nodejs, do it now
-    _node_repositories()
-    _yarn_install(**kwargs)
+    _error()
 
 def check_rules_nodejs_version(minimum_version_string):
-    """
-    Verify that a minimum build_bazel_rules_nodejs is loaded a WORKSPACE.
-
-    This should be called from the `WORKSPACE` file so that the build fails as
-    early as possible. For example:
-
-    ```
-    # in WORKSPACE:
-    load("@build_bazel_rules_nodejs//:package.bzl", "check_rules_nodejs_version")
-    check_rules_nodejs_version("0.11.2")
-    ```
-
-    Args:
-      minimum_version_string: a string indicating the minimum version
-    """
-    if not check_version(VERSION, minimum_version_string):
-        fail("\nCurrent build_bazel_rules_nodejs version is {}, expected at least {}\n".format(
-            VERSION,
-            minimum_version_string,
-        ))
+    _error()

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ See [Built-ins]
 If you have installed the [rollup] package, you could write this rule:
 
 ```python
-load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 
 nodejs_binary(
     name = "rollup",
@@ -66,7 +66,7 @@ See the `examples/parcel` example.
 We can reference a path in the local workspace to run a program we write.
 
 ```python
-load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 
 nodejs_binary(
     name = "example",

--- a/examples/angular/WORKSPACE
+++ b/examples/angular/WORKSPACE
@@ -24,9 +24,12 @@ http_archive(
 # Fetch sass rules for compiling sass files
 http_archive(
     name = "io_bazel_rules_sass",
-    sha256 = "4f05239080175a3f4efa8982d2b7775892d656bb47e8cf56914d5f9441fb5ea6",
-    strip_prefix = "rules_sass-86ca977cf2a8ed481859f83a286e164d07335116",
-    url = "https://github.com/bazelbuild/rules_sass/archive/86ca977cf2a8ed481859f83a286e164d07335116.zip",
+    sha256 = "617e444f47a1f3e25eb1b6f8e88a2451d54a2afdc7c50518861d9f706fc8baaa",
+    strip_prefix = "rules_sass-1.23.7",
+    urls = [
+        "https://github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
+    ],
 )
 
 # Check the bazel version and download npm dependencies
@@ -109,9 +112,10 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "413bb1ec0895a8d3249a01edf24b82fd06af3c8633c9fb833a0cb1d4b234d46d",
-    strip_prefix = "rules_docker-0.12.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.12.0/rules_docker-v0.12.0.tar.gz"],
+    patches = ["//:rules_docker.patch"],
+    sha256 = "7d453450e1eb70e238eea6b31f4115607ec1200e91afea01c25f9804f37e39c8",
+    strip_prefix = "rules_docker-0.10.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.10.0.tar.gz"],
 )
 
 load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories = "repositories")

--- a/examples/angular/rules_docker.patch
+++ b/examples/angular/rules_docker.patch
@@ -1,0 +1,13 @@
+diff --git nodejs/image.bzl nodejs/image.bzl
+index a01ea3e..617aa06 100644
+--- nodejs/image.bzl
++++ nodejs/image.bzl
+@@ -17,7 +17,7 @@ The signature of this rule is compatible with nodejs_binary.
+ """
+ 
+ load("@bazel_skylib//lib:dicts.bzl", "dicts")
+-load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
++load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+ load(
+     "//container:container.bzl",
+     "container_pull",

--- a/examples/angular_view_engine/WORKSPACE
+++ b/examples/angular_view_engine/WORKSPACE
@@ -23,9 +23,12 @@ http_archive(
 # Fetch sass rules for compiling sass files
 http_archive(
     name = "io_bazel_rules_sass",
-    sha256 = "4f05239080175a3f4efa8982d2b7775892d656bb47e8cf56914d5f9441fb5ea6",
-    strip_prefix = "rules_sass-86ca977cf2a8ed481859f83a286e164d07335116",
-    url = "https://github.com/bazelbuild/rules_sass/archive/86ca977cf2a8ed481859f83a286e164d07335116.zip",
+    sha256 = "617e444f47a1f3e25eb1b6f8e88a2451d54a2afdc7c50518861d9f706fc8baaa",
+    strip_prefix = "rules_sass-1.23.7",
+    urls = [
+        "https://github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
+    ],
 )
 
 # Check the bazel version and download npm dependencies

--- a/examples/nestjs/WORKSPACE
+++ b/examples/nestjs/WORKSPACE
@@ -39,6 +39,7 @@ install_bazel_dependencies()
 
 http_archive(
     name = "io_bazel_rules_docker",
+    patches = ["//:rules_docker.patch"],
     sha256 = "7d453450e1eb70e238eea6b31f4115607ec1200e91afea01c25f9804f37e39c8",
     strip_prefix = "rules_docker-0.10.0",
     urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.10.0.tar.gz"],

--- a/examples/nestjs/rules_docker.patch
+++ b/examples/nestjs/rules_docker.patch
@@ -1,0 +1,13 @@
+diff --git nodejs/image.bzl nodejs/image.bzl
+index a01ea3e..617aa06 100644
+--- nodejs/image.bzl
++++ nodejs/image.bzl
+@@ -17,7 +17,7 @@ The signature of this rule is compatible with nodejs_binary.
+ """
+ 
+ load("@bazel_skylib//lib:dicts.bzl", "dicts")
+-load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
++load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+ load(
+     "//container:container.bzl",
+     "container_pull",


### PR DESCRIPTION
BREAKING CHANGE:
Users must now switch to loading from index.bzl

Fixes #1068

