### PR TITLE
Script version check

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -12,6 +12,7 @@ module.exports = {
         'jasmine',
         'karma',
         'labs',
+        'node-patches',
         'protractor',
         'rollup',
         'terser',

--- a/internal/linker/index.js
+++ b/internal/linker/index.js
@@ -25,6 +25,11 @@
      */
     const fs = require("fs");
     const path = require("path");
+    const REQUIRED_NODEJS_MAJOR_VERSION = 10;
+    const nodejsMajorVersion = Number(process.version.split('.')[0].replace('v', ''));
+    if (nodejsMajorVersion < REQUIRED_NODEJS_MAJOR_VERSION) {
+        panic(`Expected NodeJS version to v${REQUIRED_NODEJS_MAJOR_VERSION} or higher, but got ${nodejsMajorVersion}`);
+    }
     // Run Bazel with --define=VERBOSE_LOGS=1 to enable this logging
     const VERBOSE_LOGS = !!process.env['VERBOSE_LOGS'];
     function log_verbose(...m) {

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -6,6 +6,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+const REQUIRED_NODEJS_MAJOR_VERSION = 10;
+const nodejsMajorVersion = Number(process.version.split('.')[0].replace('v', ''));
+if (nodejsMajorVersion < REQUIRED_NODEJS_MAJOR_VERSION) {
+  panic(`Expected NodeJS version to v${REQUIRED_NODEJS_MAJOR_VERSION} or higher, but got ${
+      nodejsMajorVersion}`);
+}
+
 // Run Bazel with --define=VERBOSE_LOGS=1 to enable this logging
 const VERBOSE_LOGS = !!process.env['VERBOSE_LOGS'];
 

--- a/internal/node/node_patches.js
+++ b/internal/node/node_patches.js
@@ -56,6 +56,11 @@ var __asyncGenerator = (commonjsGlobal && commonjsGlobal.__asyncGenerator) || fu
 Object.defineProperty(exports, "__esModule", { value: true });
 
 
+const REQUIRED_NODEJS_MAJOR_VERSION = 10;
+const nodejsMajorVersion = Number(process.version.split('.')[0].replace('v', ''));
+if (nodejsMajorVersion < REQUIRED_NODEJS_MAJOR_VERSION) {
+    throw new Error(`Expected NodeJS version to v${REQUIRED_NODEJS_MAJOR_VERSION} or higher, but got ${nodejsMajorVersion}`);
+}
 // using require here on purpose so we can override methods with any
 // also even though imports are mutable in typescript the cognitive dissonance is too high because
 // es modules

--- a/packages/node-patches/src/fs.ts
+++ b/packages/node-patches/src/fs.ts
@@ -19,6 +19,13 @@ import {Stats} from 'fs';
 import * as path from 'path';
 import * as util from 'util';
 
+const REQUIRED_NODEJS_MAJOR_VERSION = 10;
+const nodejsMajorVersion = Number(process.version.split('.')[0].replace('v', ''));
+if (nodejsMajorVersion < REQUIRED_NODEJS_MAJOR_VERSION) {
+  throw new Error(`Expected NodeJS version to v${
+      REQUIRED_NODEJS_MAJOR_VERSION} or higher, but got ${nodejsMajorVersion}`);
+}
+
 // windows cant find the right types
 type Dir = any;
 type Dirent = any;


### PR DESCRIPTION
Checks the major version on `internal/linker/link_node_modules.ts` and `packages/node-patches/src/fs.ts` since they use `fs.promises` which was only put in on v10 of NodeJS.

Not sure if there are any modern NodeJS features used, let me know if there are and ill add the same check.

Fixes #1498