### PR TITLE
refactor(builtin): add `args` to yarn_install & npm_install

### DIFF
--- a/e2e/packages/WORKSPACE
+++ b/e2e/packages/WORKSPACE
@@ -17,16 +17,16 @@ node_repositories()
 
 npm_install(
     name = "e2e_packages_npm_install",
+    args = ["--production"],
     data = ["//:postinstall.js"],
     package_json = "//:npm1/package.json",
     package_lock_json = "//:npm1/package-lock.json",
-    # Just here as a smoke test for this attribute
-    prod_only = True,
     symlink_node_modules = False,
 )
 
 npm_install(
     name = "e2e_packages_npm_install_duplicate_for_determinism_testing",
+    args = ["--production"],
     data = ["//:postinstall.js"],
     package_json = "//:npm2/package.json",
     package_lock_json = "//:npm2/package-lock.json",
@@ -35,6 +35,7 @@ npm_install(
 
 yarn_install(
     name = "e2e_packages_yarn_install",
+    args = ["--prod"],
     data = ["//:postinstall.js"],
     package_json = "//:yarn1/package.json",
     symlink_node_modules = False,
@@ -43,6 +44,7 @@ yarn_install(
 
 yarn_install(
     name = "e2e_packages_yarn_install_duplicate_for_determinism_testing",
+    args = ["--prod"],
     data = ["//:postinstall.js"],
     package_json = "//:yarn2/package.json",
     symlink_node_modules = False,

--- a/e2e/packages/npm1/package.json
+++ b/e2e/packages/npm1/package.json
@@ -4,6 +4,9 @@
     "jsesc": "~1.2.0",
     "jasmine": "2.8.0"
   },
+  "devDependencies": {
+    "tmp": "0.1.0"
+  },
   "scripts": {
     "postinstall": "node ./postinstall.js"
   }

--- a/e2e/packages/npm2/package.json
+++ b/e2e/packages/npm2/package.json
@@ -4,6 +4,9 @@
     "jsesc": "~1.2.0",
     "jasmine": "2.8.0"
   },
+  "devDependencies": {
+    "tmp": "0.1.0"
+  },
   "scripts": {
     "postinstall": "node ./postinstall.js"
   }

--- a/e2e/packages/npm_determinism.spec.js
+++ b/e2e/packages/npm_determinism.spec.js
@@ -8,6 +8,13 @@ const packageJsonPath2 = packageJsonPath.replace(
     '/e2e_packages_npm_install_duplicate_for_determinism_testing/', '/e2e_packages_npm_install/');
 const packageJson2 = JSON.parse(fs.readFileSync(packageJsonPath2));
 
+try {
+  require.resolve('tmp');
+  console.error(
+      'expected tmp to not be installed by npm as --production was passed via args in npm_install');
+  process.exitCode = 1;
+} catch (_) {
+}
 
 if (packageJsonPath === packageJsonPath2) {
   console.error('expected different json paths');

--- a/e2e/packages/yarn1/package.json
+++ b/e2e/packages/yarn1/package.json
@@ -4,6 +4,9 @@
     "jsesc": "~1.2.0",
     "jasmine": "2.8.0"
   },
+  "devDependencies": {
+    "tmp": "0.1.0"
+  },
   "scripts": {
     "postinstall": "node ./postinstall.js"
   }

--- a/e2e/packages/yarn2/package.json
+++ b/e2e/packages/yarn2/package.json
@@ -4,6 +4,9 @@
     "jsesc": "~1.2.0",
     "jasmine": "2.8.0"
   },
+  "devDependencies": {
+    "tmp": "0.1.0"
+  },
   "scripts": {
     "postinstall": "node ./postinstall.js"
   }

--- a/e2e/packages/yarn_determinism.spec.js
+++ b/e2e/packages/yarn_determinism.spec.js
@@ -8,6 +8,14 @@ const packageJsonPath2 = packageJsonPath.replace(
     '/e2e_packages_yarn_install_duplicate_for_determinism_testing/', '/e2e_packages_yarn_install/');
 const packageJson2 = JSON.parse(fs.readFileSync(packageJsonPath2));
 
+try {
+  require.resolve('tmp');
+  console.error(
+      'expected tmp to not be installed by yarn as --prod was passed via args in yarn_install');
+  process.exitCode = 1;
+} catch (_) {
+}
+
 if (packageJsonPath === packageJsonPath2) {
   console.error('expected different json paths');
   process.exitCode = 1;


### PR DESCRIPTION
BREAKING CHANGE:
`args` in yarn_install and npm_install can be used to pass arbitrary arguments so we removed the following attributes:
* prod_only from yarn_install and npm_install; should be replaced by args = ["--prod"] and args = ["--production"] respectively
* frozen_lockfile from yarn_install; should be replaced by args = ["--frozen-lockfile"]
* network_timeout from yanr_install; should be replaced by args = ["--network_timeout", "<time in ms>"]
