### PR TITLE
feat: add ngJitMode to the terser config

### DIFF
--- a/internal/rollup/terser-wrapped.js
+++ b/internal/rollup/terser-wrapped.js
@@ -66,7 +66,7 @@ function runterser(inputFile, outputFile, sourceMapFile) {
     'compress': {
       'pure_getters': true,
       'passes': 3,
-      'global_defs': {'ngDevMode': false, 'ngI18nClosureMode': false},
+      'global_defs': {'ngDevMode': false, 'ngI18nClosureMode': false, 'ngJitMode': false},
       'keep_fnames': !debug,
       'reduce_funcs': !debug,
       'reduce_vars': !debug,

--- a/packages/terser/src/terser_config.default.json
+++ b/packages/terser/src/terser_config.default.json
@@ -1,6 +1,6 @@
 {
     "compress": {
-        "global_defs": {"ngDevMode": false, "ngI18nClosureMode": false},
+        "global_defs": {"ngDevMode": false, "ngI18nClosureMode": false, "ngJitMode": false},
         "keep_fnames": "bazel_no_debug",
         "passes": 3,
         "pure_getters": true,


### PR DESCRIPTION
rules_nodejs controls the terser configuration used to minify Angular code,
and as a result the terser configuration in this package has some default
values for Angular global variables. These defaults are used to tree-shake
away parts of the Angular application that are only used for development,
when bundling for production.

The ngJitMode flag is one such global variable. It controls whether parts
of AOT-compiled Angular code are retained to enable JIT code to link with
it at runtime. If these parts are left in the global bundle, they will break
tree-shaking of unusued components/directives/pipes/etc. Removing them is
thus an important optimization which allows the tree-shaker to effectively
process the rest of the application.

Unfortunately there are some cases where an application may wish to use
JIT in production, and in those cases ngJitMode should be left undefined
(or set to true). Because rules_nodejs does not allow user editing of the
terser configuration, this commit effectively makes the choice to support
optimization of AOT-only apps at the expense of supporting JIT production
builds. Such hybrid apps will not work with rules_nodejs' terser pass.