### PR TITLE
refactor: remove templated_args_file from nodejs_binary & nodejs_test

### DIFF
--- a/index.bzl
+++ b/index.bzl
@@ -20,6 +20,7 @@ Users should not load files under "/internal"
 load("//internal/common:check_bazel_version.bzl", _check_bazel_version = "check_bazel_version")
 load("//internal/common:check_version.bzl", "check_version")
 load("//internal/common:copy_to_bin.bzl", _copy_to_bin = "copy_to_bin")
+load("//internal/common:params_file.bzl", _params_file = "params_file")
 load(
     "//internal/node:node.bzl",
     _nodejs_binary = "nodejs_binary",
@@ -39,6 +40,7 @@ pkg_npm = _pkg_npm
 npm_package_bin = _npm_bin
 pkg_web = _pkg_web
 copy_to_bin = _copy_to_bin
+params_file = _params_file
 # ANY RULES ADDED HERE SHOULD BE DOCUMENTED, see index.for_docs.bzl
 
 # Allows us to avoid a transitive dependency on bazel_skylib from leaking to users

--- a/index.for_docs.bzl
+++ b/index.for_docs.bzl
@@ -18,6 +18,7 @@ This differs from :index.bzl because we don't have wrapping macros that hide the
 
 load("//internal/common:check_bazel_version.bzl", _check_bazel_version = "check_bazel_version")
 load("//internal/common:copy_to_bin.bzl", _copy_to_bin = "copy_to_bin")
+load("//internal/common:params_file.bzl", _params_file = "params_file")
 load("//internal/node:node.bzl", _nodejs_binary = "nodejs_binary", _nodejs_test = "nodejs_test")
 load("//internal/node:node_repositories.bzl", _node_repositories = "node_repositories_rule")
 load("//internal/node:npm_package_bin.bzl", _npm_bin = "npm_package_bin")
@@ -27,6 +28,7 @@ load("//internal/pkg_web:pkg_web.bzl", _pkg_web = "pkg_web")
 
 check_bazel_version = _check_bazel_version
 copy_to_bin = _copy_to_bin
+params_file = _params_file
 nodejs_binary = _nodejs_binary
 nodejs_test = _nodejs_test
 node_repositories = _node_repositories

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -25,14 +25,9 @@ filegroup(
 
 nodejs_test(
     name = "package_json_test",
-    data = [
-        "check_package_json.js",
-        "//:package.json",
-    ],
+    data = ["//:package.json"],
     entry_point = ":check_package_json.js",
     templated_args = [BAZEL_VERSION],
-    # Not necessary here, just a regression test for #1043
-    templated_args_file = "package_json_test.params",
 )
 
 # Detect if the build is running under --stamp

--- a/internal/common/params_file.bzl
+++ b/internal/common/params_file.bzl
@@ -1,0 +1,98 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generates a params file from a list of arguments.
+"""
+
+load("//internal/common:expand_into_runfiles.bzl", "expand_location_into_runfiles")
+
+_DOC = """Generates a params file from a list of arguments."""
+
+_ATTRS = {
+    "out": attr.output(
+        doc = """Path of the output file, relative to this package.""",
+        mandatory = True,
+    ),
+    "args": attr.string_list(
+        doc = """Arguments to concatenate into a params file.
+Subject to $(location) substitutions""",
+    ),
+    "data": attr.label_list(
+        doc = """Data for $(location) expansions in args.""",
+        allow_files = True,
+    ),
+    "is_windows": attr.bool(mandatory = True),
+    "newline": attr.string(
+        doc = """one of ["auto", "unix", "windows"]: line endings to use. "auto"
+for platform-determined, "unix" for LF, and "windows" for CRLF.""",
+        values = ["unix", "windows", "auto"],
+        default = "auto",
+    ),
+}
+
+def _impl(ctx):
+    if ctx.attr.newline == "auto":
+        newline = "\r\n" if ctx.attr.is_windows else "\n"
+    elif ctx.attr.newline == "windows":
+        newline = "\r\n"
+    else:
+        newline = "\n"
+
+    # ctx.actions.write creates a FileWriteAction which uses UTF-8 encoding.
+    ctx.actions.write(
+        output = ctx.outputs.out,
+        content = newline.join([expand_location_into_runfiles(ctx, a, ctx.attr.data) for a in ctx.attr.args]),
+        is_executable = False,
+    )
+    files = depset(direct = [ctx.outputs.out])
+    runfiles = ctx.runfiles(files = [ctx.outputs.out])
+    return [DefaultInfo(files = files, runfiles = runfiles)]
+
+_params_file = rule(
+    implementation = _impl,
+    provides = [DefaultInfo],
+    attrs = _ATTRS,
+    doc = _DOC,
+)
+
+def params_file(
+        name,
+        out,
+        args = [],
+        newline = "auto",
+        **kwargs):
+    """Generates a UTF-8 encoded params file from a list of arguments.
+
+    Handles $(location) expansions for arguments.
+
+    Args:
+      name: Name of the rule.
+      out: Path of the output file, relative to this package.
+      args: AArguments to concatenate into a params file.
+          Subject to $(location) substitutions
+      newline: one of ["auto", "unix", "windows"]: line endings to use. "auto"
+          for platform-determined, "unix" for LF, and "windows" for CRLF.
+      **kwargs: further keyword arguments, e.g. <code>visibility</code>
+    """
+    _params_file(
+        name = name,
+        out = out,
+        args = args,
+        newline = newline or "auto",
+        is_windows = select({
+            "@bazel_tools//src/conditions:host_windows": True,
+            "//conditions:default": False,
+        }),
+        **kwargs
+    )

--- a/internal/common/test/BUILD.bazel
+++ b/internal/common/test/BUILD.bazel
@@ -1,4 +1,6 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
 load("//internal/common:copy_to_bin.bzl", "copy_to_bin")
+load("//internal/common:params_file.bzl", "params_file")
 
 licenses(["notice"])
 
@@ -17,4 +19,32 @@ sh_test(
 copy_to_bin(
     name = "a",
     srcs = ["foo/bar/a.txt"],
+)
+
+filegroup(
+    name = "locations_in",
+    srcs = [
+        "check_params_file.js",
+        "//:package.json",
+    ],
+)
+
+params_file(
+    name = "params_file",
+    out = ":params_file.out",
+    args = [
+        "$(location //:package.json)",
+        "$(locations :locations_in)",
+    ],
+    data = [
+        ":locations_in",
+        "//:package.json",
+    ],
+)
+
+nodejs_test(
+    name = "params_file_test",
+    data = [":params_file.out"],
+    entry_point = ":check_params_file.js",
+    templated_args = ["$(location :params_file.out)"],
 )

--- a/internal/common/test/check_params_file.js
+++ b/internal/common/test/check_params_file.js
@@ -18,16 +18,19 @@
 
 const args = process.argv.slice(2);
 
-const BAZEL_VERSION = args[0];
+// The arguments are passed via a params file
+const [a1, a2] = require('fs').readFileSync(require.resolve(args[0]), 'utf-8').split(/\r?\n/);
 
-const packageJson = require('build_bazel_rules_nodejs/package.json');
+const a1_exp = 'build_bazel_rules_nodejs/package.json';
+const a2_exp =
+    'build_bazel_rules_nodejs/package.json build_bazel_rules_nodejs/internal/common/test/check_params_file.js';
 
-// Test that the BAZEL_VERSION defined in //:index.bzl is in sync with the @bazel/bazel
-// version in //:pacakge.json
-if (packageJson['devDependencies']['@bazel/bazel'] !== `^${BAZEL_VERSION}`) {
-  console.error(`package.json @bazel/bazel '${
-      packageJson['devDependencies']
-                 ['@bazel/bazel']}' does not match ^BAZEL_VERSION in //:index.bzl '^${
-      BAZEL_VERSION}'`);
-  process.exitCode = 1;
+if (a1 !== a1_exp) {
+  console.error(`expected first argument in params file to be '${a1_exp}'`)
+  process.exit(1);
+}
+
+if (a2 !== a2_exp) {
+  console.error(`expected second argument in params file to be '${a2_exp}'`)
+  process.exit(1);
 }


### PR DESCRIPTION
*Branched from https://github.com/bazelbuild/rules_nodejs/pull/1488 which should land first*

@mattem This should still work for your use case and it provides a nice example of how to generate and pass in your own custom params file. See usage example below.

BREAKING CHANGE:
`templated_args_file` removed from nodejs_binary, nodejs_test & jasmine_node_test. This was a separation of concerns and complicated node.bzl more than necessary while also being rigid in how the params file is formatted. It is more flexible to expose this functionality as another simple rule named params_file.

To match standard $(location) and $(locations) expansion, `params_file` args location expansions are also in the standard short_path form (this differs from the old templated_args behavior which was not Bazel idiomatic)

Usage example:

```
load("@build_bazel_rules_nodejs//:index.bzl", "params_file", "nodejs_binary")

params_file(
    name = "params_file",
    args = [
        "--some_param",
        "$(location //path/to/some:file)",
        "--some_other_param",
        "$(location //path/to/some/other:file)",
    ],
    data = [
        "//path/to/some:file",
        "//path/to/some/other:file",
    ],
)

nodejs_binary(
    name = "my_binary",
    data = [":params_file"],
    entry_point = ":my_binary.js",
    templated_args = ["$(location :params_file)"],
)
```
