### PR TITLE
Clarification on how rollup_bundle works with ts_library inputs

### DIFF
--- a/packages/rollup/src/rollup_bundle.bzl
+++ b/packages/rollup/src/rollup_bundle.bzl
@@ -98,6 +98,27 @@ rollup_bundle(
     }
 )
 ```
+
+If `rollup_bundle` is used on a `ts_library`, the `rollup_bundle` rule handles selecting the correct outputs from `ts_library`.
+In this case, `entry_point` can be specified as the `.ts` file and `rollup_bundle` will handle the mapping to the `.mjs` output file.
+
+For example:
+
+```python
+ts_library(
+    name = "foo",
+    srcs = [
+        "foo.ts",
+        "index.ts",
+    ],
+)
+
+rollup_bundle(
+    name = "bundle",
+    deps = [ "foo" ],
+    entry_point = "index.ts",
+)
+```
 """,
         allow_single_file = True,
     ),


### PR DESCRIPTION
Added clarification from https://github.com/bazelbuild/rules_nodejs/issues/1416 to the documentation.