### PR TITLE
build: update to rules_sass 1.24.0

### DIFF
--- a/examples/angular/WORKSPACE
+++ b/examples/angular/WORKSPACE
@@ -24,11 +24,11 @@ http_archive(
 # Fetch sass rules for compiling sass files
 http_archive(
     name = "io_bazel_rules_sass",
-    sha256 = "617e444f47a1f3e25eb1b6f8e88a2451d54a2afdc7c50518861d9f706fc8baaa",
-    strip_prefix = "rules_sass-1.23.7",
+    sha256 = "77e241148f26d5dbb98f96fe0029d8f221c6cb75edbb83e781e08ac7f5322c5f",
+    strip_prefix = "rules_sass-1.24.0",
     urls = [
-        "https://github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
+        "https://github.com/bazelbuild/rules_sass/archive/1.24.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.24.0.zip",
     ],
 )
 

--- a/examples/angular_view_engine/WORKSPACE
+++ b/examples/angular_view_engine/WORKSPACE
@@ -23,11 +23,11 @@ http_archive(
 # Fetch sass rules for compiling sass files
 http_archive(
     name = "io_bazel_rules_sass",
-    sha256 = "617e444f47a1f3e25eb1b6f8e88a2451d54a2afdc7c50518861d9f706fc8baaa",
-    strip_prefix = "rules_sass-1.23.7",
+    sha256 = "77e241148f26d5dbb98f96fe0029d8f221c6cb75edbb83e781e08ac7f5322c5f",
+    strip_prefix = "rules_sass-1.24.0",
     urls = [
-        "https://github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
+        "https://github.com/bazelbuild/rules_sass/archive/1.24.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.24.0.zip",
     ],
 )
 

--- a/package.bzl
+++ b/package.bzl
@@ -30,12 +30,12 @@ def rules_nodejs_dev_dependencies():
     # Dependencies for generating documentation
     http_archive(
         name = "io_bazel_rules_sass",
-        sha256 = "617e444f47a1f3e25eb1b6f8e88a2451d54a2afdc7c50518861d9f706fc8baaa",
+        sha256 = "77e241148f26d5dbb98f96fe0029d8f221c6cb75edbb83e781e08ac7f5322c5f",
+        strip_prefix = "rules_sass-1.24.0",
         urls = [
-            "https://github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.23.7.zip",
+            "https://github.com/bazelbuild/rules_sass/archive/1.24.0.zip",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.24.0.zip",
         ],
-        strip_prefix = "rules_sass-1.23.7",
     )
 
     # Needed for com_google_protobuf


### PR DESCRIPTION
Allows for the removal of install_source_map_support.
