### PR TITLE
Realpath native sync

### DIFF
--- a/internal/node/bazel_require_script.js
+++ b/internal/node/bazel_require_script.js
@@ -232,7 +232,7 @@ exports.patcher = (fs = fs$1, root) => {
         return str;
     };
     // tslint:disable-next-line:no-any
-    fs.realpathSync = (...args) => {
+    fs.realpathSync.native = (...args) => {
         const str = origRealpathSyncNative(...args);
         if (isEscape(str, args[0])) {
             return path.resolve(args[0]);

--- a/packages/node-patches/src/fs.ts
+++ b/packages/node-patches/src/fs.ts
@@ -212,7 +212,7 @@ export const patcher = (fs: any = _fs, root: string) => {
   };
 
   // tslint:disable-next-line:no-any
-  fs.realpathSync = (...args: any[]) => {
+  fs.realpathSync.native = (...args: any[]) => {
     const str = origRealpathSyncNative(...args);
     if (isEscape(str, args[0])) {
       return path.resolve(args[0]);

--- a/packages/node-patches/test/fs/realpath.ts
+++ b/packages/node-patches/test/fs/realpath.ts
@@ -48,7 +48,16 @@ describe('testing realpath', () => {
               'SYNC: should resolve the symlink the same because its within root');
 
           assert.deepStrictEqual(
+              patchedFs.realpathSync.native(linkPath), path.join(fixturesDir, 'b', 'file'),
+              'SYNC.native: should resolve the symlink the same because its within root');
+
+          assert.deepStrictEqual(
               await util.promisify(patchedFs.realpath)(linkPath),
+              path.join(fixturesDir, 'b', 'file'),
+              'CB: should resolve the symlink the same because its within root');
+
+          assert.deepStrictEqual(
+              await util.promisify(patchedFs.realpath.native)(linkPath),
               path.join(fixturesDir, 'b', 'file'),
               'CB: should resolve the symlink the same because its within root');
 


### PR DESCRIPTION
fixes missing realpathSync.native. fs.realpathSync was duplicated.