### PR TITLE
presubmit.yml: Set skip_use_bazel_version_for_test: true

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -48,6 +48,8 @@ tasks:
     - "--build_tag_filters=e2e"
     build_targets:
     - "//..."
+    # We control Bazel version in integration tests, so we don't need USE_BAZEL_VERSION for tests.
+    skip_use_bazel_version_for_test: true
     test_flags:
     - "--test_tag_filters=e2e"
     - "--local_resources=792,1.0,1.0"
@@ -76,6 +78,8 @@ tasks:
     - "--build_tag_filters=examples"
     build_targets:
     - "//..."
+    # We control Bazel version in integration tests, so we don't need USE_BAZEL_VERSION for tests.
+    skip_use_bazel_version_for_test: true
     test_flags:
     - "--test_tag_filters=examples"
     - "--local_resources=792,1.0,1.0"
@@ -156,6 +160,8 @@ tasks:
     - "--build_tag_filters=e2e"
     build_targets:
     - "//..."
+    # We control Bazel version in integration tests, so we don't need USE_BAZEL_VERSION for tests.
+    skip_use_bazel_version_for_test: true
     test_flags:
     - "--test_tag_filters=e2e"
     - "--local_resources=792,1.0,1.0"
@@ -184,6 +190,8 @@ tasks:
     - "--build_tag_filters=examples"
     build_targets:
     - "//..."
+    # We control Bazel version in integration tests, so we don't need USE_BAZEL_VERSION for tests.
+    skip_use_bazel_version_for_test: true
     test_flags:
     - "--test_tag_filters=examples"
     - "--local_resources=792,1.0,1.0"
@@ -274,6 +282,8 @@ tasks:
     - "--build_tag_filters=e2e"
     build_targets:
     - "//..."
+    # We control Bazel version in integration tests, so we don't need USE_BAZEL_VERSION for tests.
+    skip_use_bazel_version_for_test: true
     test_flags:
     - "--test_tag_filters=e2e"
     - "--local_resources=792,1.0,1.0"
@@ -300,6 +310,8 @@ tasks:
     - "--build_tag_filters=examples"
     build_targets:
     - "//..."
+    # We control Bazel version in integration tests, so we don't need USE_BAZEL_VERSION for tests.
+    skip_use_bazel_version_for_test: true
     test_flags:
     - "--test_tag_filters=examples,-manual"
     - "--local_resources=792,1.0,1.0"
@@ -373,6 +385,8 @@ tasks:
     - "--build_tag_filters=e2e,-fix-windows"
     build_targets:
     - "//..."
+    # We control Bazel version in integration tests, so we don't need USE_BAZEL_VERSION for tests.
+    skip_use_bazel_version_for_test: true
     test_flags:
     - "--test_tag_filters=e2e,-fix-windows"
     - "--local_resources=792,1.0,1.0"
@@ -392,6 +406,8 @@ tasks:
     - "--build_tag_filters=examples,-fix-windows"
     build_targets:
     - "//..."
+    # We control Bazel version in integration tests, so we don't need USE_BAZEL_VERSION for tests.
+    skip_use_bazel_version_for_test: true
     test_flags:
     - "--test_tag_filters=examples,-manual,-fix-windows,-no-bazelci-windows"
     - "--local_resources=792,1.0,1.0"


### PR DESCRIPTION
rules_nodejs is currently failing in Bazel's Downstream Pipeline due to https://github.com/bazelbuild/bazel/issues/10554
We need this change to tell Bazel CI to not pass `--test_env=USE_BAZEL_VERSION` for Angular's integration tests.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

