### PR TITLE
feat(builtin): allow patching require in bootstrap scripts

### DIFF
--- a/e2e/jasmine/BUILD.bazel
+++ b/e2e/jasmine/BUILD.bazel
@@ -5,17 +5,11 @@ jasmine_node_test(
     srcs = ["test.spec.js"],
 )
 
-# This requires the linker as jasmine_shared_env_bootstrap.js requires @bazel/jasmine
-# which only works with the linker as the --require script doesn't get the require.resolve
-# patches.
 jasmine_node_test(
     name = "shared_env_test",
     srcs = ["jasmine_shared_env_test.spec.js"],
     data = ["jasmine_shared_env_bootstrap.js"],
-    # TODO(gregmagolan): fix Windows error: Error: Cannot find module 'e2e_jasmine/shared_env_test_devmode_srcs.MF'
-    tags = ["fix-windows"],
     templated_args = [
-        "--nobazel_patch_module_resolver",
         "--node_options=--require=$(rlocation $(location :jasmine_shared_env_bootstrap.js))",
     ],
     deps = [

--- a/e2e/jasmine/jasmine_shared_env_bootstrap.js
+++ b/e2e/jasmine/jasmine_shared_env_bootstrap.js
@@ -1,3 +1,9 @@
+// bootstrap the bazel require patch since this bootstrap script is loaded with
+// `--node_options=--require=$(rlocation $(location :jasmine_shared_env_bootstrap.js))`
+if (process.env['BAZEL_NODE_RUNFILES_HELPER']) {
+  require(process.env['BAZEL_NODE_RUNFILES_HELPER']).patchRequire();
+}
+
 global.foobar = 1;
 
 require('zone.js/dist/zone-node.js');

--- a/internal/golden_file_test/bin.js
+++ b/internal/golden_file_test/bin.js
@@ -29,7 +29,7 @@ ${prettyDiff}
 Update the golden file:
 
             bazel run ${debugBuild ? '--compilation_mode=dbg ' : ''}${
-          process.env['BAZEL_TARGET'].replace(/_bin$/, '')}.accept
+          process.env['TEST_TARGET'].replace(/_bin$/, '')}.accept
 `);
     } else {
       throw new Error('unknown mode', mode);

--- a/internal/linker/BUILD.bazel
+++ b/internal/linker/BUILD.bazel
@@ -20,7 +20,10 @@ bzl_library(
 )
 
 # END-INTERNAL
-exports_files(["index.js"])
+exports_files([
+    "index.js",
+    "runfiles_helper.js",
+])
 
 filegroup(
     name = "package_contents",

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -126,12 +126,15 @@ async function resolveRoot(root: string|undefined, runfiles: Runfiles) {
 export class Runfiles {
   manifest: Map<string, string>|undefined;
   dir: string|undefined;
-  noBin: boolean;
+  execroot: boolean;
   /**
-   * If the environment gives us enough hints, we can know the path to the package
-   * in the form workspace_name/path/to/package
+   * If the environment gives us enough hints, we can know the workspace name
    */
-  packagePath: string|undefined;
+  workspace: string|undefined;
+  /**
+   * If the environment gives us enough hints, we can know the package path
+   */
+  package: string|undefined;
 
   constructor(env: typeof process.env) {
     // If Bazel sets a variable pointing to a runfiles manifest,
@@ -159,18 +162,21 @@ export class Runfiles {
                  If you want to test runfiles manifest behavior, add
                  --spawn_strategy=standalone to the command line.`);
     }
-
-    const wksp = env['TEST_WORKSPACE'];
-    const target = env['TEST_TARGET'];
-    if (!!wksp && !!target) {
-      // //path/to:target -> //path/to
-      const pkg = target.split(':')[0];
-      this.packagePath = path.posix.join(wksp, pkg);
+    const wksp = env['BAZEL_WORKSPACE'];
+    if (!!wksp) {
+      this.workspace = wksp;
     }
-
-    // If under runfiles (and not unit testing) then don't add a bin to taget for bin links
-    this.noBin = !!env['TEST_TARGET'] && wksp !== 'build_bazel_rules_nodejs' &&
-        target !== '//internal/linker/test:unit_tests';
+    // If target is from an external workspace such as @npm//rollup/bin:rollup
+    // resolvePackageRelative is not supported since package is in an external
+    // workspace.
+    const target = env['BAZEL_TARGET'];
+    if (!!target && !target.startsWith('@')) {
+      // //path/to:target -> path/to
+      this.package = target.split(':')[0].replace(/^\/\//, '');
+    }
+    // We can derive if the process is being run in the execroot
+    // if there is a bazel-out folder at the cwd.
+    this.execroot = existsSync('bazel-out');
   }
 
   lookupDirectory(dir: string): string|undefined {
@@ -228,11 +234,29 @@ export class Runfiles {
     throw new Error(`could not resolve modulePath ${modulePath}`);
   }
 
-  resolvePackageRelative(modulePath: string) {
-    if (!this.packagePath) {
-      throw new Error('packagePath could not be determined from the environment');
+  resolveWorkspaceRelative(modulePath: string) {
+    if (!this.workspace) {
+      throw new Error('workspace could not be determined from the environment');
     }
-    return this.resolve(path.posix.join(this.packagePath, modulePath));
+    return this.resolve(path.posix.join(this.workspace, modulePath));
+  }
+
+  resolvePackageRelative(modulePath: string) {
+    if (!this.workspace) {
+      throw new Error('workspace could not be determined from the environment');
+    }
+    if (!this.package) {
+      throw new Error('package could not be determined from the environment');
+    }
+    return this.resolve(path.posix.join(this.workspace, this.package, modulePath));
+  }
+
+  patchRequire() {
+    const requirePatch = process.env['BAZEL_NODE_PATCH_REQUIRE'];
+    if (!requirePatch) {
+      throw new Error('require patch location could not be determined from the environment');
+    }
+    require(requirePatch);
   }
 }
 
@@ -248,6 +272,18 @@ declare global {
 async function exists(p: string) {
   try {
     await fs.promises.stat(p)
+    return true;
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return false;
+    }
+    throw e;
+  }
+}
+
+function existsSync(p: string) {
+  try {
+    fs.statSync(p)
     return true;
   } catch (e) {
     if (e.code === 'ENOENT') {
@@ -491,9 +527,11 @@ export async function main(args: string[], runfiles: Runfiles) {
       let target: string = '<package linking failed>';
       switch (root) {
         case 'bin':
+          // If we are in the execroot then add the bin path to the target; otherwise
+          // we are in runfiles and the bin path should be omitted.
           // FIXME(#1196)
-          target = runfiles.noBin ? path.join(workspaceAbs, toWorkspaceDir(modulePath)) :
-                                    path.join(workspaceAbs, bin, toWorkspaceDir(modulePath));
+          target = runfiles.execroot ? path.join(workspaceAbs, bin, toWorkspaceDir(modulePath)) :
+                                       path.join(workspaceAbs, toWorkspaceDir(modulePath));
           break;
         case 'src':
           target = path.join(workspaceAbs, toWorkspaceDir(modulePath));

--- a/internal/linker/runfiles_helper.js
+++ b/internal/linker/runfiles_helper.js
@@ -1,0 +1,1 @@
+module.exports = require('./index.js').runfiles;

--- a/internal/node/node_launcher.sh
+++ b/internal/node/node_launcher.sh
@@ -158,6 +158,13 @@ else
   fi
 fi
 
+# Export the location of the runfiles helpers script
+export BAZEL_NODE_RUNFILES_HELPER=$(rlocation "TEMPLATED_runfiles_helper_script")
+
+# Export the location of the loader script as it can be used to boostrap
+# node require patch if needed
+export BAZEL_NODE_PATCH_REQUIRE=$(rlocation "TEMPLATED_loader_path")
+
 readonly repository_args=$(rlocation "TEMPLATED_repository_args")
 MAIN=$(rlocation "TEMPLATED_loader_path")
 readonly link_modules_script=$(rlocation "TEMPLATED_link_modules_script")

--- a/internal/npm_install/test/check.js
+++ b/internal/npm_install/test/check.js
@@ -40,7 +40,7 @@ ${prettyDiff}
 
 Update the golden file:
 
-      bazel run ${process.env['BAZEL_TARGET']}.accept`);
+      bazel run ${process.env['TEST_TARGET']}.accept`);
     }
   }
 }

--- a/packages/jasmine/src/jasmine_runner.js
+++ b/packages/jasmine/src/jasmine_runner.js
@@ -191,7 +191,7 @@ function main(args) {
     // Special case!
     // To allow us to test sharding, always run the specs in the order they are declared
     if (process.env['TEST_WORKSPACE'] === 'build_bazel_rules_nodejs' &&
-        process.env['BAZEL_TARGET'] === '//packages/jasmine/test:sharding_test') {
+        process.env['TEST_TARGET'] === '//packages/jasmine/test:sharding_test') {
       jrunner.randomizeTests(false);
     }
   }


### PR DESCRIPTION
* export BAZEL_WORKSPACE, BAZEL_NODE_LINKER & BAZEL_NODE_PATCH_REQUIRE env variables from node launcher (in addition to currently exported BAZEL_TARGET & BAZEL_PATCH_ROOT)
* linker now uses BAZEL_WORKSPACE & BAZEL_TARGET so that its runfiles resolve support works with non-test targets that don't have TEST_WORKSPACE & TEST_TARGET envs
* adds resolveWorkspaceRelative() & patchRequire() to linker runfiles resolve support. The former is useful if you want to resolve without worrying about the workspace name. The latter is useful for nodejs_binary bootstrap scripts that want to patch require via the linker (such as e2e/jasmine/jasmine_shared_env_bootstrap.js)
* tests targets can safely use TEST_TARGET & TEST_WORKSPACE and some of these are switched over

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

