### PR TITLE
refactor(builtin): use built-in TEST_TARGET instead of custom BAZEL_TARGET

### DIFF
--- a/internal/golden_file_test/bin.js
+++ b/internal/golden_file_test/bin.js
@@ -28,7 +28,7 @@ ${prettyDiff}
 Update the golden file:
 
             bazel run ${debug ? '--compilation_mode=dbg ' : ''}${
-          process.env['BAZEL_TARGET'].replace(/_bin$/, '')}.accept
+          process.env['TEST_TARGET'].replace(/_bin$/, '')}.accept
 `);
     } else {
       throw new Error('unknown mode', mode);

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -169,7 +169,7 @@ def _nodejs_binary_impl(ctx):
 
     script_path = _to_manifest_path(ctx, ctx.outputs.loader)
 
-    env_vars = "export BAZEL_TARGET=%s\n" % ctx.label
+    env_vars = ""
     for k in ctx.attr.configuration_env_vars + ctx.attr.default_env_vars:
         if k in ctx.var.keys():
             env_vars += "export %s=\"%s\"\n" % (k, ctx.var[k])

--- a/internal/npm_install/test/check.js
+++ b/internal/npm_install/test/check.js
@@ -40,7 +40,7 @@ ${prettyDiff}
 
 Update the golden file:
 
-      bazel run ${process.env['BAZEL_TARGET']}.accept`);
+      bazel run ${process.env['TEST_TARGET']}.accept`);
     }
   }
 }

--- a/packages/jasmine/src/jasmine_runner.js
+++ b/packages/jasmine/src/jasmine_runner.js
@@ -191,7 +191,7 @@ function main(args) {
     // Special case!
     // To allow us to test sharding, always run the specs in the order they are declared
     if (process.env['TEST_WORKSPACE'] === 'build_bazel_rules_nodejs' &&
-        process.env['BAZEL_TARGET'] === '//packages/jasmine/test:sharding_test') {
+        process.env['TEST_TARGET'] === '//packages/jasmine/test:sharding_test') {
       jrunner.randomizeTests(false);
     }
   }


### PR DESCRIPTION
BAZEL_TARGET is not a documented env variable but if a user is relying on it they should be using TEST_TARGET instead.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

