### PR TITLE
fix: support realpath.native and fix crash in mkdirp

### DIFF
--- a/packages/node-patches/BUILD.bazel
+++ b/packages/node-patches/BUILD.bazel
@@ -21,11 +21,11 @@ package(default_visibility = ["//:__subpackages__"])
 sources = glob([
     "*.ts",
     "src/*.ts",
-])
+],exclude=["**/*.d.ts"])
 
 js = [s.replace(".ts", ".js") for s in sources]
 
-tests = glob(["test/**/*.ts"])
+tests = glob(["test/**/*.ts"],exclude=["**/*.d.ts"])
 
 test_js = [t.replace(".ts", ".js") for t in tests]
 

--- a/packages/node-patches/BUILD.bazel
+++ b/packages/node-patches/BUILD.bazel
@@ -18,14 +18,20 @@ load("@npm_node_patches//typescript:index.bzl", "tsc")
 
 package(default_visibility = ["//:__subpackages__"])
 
-sources = glob([
-    "*.ts",
-    "src/*.ts",
-],exclude=["**/*.d.ts"])
+sources = glob(
+    [
+        "*.ts",
+        "src/*.ts",
+    ],
+    exclude = ["**/*.d.ts"],
+)
 
 js = [s.replace(".ts", ".js") for s in sources]
 
-tests = glob(["test/**/*.ts"],exclude=["**/*.d.ts"])
+tests = glob(
+    ["test/**/*.ts"],
+    exclude = ["**/*.d.ts"],
+)
 
 test_js = [t.replace(".ts", ".js") for t in tests]
 

--- a/packages/node-patches/src/subprocess.ts
+++ b/packages/node-patches/src/subprocess.ts
@@ -11,7 +11,14 @@ export const patcher = (requireScriptName: string, binDir?: string) => {
 
   if (!process.env.NP_PATCHED_NODEJS) {
     // TODO: WINDOWS.
-    fs.mkdirSync(nodeDir, {recursive: true});
+    try {
+      fs.mkdirSync(nodeDir, {recursive: true});
+    } catch (e) {
+      // with node versions that don't have recursive mkdir this may throw an error.
+      if (e.code !== 'EEXIST') {
+        throw e;
+      }
+    }
     if (process.platform == 'win32') {
       fs.writeFileSync(path.join(nodeDir, 'node.bat'), `@if not defined DEBUG_HELPER @ECHO OFF
 set NP_PATCHED_NODEJS=${nodeDir}


### PR DESCRIPTION
fixes #1401 

this should fix jest :crossed_fingers: the example repro still fails but i think its because of a legitimate reason.