### PR TITLE
rollup_bundle: add "hidden" as a valid sourcemap option

### DIFF
--- a/packages/rollup/src/rollup_bundle.bzl
+++ b/packages/rollup/src/rollup_bundle.bzl
@@ -148,7 +148,7 @@ Otherwise, the outputs are assumed to be a single file.
 Passed to the [`--sourcemap` option](https://github.com/rollup/rollup/blob/master/docs/999-big-list-of-options.md#outputsourcemap") in Rollup
 """,
         default = "inline",
-        values = ["inline", "true", "false"],
+        values = ["inline", "hidden", "true", "false"],
     ),
     "deps": attr.label_list(
         aspects = [module_mappings_aspect, node_modules_aspect],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- ~[ ] Tests for the changes have been added (for bug fixes / features)~
- ~[ ] Docs have been added / updated (for bug fixes / features)~

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

Per https://github.com/rollup/rollup/blob/master/docs/999-big-list-of-options.md#outputsourcemap, 'hidden' is supported for output.sourcemap, but not `rollup_bundle` rule.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No