### PR TITLE
Fix protractor & karma debugging

### DIFF
--- a/packages/karma/src/karma_web_test.bzl
+++ b/packages/karma/src/karma_web_test.bzl
@@ -268,7 +268,24 @@ if [[ ! -z "${{TEST_TMPDIR}}" && ! -n "${{BUILD_WORKSPACE_DIRECTORY}}" ]]; then
   ARGV+=( "--single-run" )
 fi
 
-$KARMA ${{ARGV[@]}}
+# Pass --node_options from args on karma node process
+NODE_OPTIONS=()
+for ARG in "$@"; do
+  case "$ARG" in
+    --node_options=*) NODE_OPTIONS+=( "${{ARG}}" ) ;;
+  esac
+done
+
+KARMA_VERSION=$(${{KARMA}} --version)
+
+printf "\n\n\n\nRunning karma tests\n-----------------------------------------------------------------------------\n"
+echo "version     :" ${{KARMA_VERSION#Karma version: }}
+echo "pwd         :" ${{PWD}}
+echo "conf        :" ${{CONF}}
+echo "node_options:" ${{NODE_OPTIONS[@]}}
+printf "\n"
+
+${{KARMA}} ${{ARGV[@]}} ${{NODE_OPTIONS[@]}}
 """.format(
             TMPL_workspace = ctx.workspace_name,
             TMPL_karma = _to_manifest_path(ctx, ctx.executable.karma),

--- a/packages/protractor/src/protractor_web_test.bzl
+++ b/packages/protractor/src/protractor_web_test.bzl
@@ -125,12 +125,24 @@ fi
 
 export HOME=$(mktemp -d)
 
-# Print the protractor version in the test log
-PROTRACTOR_VERSION=$($PROTRACTOR --version)
-echo "Protractor $PROTRACTOR_VERSION"
+# Pass --node_options from args on protractor node process
+NODE_OPTIONS=()
+for ARG in "$@"; do
+  case "$ARG" in
+    --node_options=*) NODE_OPTIONS+=( "${{ARG}}" ) ;;
+  esac
+done
 
-# Run the protractor binary
-$PROTRACTOR $CONF
+PROTRACTOR_VERSION=$(${{PROTRACTOR}} --version)
+
+printf "\n\n\n\nRunning protractor tests\n-----------------------------------------------------------------------------\n"
+echo "version     :" ${{PROTRACTOR_VERSION#Version }}
+echo "pwd         :" ${{PWD}}
+echo "conf        :" ${{CONF}}
+echo "node_options:" ${{NODE_OPTIONS[@]}}
+printf "\n"
+
+${{PROTRACTOR}} ${{CONF}} "${{NODE_OPTIONS[@]}}"
 """.format(
             TMPL_protractor = _to_manifest_path(ctx, ctx.executable.protractor),
             TMPL_conf = _to_manifest_path(ctx, configuration),


### PR DESCRIPTION
* fix(protractor): pass --node_options to protractor
This enables debugging protractor tests with --node_options=--inspect-brk

```
$ bazel run --config=debug //packages/protractor/test/protractor:test_chromium-local

...
Running protractor tests
-----------------------------------------------------------------------------
version     : 5.4.2
pwd         : /private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/execroot/build_bazel_rules_nodejs/bazel-out/darwin-dbg/bin/packages/protractor/test/protractor/test_chromium-local.sh.runfiles/build_bazel_rules_nodejs
conf        : ../build_bazel_rules_nodejs/packages/protractor/test/protractor/test_wrapped_test.conf.js
node_options: --node_options=--inspect-brk

Debugger listening on ws://127.0.0.1:9229/7244faba-d905-4072-b0ba-301f9a0e1648
For help, see: https://nodejs.org/en/docs/inspector
```

* fix(karma): pass --node_options to karma
This enables debugging karma tests with --node_options=--inspect-brk

```
$ bazel run --config=debug //packages/karma/test/stack_trace:karma_test_chromium-local

...
Running karma tests
-----------------------------------------------------------------------------
version     : 4.1.0
pwd         : /private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/execroot/build_bazel_rules_nodejs/bazel-out/darwin-dbg/bin/packages/karma/test/stack_trace/karma_test_chromium-local.sh.runfiles/build_bazel_rules_nodejs
conf        : ../build_bazel_rules_nodejs/packages/karma/test/stack_trace/karma_test_wrapped_test.conf.js
node_options: --node_options=--inspect-brk

Debugger listening on ws://127.0.0.1:9229/6000798d-e54e-4ecb-a0f1-733f4ab445c3
For help, see: https://nodejs.org/en/docs/inspector
```