### PR TITLE
fix(builtin): additional_root_paths in pkg_web should also include paths in genfiles and bin dirs

### DIFF
--- a/internal/pkg_web/pkg_web.bzl
+++ b/internal/pkg_web/pkg_web.bzl
@@ -63,6 +63,13 @@ def move_files(output_name, files, action_factory, assembler, root_paths):
 
 def additional_root_paths(ctx):
     return ctx.attr.additional_root_paths + [
+        # also add additional_root_paths variants from genfiles dir and bin dir
+        "/".join([ctx.genfiles_dir.path, p])
+        for p in ctx.attr.additional_root_paths
+    ] + [
+        "/".join([ctx.bin_dir.path, p])
+        for p in ctx.attr.additional_root_paths
+    ] + [
         # package path is the root, including in bin/gen
         ctx.label.package,
         "/".join([ctx.bin_dir.path, ctx.label.package]),


### PR DESCRIPTION
This allows generating an index.html file into a different folder in the output tree (so that it doesn't collide within put index.html file) and then re-mapping
the output in pkg_web back to /index.html. ts_devserver already supports this via additional_root_paths so this brings the same functionality to pkg_web.

It is useful for the case where you have a single input index.html file and you inject scripts tags and output to a dir such as _/index.html and consume the output in both ts_devserver & pkg_web. For example,

```
html_insert_assets(
    name = "inject_scripts",
    # We can't output "src/index.html" since that collides with the input file.
    # We output "src/_/index.html" instead ond remap in ts_devserver & pkg_web
    # using additional_root_paths.
    outs = ["_/index.html"],
    args = [
        "--html",
        "$(location :index.html)",
        "--out",
        "$@",
        "--assets",
        "$(location @npm//:node_modules/zone.js/dist/zone.min.js)",
        # Bundle path for both prodapp & devserver
        "bundle.min.js",
    ],
    data = [
        ":index.html",
        "@npm//:node_modules/zone.js/dist/zone.min.js",
    ],
)

ts_devserver(
    name = "devserver",
    # Remap "src/_/index.html" => "index.html"
    additional_root_paths = ["src/_"],
    entry_module = "bazel_integration_test/src/main",
    scripts = [
        ":rxjs_umd_modules",
    ],
    # Use the same bundle serving path as prodserver so that we can share
    # an index.html file.
    serving_path = "/bundle.min.js",
    static_files = [
        ":inject_scripts",
        "@npm//:node_modules/zone.js/dist/zone.min.js",
    ],
    deps = ["//src"],
)

rollup_bundle(
    name = "bundle",
    config_file = "rollup.config.js",
    entry_point = ":main.ts",
    deps = [
        "//src",
        "@npm//rollup-plugin-commonjs",
        "@npm//rollup-plugin-node-resolve",
    ],
)

terser_minified(
    name = "bundle.min",
    src = ":bundle",
)

pkg_web(
    name = "prodapp",
    # Remap "src/_/index.html" => "index.html"
    additional_root_paths = ["src/_"],
    srcs = [
        ":inject_scripts",
        "@npm//:node_modules/zone.js/dist/zone.min.js",
        ":bundle.min",
    ],
)

http_server(
    name = "prodserver",
    data = [":prodapp"],
    templated_args = ["src/prodapp"],
)
```
