### PR TITLE
fix: prevent dpulicate entries in owners files for global owners

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -44,7 +44,9 @@ def npm_package(**kwargs):
         **kwargs
     )
 
-_GLOBAL_OWNERS = "@alexeagle"
+_GLOBAL_OWNERS = [
+    "@alexeagle",
+]
 
 def codeowners(name = "OWNERS", no_parent = False, **kwargs):
     """Convenience macro to set some defaults
@@ -62,7 +64,7 @@ def codeowners(name = "OWNERS", no_parent = False, **kwargs):
 
     # Googlers: see http://go/owners#noparent
     if not no_parent:
-        teams.append(_GLOBAL_OWNERS)
+        teams += [owner for owner in _GLOBAL_OWNERS if owner not in teams]
 
     _codeowners(
         name = name,


### PR DESCRIPTION
this patch refactors the _GLOBAL_ODEOWNERS variable to a list,
additionally refactoring the logic when appending _GLOBAL_OWNERS to the
`teams` property of a `codeowners()` rule to ensure that users in
_GLOBAL_OWNERS are not duplicated in the generated output.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

I didn't see any tests for the current macro (other than the `golden_file_test()` to test the generated output from all usages of the rule/macro). There is no documentation update required.


## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

The `_GLOBAL_OWNERS` variable is a string, and is appended to each `teams` property in `codeowners()` rules (as long as `no_parent = False` [the default]).

This presents two problems:

1. A string is not extensible, when other global owners need to be added
2. The current implementation will result in duplicate entries if the user in `_GLOBAL_OWNERS` is ever added explicitly to a `codeowners()` rule.


## What is the new behavior?

1. `_GLOBAL_OWNERS` has been refactored to be a list
2. The implementation has been refactored to support adding global owners, but only if the owner is not currently in `teams`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

---

cc @alexeagle 
