### PR TITLE
fix(bazel): no longer always include the version_file in inputs

### DIFF
--- a/packages/rollup/src/rollup_bundle.bzl
+++ b/packages/rollup/src/rollup_bundle.bzl
@@ -150,6 +150,10 @@ Passed to the [`--sourcemap` option](https://github.com/rollup/rollup/blob/maste
         default = "inline",
         values = ["inline", "hidden", "true", "false"],
     ),
+    "stamp": attr.bool(
+        default = False,
+        doc = """Whether stamping is requested for the rollup_bundle.""",
+    ),
     "deps": attr.label_list(
         aspects = [module_mappings_aspect, node_modules_aspect],
         doc = """Other libraries that are required by the code, or by the rollup.config.js""",
@@ -282,14 +286,14 @@ def _rollup_bundle(ctx):
         template = ctx.file.config_file,
         output = config,
         substitutions = {
-            "bazel_stamp_file": "\"%s\"" % ctx.version_file.path if ctx.version_file else "undefined",
+            "bazel_stamp_file": "\"%s\"" % ctx.version_file.path if ctx.attr.stamp else "undefined",
         },
     )
 
     args.add_all(["--config", config.path])
     inputs.append(config)
 
-    if ctx.version_file:
+    if ctx.attr.stamp:
         inputs.append(ctx.version_file)
 
     # Prevent rollup's module resolver from hopping outside Bazel's sandbox


### PR DESCRIPTION
While bazel properly handles not causing rebuilds based on version_file locally,
if the version_file is included in the inputs it prevents caching from ever
working when caching using remote cache or disk cache.

Instead of determining if stamping should occur based on the presence of the
version_file, we should choose to stamp based on an attribute stamp.