### PR TITLE
--compilation_mode fixes

### DIFF
--- a/common.bazelrc
+++ b/common.bazelrc
@@ -47,8 +47,8 @@ test --test_output=errors
 #     `nodejs_binary` and `nodejs_test` via the default value of the `default_env_vars` attribute of those rules.
 # --compilation_mode=dbg
 #     Rules may change their build outputs if the compilation mode is set to dbg. For example,
-#     mininfiers such as terser may make their output more human readable when this is set. `COMPILATION_MODE` will be passed to
-#     `nodejs_binary` and `nodejs_test` via the default value of the `default_env_vars` attribute of those rules.
+#     mininfiers such as terser may make their output more human readable when this is set. Rules will pass `COMPILATION_MODE`
+#     to `nodejs_binary` executables via the actions.run env attribute.
 #     See https://docs.bazel.build/versions/master/user-manual.html#flag--compilation_mode for more details.
 test:debug --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results --define=VERBOSE_LOGS=1
 # Use bazel run with `--config=debug` to turn on the NodeJS inspector agent.

--- a/examples/parcel/parcel.bzl
+++ b/examples/parcel/parcel.bzl
@@ -36,6 +36,7 @@ def _parcel_impl(ctx):
         executable = ctx.executable.parcel,
         outputs = [ctx.outputs.bundle, ctx.outputs.sourcemap],
         arguments = args,
+        env = {"COMPILATION_MODE": ctx.var["COMPILATION_MODE"]},
         progress_message = "Bundling JavaScript %s [parcel]" % ctx.outputs.bundle.short_path,
     )
     return [DefaultInfo()]

--- a/examples/worker/uses_workers.bzl
+++ b/examples/worker/uses_workers.bzl
@@ -22,6 +22,7 @@ def _work(ctx):
         execution_requirements = {"supports-workers": "1"},
         # The user can explicitly set the execution strategy
         mnemonic = "DoWork",
+        env = {"COMPILATION_MODE": ctx.var["COMPILATION_MODE"]},
     )
 
     return [DefaultInfo(files = depset([output]))]

--- a/internal/bazel_integration_test/BUILD.bazel
+++ b/internal/bazel_integration_test/BUILD.bazel
@@ -19,6 +19,7 @@ package(default_visibility = ["//visibility:public"])
 
 nodejs_binary(
     name = "test_runner",
+    configuration_env_vars = ["BAZEL_INTEGRATION_TEST_DEBUG"],
     data = ["@npm//tmp"],
     entry_point = ":test_runner.js",
     # reduce memory usage by disabling source_map_support

--- a/internal/bazel_integration_test/bazel_integration_test.bzl
+++ b/internal/bazel_integration_test/bazel_integration_test.bzl
@@ -244,7 +244,13 @@ is published on GitHub.
 
 bazel_integration_test = rule(
     implementation = _bazel_integration_test,
-    doc = """Runs an integration test by running a specified version of bazel against an external workspace.""",
+    doc = """Runs an integration test by running a specified version of bazel against an external workspace.
+
+Run with --define=BAZEL_INTEGRATION_TEST_DEBUG=1 to put the test in debug mode which will
+preserve the workspace under test root /tmp folder and exit without running the test. This
+allows you to change directory into the workspace under test root folder and run the integration
+test manually.
+""",
     attrs = BAZEL_INTEGRATION_TEST_ATTRS,
     test = True,
 )

--- a/internal/bazel_integration_test/test_runner.js
+++ b/internal/bazel_integration_test/test_runner.js
@@ -24,7 +24,7 @@ const fs = require('fs');
 const path = require('path');
 const tmp = require('tmp');
 
-const DEBUG = process.env['COMPILATION_MODE'] === 'dbg';
+const DEBUG = !!process.env['BAZEL_INTEGRATION_TEST_DEBUG'];
 const VERBOSE_LOGS = !!process.env['VERBOSE_LOGS'];
 
 function log(...m) {
@@ -283,18 +283,25 @@ const isWindows = process.platform === 'win32';
 const bazelBinary =
     require.resolve(`${config.bazelBinaryWorkspace}/bazel${isWindows ? '.exe' : ''}`);
 
-if (DEBUG || VERBOSE_LOGS) {
-  // If DEBUG is set then the tmp folders created by the `tmp.dirSync` are not
-  // cleaned up so we should log out the location of the workspace under test
-  // tmp folder in that case even if VERBOSE_LOGS is not set as it may be useful
-  // to `cd /path/to/workspace/tmp` for manual testing at that point.
+if (DEBUG) {
   log(`
 
-********************************************************************************
-bazel binary under test is ${bazelBinary}
-workspace under test root is ${workspaceRoot}
-********************************************************************************
+================================================================================
+Integration test put in DEBUG mode with BAZEL_INTEGRATION_TEST_DEBUG env set.
+
+    bazel binary: ${bazelBinary}
+    workspace under test root: ${workspaceRoot}
+
+Change directory to workspace under test root folder,
+
+    cd ${workspaceRoot}
+
+and run integration test manually.
+================================================================================
 `);
+  // Exit with error code so that BAZEL_INTEGRATION_TEST_DEBUG does not lead
+  // to a accidental passing test.
+  process.exit(1);
 }
 
 log(`running 'bazel version'`);

--- a/internal/golden_file_test/bin.js
+++ b/internal/golden_file_test/bin.js
@@ -3,9 +3,10 @@ const path = require('path');
 
 function main(args) {
   const [mode, golden_no_debug, golden_debug, actual] = args;
-  const debug = process.env['COMPILATION_MODE'] === 'dbg';
-  const golden = debug ? golden_debug : golden_no_debug;
-  const actualContents = fs.readFileSync(require.resolve(actual), 'utf-8').replace(/\r\n/g, '\n');
+  const actualPath = require.resolve(actual);
+  const debugBuild = /\/bazel-out\/[^/\s]*-dbg\//.test(actualPath);
+  const golden = debugBuild ? golden_debug : golden_no_debug;
+  const actualContents = fs.readFileSync(actualPath, 'utf-8').replace(/\r\n/g, '\n');
   const goldenContents = fs.readFileSync(require.resolve(golden), 'utf-8').replace(/\r\n/g, '\n');
 
   if (actualContents !== goldenContents) {
@@ -27,7 +28,7 @@ ${prettyDiff}
 
 Update the golden file:
 
-            bazel run ${debug ? '--compilation_mode=dbg ' : ''}${
+            bazel run ${debugBuild ? '--compilation_mode=dbg ' : ''}${
           process.env['BAZEL_TARGET'].replace(/_bin$/, '')}.accept
 `);
     } else {

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -174,13 +174,6 @@ def _nodejs_binary_impl(ctx):
         if k in ctx.var.keys():
             env_vars += "export %s=\"%s\"\n" % (k, ctx.var[k])
 
-    if "DEBUG" in ctx.var and ctx.var["COMPILATION_MODE"] != "dbg":
-        print("""
-        WARNING: `--define DEBUG` no longer triggers a debugging build, use
-        `--compilation_mode=dbg` instead.
-
-        """)
-
     expected_exit_code = 0
     if hasattr(ctx.attr, "expected_exit_code"):
         expected_exit_code = ctx.attr.expected_exit_code
@@ -287,12 +280,10 @@ without losing the defaults that should be set in most cases.
 
 The set of default  environment variables is:
 
-- `COMPILATION_MODE`: rules use this environment variable to produce optimized (eg. mangled and minimized) or debugging output
-- `VERBOSE_LOGS`: rules use this environment variable to turn on debug output in their logs
-- `DEBUG`: used by some npm packages to print debugging logs
+- `VERBOSE_LOGS`: use by some rules & tools to turn on debug output in their logs
 - `NODE_DEBUG`: used by node.js itself to print more logs
 """,
-        default = ["COMPILATION_MODE", "VERBOSE_LOGS", "DEBUG", "NODE_DEBUG"],
+        default = ["VERBOSE_LOGS", "NODE_DEBUG"],
     ),
     "entry_point": attr.label(
         doc = """The script which should be executed first, usually containing a main function.

--- a/internal/pkg_web/pkg_web.bzl
+++ b/internal/pkg_web/pkg_web.bzl
@@ -32,7 +32,7 @@ _ATTRS = {
     ),
 }
 
-def move_files(output_name, files, action_factory, assembler, root_paths):
+def move_files(output_name, files, action_factory, var, assembler, root_paths):
     """Moves files into an output directory
 
     Args:
@@ -58,6 +58,7 @@ def move_files(output_name, files, action_factory, assembler, root_paths):
         executable = assembler,
         arguments = [args],
         execution_requirements = {"local": "1"},
+        env = {"COMPILATION_MODE": var["COMPILATION_MODE"]},
     )
     return depset([www_dir])
 
@@ -90,6 +91,7 @@ def _impl(ctx):
         ctx.label.name,
         ctx.files.srcs,
         ctx.actions,
+        ctx.var,
         ctx.executable._assembler,
         root_paths,
     )

--- a/internal/providers/node_runtime_deps_info.bzl
+++ b/internal/providers/node_runtime_deps_info.bzl
@@ -63,9 +63,15 @@ def run_node(ctx, inputs, arguments, executable, **kwargs):
     # To access runfiles, you must use a runfiles helper in the program instead
     add_arg(arguments, "--nobazel_patch_module_resolver")
 
+    # Forward the COMPILATION_MODE to node process as an environment variable
+    env = kwargs.pop("env", {})
+    if "COMPILATION_MODE" not in env.keys():
+        env["COMPILATION_MODE"] = ctx.var["COMPILATION_MODE"]
+
     ctx.actions.run(
         inputs = inputs + extra_inputs,
         arguments = arguments,
         executable = exec_exec,
+        env = env,
         **kwargs
     )

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "test_e2e": "bazel --host_jvm_args=-Xms256m --host_jvm_args=-Xmx1280m test --test_tag_filters=e2e --local_resources=792,1.0,1.0 --test_arg=--local_resources=13288,1.0,1.0",
         "test_examples": "bazel --host_jvm_args=-Xms256m --host_jvm_args=-Xmx1280m test --test_tag_filters=examples --local_resources=792,1.0,1.0 --test_arg=--local_resources=13288,1.0,1.0",
         "run_integration_test": "bazel --host_jvm_args=-Xms256m --host_jvm_args=-Xmx1280m run --local_resources=792,1.0,1.0 --test_arg=--local_resources=13288,1.0,1.0",
-        "run_integration_test_debug": "yarn run_integration_test --compilation_mode=dbg",
+        "run_integration_test_debug": "yarn run_integration_test --define=BAZEL_INTEGRATION_TEST_DEBUG=1",
         "test_all": "./scripts/test_all.sh",
         "clean_all": "./scripts/clean_all.sh",
         "// Unchecked warnings": "The following warnings are not checked as disabling them locally is broken",

--- a/packages/create/index.js
+++ b/packages/create/index.js
@@ -2,7 +2,11 @@
 
 const fs = require('fs');
 const path = require('path');
-const DEBUG = process.env['COMPILATION_MODE'] === 'dbg';
+const VERBOSE_LOGS = !!process.env['VERBOSE_LOGS'];
+
+function log_verbose(...m) {
+  if (VERBOSE_LOGS) console.error('[@bazel/create]', ...m);
+}
 
 /**
  * Detect if the user ran `yarn create @bazel` so we can default
@@ -73,10 +77,8 @@ function main(argv, error = console.error, log = console.log) {
   // Which package manager will be used in the new project
   const pkgMgr = args['packageManager'] || detectRunningUnderYarn() ? 'yarn' : 'npm';
 
-  if (DEBUG) {
-    log('Running with', process.argv);
-    log('Environment', process.env);
-  }
+  log_verbose('Running with', process.argv);
+  log_verbose('Environment', process.env);
 
   const [wkspDir] = args['_'];
   // TODO: user might want these to differ

--- a/packages/labs/src/webpack/webpack_bundle.bzl
+++ b/packages/labs/src/webpack/webpack_bundle.bzl
@@ -39,6 +39,7 @@ def _webpack_bundle(ctx):
         outputs = [ctx.outputs.bundle, ctx.outputs.sourcemap],
         arguments = [args],
         progress_message = "Bundling JavaScript %s [webpack]" % ctx.outputs.bundle.path,
+        env = {"COMPILATION_MODE": ctx.var["COMPILATION_MODE"]},
     )
     return [DefaultInfo()]
 

--- a/packages/rollup/test/version_stamp/BUILD.bazel
+++ b/packages/rollup/test/version_stamp/BUILD.bazel
@@ -22,4 +22,5 @@ golden_file_test(
     # Leave off the ".js" extension to test that it's the default output
     actual = "version_stamp",
     golden = "golden.js_",
+    golden_debug = "golden_debug.js_",
 )

--- a/packages/rollup/test/version_stamp/golden_debug.js_
+++ b/packages/rollup/test/version_stamp/golden_debug.js_
@@ -1,0 +1,7 @@
+/**
+ * @license A dummy license banner that goes at the top of the file.
+ * This is version v1.2.3_debug
+ */
+
+// License banner with version stamp will appear here
+console.error('stamp');

--- a/packages/rollup/test/version_stamp/rollup.config.js
+++ b/packages/rollup/test/version_stamp/rollup.config.js
@@ -1,3 +1,5 @@
+const DEBUG = process.env['COMPILATION_MODE'] === 'dbg';
+
 // Parse the stamp file produced by Bazel from the version control system
 let version = '<unknown>';
 if (bazel_stamp_file) {
@@ -8,6 +10,9 @@ if (bazel_stamp_file) {
   // Don't assume BUILD_SCM_VERSION exists
   if (versionTag) {
     version = 'v' + versionTag.split(' ')[1].trim();
+    if (DEBUG) {
+      version += '_debug';
+    }
   }
 }
 

--- a/packages/terser/src/terser_minified.bzl
+++ b/packages/terser/src/terser_minified.bzl
@@ -170,6 +170,7 @@ def _terser(ctx):
         outputs = outputs,
         executable = ctx.executable.terser_bin,
         arguments = [args],
+        env = {"COMPILATION_MODE": ctx.var["COMPILATION_MODE"]},
         progress_message = "Minifying JavaScript %s [terser]" % (outputs[0].short_path),
     )
 

--- a/packages/terser/test/inline_sourcemap/spec.js
+++ b/packages/terser/test/inline_sourcemap/spec.js
@@ -2,16 +2,16 @@ const fs = require('fs');
 const path = require('path');
 const sm = require('source-map');
 const {runfiles} = require('build_bazel_rules_nodejs/internal/linker');
-const DEBUG = process.env['COMPILATION_MODE'] === 'dbg';
 
 describe('terser sourcemap handling', () => {
   it('should produce a sourcemap output', async () => {
     const file = runfiles.resolvePackageRelative('out.min.js.map');
+    const debugBuild = /\/bazel-out\/[^/\s]*-dbg\//.test(file);
     const rawSourceMap = JSON.parse(fs.readFileSync(file, 'utf-8'));
     await sm.SourceMapConsumer.with(rawSourceMap, null, consumer => {
       // terser will produce different output based on DEBUG flag
       const pos =
-          consumer.originalPositionFor(!DEBUG ? {line: 1, column: 89} : {line: 6, column: 22});
+          consumer.originalPositionFor(!debugBuild ? {line: 1, column: 89} : {line: 6, column: 22});
       expect(pos.name).toBe('something');
       expect(pos.line).toBe(3);
       expect(pos.column).toBe(14);

--- a/packages/terser/test/sourcemap/directory_spec.js
+++ b/packages/terser/test/sourcemap/directory_spec.js
@@ -1,8 +1,6 @@
 const fs = require('fs');
 const sm = require('source-map');
-const path = require('path');
 const {runfiles} = require('build_bazel_rules_nodejs/internal/linker');
-const DEBUG = process.env['COMPILATION_MODE'] === 'dbg';
 
 describe('terser on a directory with map files', () => {
   it('should produce an output for each input', () => {
@@ -13,12 +11,13 @@ describe('terser on a directory with map files', () => {
   it('should produce a sourcemap output', async () => {
     const out = runfiles.resolvePackageRelative('dir.min');
     const file = require.resolve(out + '/src1.js.map');
+    const debugBuild = /\/bazel-out\/[^/\s]*-dbg\//.test(file);
     const rawSourceMap = JSON.parse(fs.readFileSync(file, 'utf-8'));
     await sm.SourceMapConsumer.with(rawSourceMap, null, consumer => {
       const pos = consumer.originalPositionFor(
           // position of MyClass in terser_minified output src1.min.js
           // depends on COMPILATION_MODE
-          !DEBUG ? {line: 1, column: 18} : {line: 3, column: 5});
+          !debugBuild ? {line: 1, column: 18} : {line: 3, column: 5});
       expect(pos.source).toBe('src1.ts');
       expect(pos.line).toBe(2);
       expect(pos.column).toBe(14);

--- a/packages/terser/test/sourcemap/terser_spec.js
+++ b/packages/terser/test/sourcemap/terser_spec.js
@@ -1,17 +1,17 @@
 const fs = require('fs');
 const sm = require('source-map');
 const DIR = 'build_bazel_rules_nodejs/packages/terser/test/sourcemap';
-const DEBUG = process.env['COMPILATION_MODE'] === 'dbg';
 
 describe('terser sourcemap handling', () => {
   it('should produce a sourcemap output', async () => {
     const file = require.resolve(DIR + '/src1.min.js.map');
+    const debugBuild = /\/bazel-out\/[^/\s]*-dbg\//.test(file);
     const rawSourceMap = JSON.parse(fs.readFileSync(file, 'utf-8'));
     await sm.SourceMapConsumer.with(rawSourceMap, null, consumer => {
       const pos = consumer.originalPositionFor(
           // position of MyClass in terser_minified output src1.min.js
           // depends on DEBUG flag
-          !DEBUG ? {line: 1, column: 18} : {line: 3, column: 5});
+          !debugBuild ? {line: 1, column: 18} : {line: 3, column: 5});
       expect(pos.source).toBe('src1.ts');
       expect(pos.line).toBe(2);
       expect(pos.column).toBe(14);

--- a/packages/typescript/src/internal/build_defs.bzl
+++ b/packages/typescript/src/internal/build_defs.bzl
@@ -156,6 +156,7 @@ def _compile_action(ctx, inputs, outputs, tsconfig_file, node_opts, description 
         execution_requirements = {
             "supports-workers": str(int(ctx.attr.supports_workers)),
         },
+        env = {"COMPILATION_MODE": ctx.var["COMPILATION_MODE"]},
     )
 
     # Enable the replay_params in case an aspect needs to re-build this library.


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_nodejs/issues/1446

----------------------
* fix: don't bake COMPILATION_MODE into launcher as exported environment var

This approach is incorrect as tools that are build for host such as "rollup_bin" in the rollup_bundle rule will see the --host_compilation_mode and not the --compilation_mode configuration value when built by Bazel as their cfg in the rule is correctly set to "host".

```
"rollup_bin": attr.label(
doc = "Target that executes the rollup binary",
executable = True,
cfg = "host",
default = "@npm//rollup/bin:rollup",
),
```

The correct approach is to pass COMPILATION_MODE via the actions.run env attribute.

For the rollup_bundle rollup_bin tool, this is passed via run_node:

```
def run_node(ctx, inputs, arguments, executable, **kwargs):
    """Helper to replace ctx.actions.run
    This calls node programs with a node_modules directory in place"""
    ....
    # Forward the COMPILATION_MODE to node process as an environment variable
    env = kwargs.pop("env", {})
    if "COMPILATION_MODE" not in env.keys():
        env["COMPILATION_MODE"] = ctx.var["COMPILATION_MODE"]

    ctx.actions.run(
        inputs = inputs + extra_inputs,
        arguments = arguments,
        executable = exec_exec,
        env = env,
        **kwargs
    )
```

----------------------
* test: bazel_integration_test should use --define=BAZEL_INTEGRATION_TEST_DEBUG=1 to go into debug mode

Run with --define=BAZEL_INTEGRATION_TEST_DEBUG=1 to put the test in debug mode which will
preserve the workspace under test root /tmp folder and exit without running the test so that
you can change directory into the workspace under test root folder and run the integration
test manually.

This is a different concept from --compilation_mode as this is meant to put the test into a debug mode rather than generate debug build artifacts.

----------------------
* fix(create): @bazel/create should verbose log based on VERBOSE_LOGS instead of COMPILATION_MODE

----------------------
* test(builtin): fix golden_file_test that check compilation_mode=dbg outputs

This test should not check COMPILATION_MODE since a test does not have a compilation_mode as all of the outputs have already been compiled. The test should determine if the output was debug/non-debug based on the bazel-out folder name of the file being checked.

----------------------
* test(terser): fix specs that check compilation_mode=dbg terser output

These specs should not check COMPILATION_MODE since a test does not have a compilation_mode as all of the outputs have already been compiled. The specs should determine if the output was debug/non-debug based on the bazel-out folder name of the file being checked.