### PR TITLE
feat(examples): add nodejs_binary cluster example

### DIFF
--- a/examples/nestjs/package.json
+++ b/examples/nestjs/package.json
@@ -8,6 +8,7 @@
     "@nestjs/core": "6.5.2",
     "@nestjs/platform-express": "6.5.2",
     "@types/jasmine": "^3.5.0",
+    "@types/superagent": "^4.1.4",
     "@types/supertest": "^2.0.8",
     "minimist": "1.2.0",
     "reflect-metadata": "0.1.13",

--- a/examples/nestjs/src/BUILD.bazel
+++ b/examples/nestjs/src/BUILD.bazel
@@ -40,8 +40,10 @@ ts_library(
         ":app",
         "@npm//@nestjs/common",
         "@npm//@types/jasmine",
+        "@npm//@types/superagent",
         "@npm//@types/supertest",
         "@npm//jasmine",
+        "@npm//superagent",
         "@npm//supertest",
     ],
 )

--- a/examples/nestjs/src/BUILD.bazel
+++ b/examples/nestjs/src/BUILD.bazel
@@ -56,7 +56,8 @@ nodejs_binary(
         "@npm//@nestjs/core",
         "@npm//minimist",
     ],
-    entry_point = ":main.ts",
+    entry_point = ":main",
+    templated_args = ["--nobazel_patch_module_resolver"],
 )
 
 jasmine_node_test(

--- a/examples/nestjs/src/main.spec.ts
+++ b/examples/nestjs/src/main.spec.ts
@@ -1,21 +1,13 @@
-import {INestApplication} from '@nestjs/common';
 import * as request from 'supertest';
 
-import {bootstrap} from './main';
+import {bootstrap, bootstrapCluster} from './main';
 
 describe('App', () => {
-  let server: INestApplication;
-
-  beforeAll(async () => {
-    server = await bootstrap(3000);
-  });
-  afterAll(async () => {
-    await server.close();
-  })
-
-  it(`GET /`, () => {
-    return request(server.getHttpServer()).get('/hello').expect(200).expect({
+  it(`GET /`, async () => {
+    const server = await bootstrap(3000);
+    await request(server.getHttpServer()).get('/hello').expect(200).expect({
       message: 'Hello world!'
     });
+    await server.close();
   });
 });

--- a/examples/nestjs/src/main.ts
+++ b/examples/nestjs/src/main.ts
@@ -1,6 +1,8 @@
 import {INestApplication, Logger} from '@nestjs/common';
 import {NestFactory} from '@nestjs/core';
 import {ExpressAdapter} from '@nestjs/platform-express';
+import * as cluster from 'cluster';
+import * as os from 'os';
 
 import {AppModule} from './app.module';
 
@@ -11,7 +13,26 @@ export async function bootstrap(port: number): Promise<INestApplication> {
   return app;
 }
 
+function main(port: number) {
+  if (cluster.isMaster) {
+    const cpuCount = os.cpus().length;
+
+    for (let i = 0; i < cpuCount; i += 1) {
+      cluster.fork();
+    }
+
+    cluster.on('online', worker => {
+      Logger.log('Worker ' + worker.process.pid + ' is online.');
+    });
+    cluster.on('exit', ({process}, code, signal) => {
+      Logger.log('worker ' + process.pid + ' died.');
+    });
+  } else {
+    bootstrap(port);
+  }
+}
+
 if (require.main === module) {
   const argv = require('minimist')(process.argv.slice(2));
-  bootstrap(argv.port || 3000);
+  main(argv.port || 3000);
 }

--- a/examples/nestjs/yarn.lock
+++ b/examples/nestjs/yarn.lock
@@ -180,7 +180,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.21.tgz#4a9db7ef1d1671c0015e632c5fa3d46c86c58c1e"
   integrity sha512-nuFlRdBiqbF+PJIEVxm2jLFcQWN7q7iWEJGsBV4n7v1dbI9qXB8im2pMMKMCUZe092sQb5SQft2DHfuQGK5hqQ==
 
-"@types/superagent@*":
+"@types/superagent@*", "@types/superagent@^4.1.4":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-4.1.4.tgz#63f74955a28073870cfd9c100bcacb26d72b3764"
   integrity sha512-SRH2q6/5/nhOkAuLXm3azRGjBYpoKCZWh138Rt1AxSIyE6/1b9uClIH2V+JfyDtjIvgr5yQqYgNUmdpbneJoZQ==
@@ -1388,10 +1388,23 @@ readable-stream@1.1.x:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.2.2, readable-stream@^2.3.5:
+readable-stream@^2.2.2:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.3.5:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"


### PR DESCRIPTION
Adds a basic example of how to use the clustering module in Nestjs.

It currently fails with 
```
Error: Cannot find module 'examples_nestjs/src/app.module'
Require stack:
- /SNIP/execroot/examples_nestjs/bazel-out/darwin-fastbuild/bin/src/server.sh.runfiles/examples_nestjs/src/main.js
```

So also doubles as a test for the linker applying correctly to `nodejs_binary`
When this passes then this should be resolved https://github.com/bazelbuild/rules_nodejs/issues/227