### PR TITLE
fix(builtin): $(RULEDIR) npm_package_bin expansion should always be the root output directory

### DIFF
--- a/examples/angular/src/BUILD.bazel
+++ b/examples/angular/src/BUILD.bazel
@@ -154,7 +154,7 @@ babel(
         "--source-maps",
         "--presets=@babel/preset-env",
         "--out-dir",
-        "$(RULEDIR)",
+        "$(@D)",
     ],
     data = [
         ":bundle-es2015",

--- a/examples/angular_view_engine/src/BUILD.bazel
+++ b/examples/angular_view_engine/src/BUILD.bazel
@@ -154,7 +154,7 @@ babel(
         "--source-maps",
         "--presets=@babel/preset-env",
         "--out-dir",
-        "$(RULEDIR)",
+        "$(@D)",
     ],
     data = [
         ":bundle-es2015",

--- a/examples/webapp/differential_loading.bzl
+++ b/examples/webapp/differential_loading.bzl
@@ -38,7 +38,7 @@ def differential_loading(name, entry_point, srcs):
             "--config-file",
             "$(location es5.babelrc)",
             "--out-dir",
-            "$(RULEDIR)",
+            "$(@D)",
         ],
     )
 

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -166,7 +166,7 @@ npm_package_bin(
     name = "dir_output",
     args = [
         "--output-dir",
-        "$(RULEDIR)",
+        "$(@D)",
         "$(location terser_input.js)",
     ],
     data = ["terser_input.js"],


### PR DESCRIPTION
To match genrule behavior described here: https://docs.bazel.build/versions/master/be/make-variables.html#predefined_genrule_variables:
```
RULEDIR: The output directory of the rule, that is, the directory corresponding to the name of the package containing the rule under the genfiles or the bin tree.
```

Also added $(@D) to be equal to the path of the directory artifact when output_dir=True.
