### PR TITLE
build: pin bazel on bazelci to 1.2.1

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,4 +1,5 @@
 ---
+bazel: 1.2.1
 tasks:
   ubuntu1604:
     name: ubuntu1604


### PR DESCRIPTION
master broke on the bump to 2.0.0 so needs to be fixed before we can upgrade
