### PR TITLE
test: reproduce issue https://github.com/bazelbuild/rules_nodejs/issues/1305 on buildkite

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -232,6 +232,17 @@ tasks:
     - "--platforms=@build_bazel_rules_nodejs//toolchains/node:linux_amd64"
     build_targets:
     - "//..."
+  macos_fake_rbe:
+    name: macos_fake_rbe
+    platform: macos
+    shell_commands:
+    # Reproduce https://github.com/bazelbuild/rules_nodejs/issues/1305
+    # TODO: switch to use real mac cross-platform RBE on CI when
+    #       https://github.com/bazelbuild/continuous-integration/pull/749
+    #       lands on bazelci master.
+    - echo 'build --platforms=@rbe_default//config:platform' >> .bazelrc
+    run_targets:
+    - "//internal/node/test:no_deps"
   windows:
     name: windows
     platform: windows


### PR DESCRIPTION
A bit hacky but the issue can be reproduced in run_targets in bazelci. There doesn’t seem to be a run_flags to pass —config=remote so I used shell_commands to set the --platform to linux in a new mac_fake_rbe job on buildkite. This sets up the same scenario as would be in cross-platform RBE where the build with --platform linux selected but the resulting nodejs_binary runnable target is run on osx.