### PR TITLE
fix(builtin): set root of node symlink patches to execroot/my_wksp

### DIFF
--- a/internal/node/node_launcher.sh
+++ b/internal/node/node_launcher.sh
@@ -203,9 +203,10 @@ if [[ -n "$MODULES_MANIFEST" ]]; then
   "${node}" "${link_modules_script}" "${MODULES_MANIFEST}"
 fi
 
-# Tell the bazel_require_script that programs should not escape the execroot
-# Bazel always sets the PWD to execroot/my_wksp so we go up one directory.
-export BAZEL_PATCH_ROOT=$(dirname $PWD)
+# Tell the bazel_require_script that programs should not escape execroot/my_wksp.
+# Bazel always sets the PWD to execroot/my_wksp so we want to keep programs
+# within that root.
+export BAZEL_PATCH_ROOT=${PWD}
 
 # The EXPECTED_EXIT_CODE lets us write bazel tests which assert that
 # a binary fails to run. Otherwise any failure would make such a test


### PR DESCRIPTION
Alternative fix to #1505  for run & test.

This will prevent symlinks to escaping to `.../runfiles/npm/node_modules`  as it sets the symlink node patch root to `.../runfiles/repo`. `--nolegacy_external_runfiles` may still be needed to so that there is no `.../runfiles/repo/external/npm/node_modules` to escape to.

For the build case, this will not prevent escaping to `.../execroot/repo/external/npm/node_modules` as the root is set to `.../execroot/repo`.
