### PR TITLE
Rules nodejs version check

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,7 +25,6 @@ exports_files([
     "tsconfig.json",
     "package.json",
     "bootstrap.js",
-    "tools/npm_version_check.js",
 ])
 
 bzl_library(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,7 @@ exports_files([
     "tsconfig.json",
     "package.json",
     "bootstrap.js",
+    "tools/npm_version_check.js",
 ])
 
 bzl_library(
@@ -33,6 +34,7 @@ bzl_library(
         "index.bzl",
         "index.for_docs.bzl",
         "providers.bzl",
+        "version.bzl",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/examples/app/test/BUILD.bazel
+++ b/examples/app/test/BUILD.bazel
@@ -1,7 +1,8 @@
+load("@build_bazel_rules_nodejs//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "copy_file")
+
 # Verify that we can do something with the devserver manifest
-genrule(
+copy_file(
     name = "consume_manifest",
-    srcs = ["//:devserver.MF"],
-    outs = [":MANIFEST"],
-    cmd = "cp $< $@",
+    src = "//:devserver.MF",
+    out = ":MANIFEST",
 )

--- a/index.bzl
+++ b/index.bzl
@@ -17,6 +17,7 @@
 Users should not load files under "/internal"
 """
 
+load("//internal:version.bzl", "VERSION")
 load("//internal/common:check_bazel_version.bzl", _check_bazel_version = "check_bazel_version")
 load("//internal/common:check_version.bzl", "check_version")
 load("//internal/common:copy_to_bin.bzl", _copy_to_bin = "copy_to_bin")

--- a/index.bzl
+++ b/index.bzl
@@ -17,7 +17,7 @@
 Users should not load files under "/internal"
 """
 
-load("//internal:version.bzl", "VERSION")
+load("//:version.bzl", "VERSION")
 load("//internal/common:check_bazel_version.bzl", _check_bazel_version = "check_bazel_version")
 load("//internal/common:check_version.bzl", "check_version")
 load("//internal/common:copy_to_bin.bzl", _copy_to_bin = "copy_to_bin")
@@ -83,12 +83,6 @@ def yarn_install(**kwargs):
     # Just in case the user didn't install nodejs, do it now
     _node_repositories()
     _yarn_install(**kwargs)
-
-# This version is synced with the version in package.json.
-# It will be automatically synced via the npm "version" script
-# that is run when running `npm version` during the release
-# process. See `Releasing` section in README.md.
-VERSION = "1.5.0"
 
 # Currently used Bazel version. This version is what the rules here are tested
 # against.

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -17,6 +17,8 @@ load("//internal/node:context.bzl", "node_context_data")
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["npm_version_check.js"])
+
 filegroup(
     name = "package_contents",
     srcs = glob(["*"]),

--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -21,7 +21,7 @@ as the package manager.
 See discussion in the README.
 """
 
-load("//internal:version.bzl", "VERSION")
+load("//:version.bzl", "VERSION")
 load("//internal/common:check_bazel_version.bzl", "check_bazel_version")
 load("//internal/common:os_name.bzl", "is_windows_os")
 load("//internal/node:node_labels.bzl", "get_node_label", "get_npm_label", "get_yarn_label")
@@ -276,7 +276,7 @@ cd /D "{root}" && "{npm}" {npm_args}
     env_key = "BAZEL_NPM_INSTALL"
     if env_key not in env.keys():
         env[env_key] = "1"
-    env["build_bazel_rules_nodejs_version"] = VERSION
+    env["BUILD_BAZEL_RULES_NODEJS_VERSION"] = VERSION
 
     repository_ctx.report_progress("Running npm install on %s" % repository_ctx.attr.package_json)
     result = repository_ctx.execute(
@@ -414,7 +414,7 @@ cd /D "{root}" && "{yarn}" {yarn_args}
     env_key = "BAZEL_YARN_INSTALL"
     if env_key not in env.keys():
         env[env_key] = "1"
-    env["build_bazel_rules_nodejs_version"] = VERSION
+    env["BUILD_BAZEL_RULES_NODEJS_VERSION"] = VERSION
 
     repository_ctx.report_progress("Running yarn install on %s" % repository_ctx.attr.package_json)
     result = repository_ctx.execute(

--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -21,6 +21,7 @@ as the package manager.
 See discussion in the README.
 """
 
+load("//internal:version.bzl", "VERSION")
 load("//internal/common:check_bazel_version.bzl", "check_bazel_version")
 load("//internal/common:os_name.bzl", "is_windows_os")
 load("//internal/node:node_labels.bzl", "get_node_label", "get_npm_label", "get_yarn_label")
@@ -275,6 +276,7 @@ cd /D "{root}" && "{npm}" {npm_args}
     env_key = "BAZEL_NPM_INSTALL"
     if env_key not in env.keys():
         env[env_key] = "1"
+    env["build_bazel_rules_nodejs_version"] = VERSION
 
     repository_ctx.report_progress("Running npm install on %s" % repository_ctx.attr.package_json)
     result = repository_ctx.execute(
@@ -412,6 +414,7 @@ cd /D "{root}" && "{yarn}" {yarn_args}
     env_key = "BAZEL_YARN_INSTALL"
     if env_key not in env.keys():
         env[env_key] = "1"
+    env["build_bazel_rules_nodejs_version"] = VERSION
 
     repository_ctx.report_progress("Running yarn install on %s" % repository_ctx.attr.package_json)
     result = repository_ctx.execute(

--- a/internal/npm_version_check.js
+++ b/internal/npm_version_check.js
@@ -10,5 +10,6 @@ const getMajor = versionString => versionString.split('.')[0];
 if (pkgVersion !== '0.0.0' && getMajor(pkgVersion) !== getMajor(rules_nodejsVersion)) {
   throw new Error(`Expected package major version to equal @build_bazel_rules_nodejs major version
     ${pkg.name} - ${pkgVersion}  
-    @build_bazel_rules_nodejs - ${rules_nodejsVersion}`)
+    @build_bazel_rules_nodejs - ${rules_nodejsVersion}
+  See https://github.com/bazelbuild/rules_nodejs/wiki/Avoiding-version-skew`);
 }

--- a/internal/version.bzl
+++ b/internal/version.bzl
@@ -1,0 +1,22 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Version for the rules_nodejs repository
+"""
+
+# This version is synced with the version in package.json.
+# It will be automatically synced via the npm "version" script
+# that is run when running `npm version` during the release
+# process. See `Releasing` section in README.md.
+VERSION = "1.0.0"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
         "format": "git-clang-format",
         "format-all": "clang-format --glob='{internal/**/,examples/**/}*.{js,ts}' -i",
         "stardoc": "bazelisk build //docs && cp -f dist/bin/docs/*.md docs",
-        "version": "conventional-changelog -p angular -i CHANGELOG.md -s && node ./scripts/on-version.js && bazel build //:release && node ./scripts/on-release.js && git stage index.bzl docs/install.md packages/create/index.js README.md CHANGELOG.md e2e/*/WORKSPACE examples/*/WORKSPACE",
+        "version": "conventional-changelog -p angular -i CHANGELOG.md -s && node ./scripts/on-version.js && bazel build //:release && node ./scripts/on-release.js && git stage version.bzl docs/install.md packages/create/index.js README.md CHANGELOG.md e2e/*/WORKSPACE examples/*/WORKSPACE",
         "postinstall": "node internal/npm_install/test/postinstall.js"
     },
     "husky": {

--- a/packages/jasmine/BUILD.bazel
+++ b/packages/jasmine/BUILD.bazel
@@ -29,6 +29,13 @@ genrule(
     visibility = ["//docs:__pkg__"],
 )
 
+genrule(
+    name = "npm_version_check",
+    srcs = ["//:tools/npm_version_check.js"],
+    outs = [":npm_version_check.js"],
+    cmd = "cp $< $@",
+)
+
 pkg_npm(
     name = "npm_package",
     srcs = [
@@ -38,7 +45,9 @@ pkg_npm(
     vendor_external = [
         "npm_bazel_jasmine",
     ],
-    deps = select({
+    deps = [
+        ":npm_version_check",
+    ] + select({
         # FIXME: fix stardoc on Windows; @npm_bazel_jasmine//:index.md generation fails with:
         #   ERROR: D:/b/62unjjin/external/npm_bazel_jasmine/BUILD.bazel:34:1: Couldn't build file
         #   external/npm_bazel_jasmine/docs.raw: Generating proto for Starlark doc for docs failed (Exit 1)

--- a/packages/jasmine/BUILD.bazel
+++ b/packages/jasmine/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "pkg_npm")
+load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "copy_file")
 
 # Ugly genrule depending on local linux environment to build the README out of skylark doc generation.
 # Only referenced when we do a release.
@@ -29,11 +30,10 @@ genrule(
     visibility = ["//docs:__pkg__"],
 )
 
-genrule(
+copy_file(
     name = "npm_version_check",
-    srcs = ["//:tools/npm_version_check.js"],
-    outs = [":npm_version_check.js"],
-    cmd = "cp $< $@",
+    src = "//internal:npm_version_check.js",
+    out = ":npm_version_check.js",
 )
 
 pkg_npm(

--- a/packages/jasmine/src/package.json
+++ b/packages/jasmine/src/package.json
@@ -26,5 +26,8 @@
         "npm_bazel_jasmine": {
             "rootPath": "."
         }
+    },
+    "scripts": {
+        "postinstall": "node npm_version_check.js"
     }
 }

--- a/packages/karma/BUILD.bazel
+++ b/packages/karma/BUILD.bazel
@@ -29,6 +29,13 @@ genrule(
     visibility = ["//docs:__pkg__"],
 )
 
+genrule(
+    name = "npm_version_check",
+    srcs = ["//:tools/npm_version_check.js"],
+    outs = [":npm_version_check.js"],
+    cmd = "cp $< $@",
+)
+
 pkg_npm(
     name = "npm_package",
     srcs = [
@@ -40,6 +47,7 @@ pkg_npm(
     ],
     deps = [
         "@npm_bazel_karma//:bazel_karma_lib",
+        ":npm_version_check",
     ] + select({
         # FIXME: fix stardoc on Windows; @npm_bazel_karma//:index.md generation fails with:
         #   ERROR: D:/b/62unjjin/external/npm_bazel_karma/BUILD.bazel:65:1: Couldn't build file

--- a/packages/karma/BUILD.bazel
+++ b/packages/karma/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "pkg_npm")
+load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "copy_file")
 
 # Ugly genrule depending on local linux environment to build the README out of skylark doc generation.
 # Only referenced when we do a release.
@@ -29,11 +30,10 @@ genrule(
     visibility = ["//docs:__pkg__"],
 )
 
-genrule(
+copy_file(
     name = "npm_version_check",
-    srcs = ["//:tools/npm_version_check.js"],
-    outs = [":npm_version_check.js"],
-    cmd = "cp $< $@",
+    src = "//internal:npm_version_check.js",
+    out = ":npm_version_check.js",
 )
 
 pkg_npm(

--- a/packages/karma/src/package.json
+++ b/packages/karma/src/package.json
@@ -33,5 +33,8 @@
     "npm_bazel_karma": {
       "rootPath": "."
     }
+  },
+  "scripts": {
+    "postinstall": "node npm_version_check.js"
   }
 }

--- a/packages/protractor/BUILD.bazel
+++ b/packages/protractor/BUILD.bazel
@@ -29,6 +29,13 @@ genrule(
     visibility = ["//docs:__pkg__"],
 )
 
+genrule(
+    name = "npm_version_check",
+    srcs = ["//:tools/npm_version_check.js"],
+    outs = [":npm_version_check.js"],
+    cmd = "cp $< $@",
+)
+
 pkg_npm(
     name = "npm_package",
     srcs = [
@@ -39,6 +46,7 @@ pkg_npm(
         "npm_bazel_protractor",
     ],
     deps = [
+        ":npm_version_check",
         "@npm_bazel_protractor//:utils_lib",
     ] + select({
         # FIXME: fix stardoc on Windows; @npm_bazel_protractor//:index.md generation fails with:

--- a/packages/protractor/BUILD.bazel
+++ b/packages/protractor/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "pkg_npm")
+load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "copy_file")
 
 # Ugly genrule depending on local linux environment to build the README out of skylark doc generation.
 # Only referenced when we do a release.
@@ -29,11 +30,10 @@ genrule(
     visibility = ["//docs:__pkg__"],
 )
 
-genrule(
+copy_file(
     name = "npm_version_check",
-    srcs = ["//:tools/npm_version_check.js"],
-    outs = [":npm_version_check.js"],
-    cmd = "cp $< $@",
+    src = "//internal:npm_version_check.js",
+    out = ":npm_version_check.js",
 )
 
 pkg_npm(

--- a/packages/protractor/src/package.json
+++ b/packages/protractor/src/package.json
@@ -22,5 +22,8 @@
       "npm_bazel_protractor": {
           "rootPath": "."
       }
+  },
+  "scripts": {
+    "postinstall": "node npm_version_check.js"
   }
 }

--- a/packages/rollup/BUILD.bazel
+++ b/packages/rollup/BUILD.bazel
@@ -53,6 +53,13 @@ copy_file(
     visibility = ["//visibility:public"],
 )
 
+genrule(
+    name = "npm_version_check",
+    srcs = ["//:tools/npm_version_check.js"],
+    outs = [":npm_version_check.js"],
+    cmd = "cp $< $@",
+)
+
 pkg_npm(
     name = "npm_package",
     srcs = [
@@ -65,7 +72,9 @@ pkg_npm(
     vendor_external = [
         "npm_bazel_rollup",
     ],
-    deps = select({
+    deps = [
+        ":npm_version_check",
+    ] + select({
         # FIXME: fix stardoc on Windows; @npm_bazel_rollup//:index.md generation fails with:
         #   ERROR: D:/b/62unjjin/external/npm_bazel_rollup/BUILD.bazel:32:1: Couldn't build file
         #   external/npm_bazel_rollup/docs.raw: Generating proto for Starlark doc for docs failed (Exit 1)

--- a/packages/rollup/BUILD.bazel
+++ b/packages/rollup/BUILD.bazel
@@ -53,11 +53,10 @@ copy_file(
     visibility = ["//visibility:public"],
 )
 
-genrule(
+copy_file(
     name = "npm_version_check",
-    srcs = ["//:tools/npm_version_check.js"],
-    outs = [":npm_version_check.js"],
-    cmd = "cp $< $@",
+    src = "//internal:npm_version_check.js",
+    out = ":npm_version_check.js",
 )
 
 pkg_npm(

--- a/packages/rollup/src/package.json
+++ b/packages/rollup/src/package.json
@@ -25,5 +25,8 @@
         "npm_bazel_rollup": {
             "rootPath": "."
         }
+    },
+    "scripts": {
+      "postinstall": "node npm_version_check.js"
     }
 }

--- a/packages/terser/BUILD.bazel
+++ b/packages/terser/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "pkg_npm")
+load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "copy_file")
 
 # Ugly genrule depending on local linux environment to build the README out of skylark doc generation.
 # Only referenced when we do a release.
@@ -29,11 +30,10 @@ genrule(
     visibility = ["//docs:__pkg__"],
 )
 
-genrule(
+copy_file(
     name = "npm_version_check",
-    srcs = ["//:tools/npm_version_check.js"],
-    outs = [":npm_version_check.js"],
-    cmd = "cp $< $@",
+    src = "//internal:npm_version_check.js",
+    out = ":npm_version_check.js",
 )
 
 pkg_npm(

--- a/packages/terser/BUILD.bazel
+++ b/packages/terser/BUILD.bazel
@@ -29,6 +29,13 @@ genrule(
     visibility = ["//docs:__pkg__"],
 )
 
+genrule(
+    name = "npm_version_check",
+    srcs = ["//:tools/npm_version_check.js"],
+    outs = [":npm_version_check.js"],
+    cmd = "cp $< $@",
+)
+
 pkg_npm(
     name = "npm_package",
     srcs = [
@@ -41,7 +48,9 @@ pkg_npm(
     vendor_external = [
         "npm_bazel_terser",
     ],
-    deps = select({
+    deps = [
+        ":npm_version_check",
+    ] + select({
         # FIXME: fix stardoc on Windows; @npm_bazel_terser//:index.md generation fails with:
         #   ERROR: D:/b/62unjjin/external/npm_bazel_terser/BUILD.bazel:32:1: Couldn't build file
         #   external/npm_bazel_terser/docs.raw: Generating proto for Starlark doc for docs failed (Exit 1)

--- a/packages/terser/src/package.json
+++ b/packages/terser/src/package.json
@@ -25,5 +25,8 @@
         "npm_bazel_terser": {
             "rootPath": "."
         }
+    },
+    "scripts": {
+      "postinstall": "node npm_version_check.js"
     }
 }

--- a/packages/typescript/BUILD.bazel
+++ b/packages/typescript/BUILD.bazel
@@ -30,6 +30,13 @@ genrule(
     visibility = ["//docs:__pkg__"],
 )
 
+genrule(
+    name = "npm_version_check",
+    srcs = ["//:tools/npm_version_check.js"],
+    outs = [":npm_version_check.js"],
+    cmd = "cp $< $@",
+)
+
 pkg_npm(
     name = "npm_package",
     srcs = [
@@ -45,6 +52,7 @@ pkg_npm(
         "build_bazel_rules_typescript",
     ],
     deps = [
+        ":npm_version_check",
         "@npm_bazel_typescript//internal:BUILD",
         "@npm_bazel_typescript//internal:ts_project_options_validator.js",
     ] + select({

--- a/packages/typescript/BUILD.bazel
+++ b/packages/typescript/BUILD.bazel
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "pkg_npm")
+load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "copy_file")
 load(":replacements.bzl", "TYPESCRIPT_REPLACEMENTS")
 
 # Ugly genrule depending on local linux environment to build the README out of skylark doc generation.
@@ -30,11 +31,10 @@ genrule(
     visibility = ["//docs:__pkg__"],
 )
 
-genrule(
+copy_file(
     name = "npm_version_check",
-    srcs = ["//:tools/npm_version_check.js"],
-    outs = [":npm_version_check.js"],
-    cmd = "cp $< $@",
+    src = "//internal:npm_version_check.js",
+    out = ":npm_version_check.js",
 )
 
 pkg_npm(

--- a/packages/typescript/src/package.json
+++ b/packages/typescript/src/package.json
@@ -35,5 +35,8 @@
         "npm_bazel_typescript": {
             "rootPath": "."
         }
+    },
+    "scripts": {
+      "postinstall": "node npm_version_check.js"
     }
 }

--- a/packages/worker/BUILD.bazel
+++ b/packages/worker/BUILD.bazel
@@ -45,11 +45,10 @@ copy_file(
     out = "%s/worker_protocol.proto" % _worker_proto_dir,
 )
 
-genrule(
+copy_file(
     name = "npm_version_check",
-    srcs = ["//:tools/npm_version_check.js"],
-    outs = [":npm_version_check.js"],
-    cmd = "cp $< $@",
+    src = "//internal:npm_version_check.js",
+    out = ":npm_version_check.js",
 )
 
 pkg_npm(

--- a/packages/worker/BUILD.bazel
+++ b/packages/worker/BUILD.bazel
@@ -45,6 +45,13 @@ copy_file(
     out = "%s/worker_protocol.proto" % _worker_proto_dir,
 )
 
+genrule(
+    name = "npm_version_check",
+    srcs = ["//:tools/npm_version_check.js"],
+    outs = [":npm_version_check.js"],
+    cmd = "cp $< $@",
+)
+
 pkg_npm(
     name = "npm_package",
     srcs = [
@@ -64,5 +71,6 @@ pkg_npm(
         ":copy_worker_dts",
         ":copy_worker_js",
         ":copy_worker_proto",
+        ":npm_version_check",
     ],
 )

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -16,5 +16,8 @@
     },
     "keywords": [
         "bazel"
-    ]
+    ],
+    "scripts": {
+      "postinstall": "node npm_version_check.js"
+    }
 }

--- a/scripts/on-version.js
+++ b/scripts/on-version.js
@@ -4,4 +4,4 @@
 const shell = require('shelljs');
 const version = require('../package.json').version;
 
-shell.sed('-i', /^VERSION \= \"[0-9\.]*\"/, `VERSION = "${version}"`, 'internal/version.bzl');
+shell.sed('-i', /^VERSION \= \"[0-9\.]*\"/, `VERSION = "${version}"`, 'version.bzl');

--- a/scripts/on-version.js
+++ b/scripts/on-version.js
@@ -4,4 +4,4 @@
 const shell = require('shelljs');
 const version = require('../package.json').version;
 
-shell.sed('-i', /^VERSION \= \"[0-9\.]*\"/, `VERSION = "${version}"`, 'index.bzl');
+shell.sed('-i', /^VERSION \= \"[0-9\.]*\"/, `VERSION = "${version}"`, 'internal/version.bzl');

--- a/tools/npm_version_check.js
+++ b/tools/npm_version_check.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+const pkg = require('./package.json');
+const pkgVersion = pkg.version;
+const rules_nodejsVersion = process.env['BUILD_BAZEL_RULES_NODEJS_VERSION'];
+
+const getMajor = versionString => versionString.split('.')[0];
+
+// special case the version 0.0.0 so that we don't have to stamp builds
+// for dev and testing
+if (pkgVersion !== '0.0.0' && getMajor(pkgVersion) !== getMajor(rules_nodejsVersion)) {
+  throw new Error(`Expected package major version to equal @build_bazel_rules_nodejs major version
+    ${pkg.name} - ${pkgVersion}  
+    @build_bazel_rules_nodejs - ${rules_nodejsVersion}`)
+}

--- a/version.bzl
+++ b/version.bzl
@@ -19,4 +19,4 @@
 # It will be automatically synced via the npm "version" script
 # that is run when running `npm version` during the release
 # process. See `Releasing` section in README.md.
-VERSION = "1.0.0"
+VERSION = "1.5.0"


### PR DESCRIPTION
Adds a way to check the npm package version against the bazel rules_nodejs version ensuring they don't skew when installed at a user level.

fixes https://github.com/bazelbuild/rules_nodejs/issues/1280