### PR TITLE
Nodejs binary module mappings

### DIFF
--- a/internal/common/module_mappings.bzl
+++ b/internal/common/module_mappings.bzl
@@ -80,7 +80,7 @@ def get_module_mappings(label, attrs, srcs = [], workspace_name = None, mappings
             mr = "%s/%s" % (workspace_name, mr)
         elif label.workspace_root:
             mr = "%s/%s" % (label.workspace_root, mr)
-        if attrs.module_root and attrs.module_root != ".":
+        if hasattr(attrs, "module_root") and attrs.module_root and attrs.module_root != ".":
             if attrs.module_root.endswith(".ts"):
                 if workspace_name:
                     # workspace_name is set only when doing module mapping for runtime.

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -25,7 +25,7 @@ load("//internal/common:expand_into_runfiles.bzl", "expand_location_into_runfile
 load("//internal/common:module_mappings.bzl", "module_mappings_runtime_aspect")
 load("//internal/common:path_utils.bzl", "strip_external")
 load("//internal/common:windows_utils.bzl", "create_windows_native_launcher_script", "is_windows")
-load("//internal/linker:link_node_modules.bzl", "write_node_modules_manifest")
+load("//internal/linker:link_node_modules.bzl", "module_mappings_aspect", "write_node_modules_manifest")
 load("//internal/node:node_repositories.bzl", "BUILT_IN_NODE_PLATFORMS")
 
 def _trim_package_node_modules(package_name):
@@ -282,7 +282,7 @@ _NODEJS_EXECUTABLE_ATTRS = {
     "data": attr.label_list(
         doc = """Runtime dependencies which may be loaded during execution.""",
         allow_files = True,
-        aspects = [node_modules_aspect, module_mappings_runtime_aspect],
+        aspects = [node_modules_aspect, module_mappings_aspect, module_mappings_runtime_aspect],
     ),
     "default_env_vars": attr.string_list(
         doc = """Default environment variables that are added to `configuration_env_vars`.

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -56,12 +56,10 @@ nodejs_binary(
     entry_point = ":entry_file",
 )
 
-# Coverage for issue https://github.com/bazelbuild/rules_nodejs/issues/834
-# where module_name is equal to the workspace naem
 js_library(
     name = "module_name_lib",
     srcs = ["module-name.js"],
-    module_name = "build_bazel_rules_nodejs",
+    module_name = "build_bazel_rules_nodejs/internal/node/test",
 )
 
 nodejs_binary(


### PR DESCRIPTION
* fix(builtin): nodejs_binary collects module_mappings for linker

Module name cannot be equal to the workspace name with the linker so this change removes the regression test for 834. This was a corner case and was already broken with the 1.0 for npm_package_bin so this fix makes nodejs_binary consistent with npm_package_bin and the new desired behavior for 1.0.

* fix(builtin): legacy module_mappings_runtime_aspect handles dep with module_name but no module_root




## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

