### PR TITLE
build: fix macos_fake_rbe job on bazelci

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,6 +18,7 @@ workspace(
 )
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("//:index.bzl", "BAZEL_VERSION")
 
 #
 # Check that build is using a minimum compatible bazel version
@@ -259,13 +260,12 @@ rbe_autoconfig(
 
 rbe_autoconfig(
     name = "rbe_default",
+    bazel_version = BAZEL_VERSION,
 )
 
 load("@build_bazel_integration_testing//tools:repositories.bzl", "bazel_binaries")
 
 # Depend on the Bazel binaries
-load("//:index.bzl", "BAZEL_VERSION")
-
 bazel_binaries(versions = [BAZEL_VERSION])
 
 #


### PR DESCRIPTION
Pins bazel version for rbe_autoconfig to BAZEL_VERISON. This fixes a bazelci failure on the macos_fake_rbe job that showed up when Bazel 1.2.0 was selected in rbe_default.

```
(02:39:31) DEBUG: /private/var/tmp/_bazel_buildkite/6597d199fda0844cb2301c486cfe87c0/external/bazel_toolchains/rules/rbe_repo.bzl:477:5: Bazel 1.2.0 is used in rbe_default.
--
  | (02:39:31) ERROR: An error occurred during the fetch of repository 'rbe_default':
  | Traceback (most recent call last):
  | File "/private/var/tmp/_bazel_buildkite/6597d199fda0844cb2301c486cfe87c0/external/bazel_toolchains/rules/rbe_repo.bzl", line 505
  | validate_host(ctx)
  | File "/private/var/tmp/_bazel_buildkite/6597d199fda0844cb2301c486cfe87c0/external/bazel_toolchains/rules/rbe_repo/util.bzl", line 147, in validate_host
  | fail(<1 more arguments>)
  | Not running on linux host, cannot run rbe_autoconfig.
  | (02:39:31) ERROR: While resolving toolchains for target //internal/node/test:no_deps: com.google.devtools.build.lib.packages.RepositoryFetchException: no such package '@rbe_default//config': Traceback (most recent call last):
  | File "/private/var/tmp/_bazel_buildkite/6597d199fda0844cb2301c486cfe87c0/external/bazel_toolchains/rules/rbe_repo.bzl", line 505
  | validate_host(ctx)
  | File "/private/var/tmp/_bazel_buildkite/6597d199fda0844cb2301c486cfe87c0/external/bazel_toolchains/rules/rbe_repo/util.bzl", line 147, in validate_host
  | fail(<1 more arguments>)
  | Not running on linux host, cannot run rbe_autoconfig.
```

We'll likely need to fix this again when updating to Bazel 1.2.0 but for now this works and it is correct to pin the version in `rbe_autoconfig` anyway.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

