### PR TITLE
@bazel/runfiles module

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -89,6 +89,7 @@ pkg_npm(
         "//internal/pkg_npm:package_contents",
         "//internal/pkg_web:package_contents",
         "//internal/providers:package_contents",
+        "//internal/runfiles:package_contents",
         "//third_party/github.com/bazelbuild/bazel-skylib:package_contents",
         "//third_party/github.com/buffer-from:package_contents",
         "//third_party/github.com/gjtorikian/isBinaryFile:package_contents",
@@ -113,4 +114,9 @@ pkg_tar(
     extension = "tar.gz",
     strip_prefix = "./rules_nodejs_package",
     tags = ["manual"],
+)
+
+alias(
+    name = "runfiles",
+    actual = "//internal/runfiles:runfiles_helper",
 )

--- a/examples/closure/BUILD.bazel
+++ b/examples/closure/BUILD.bazel
@@ -16,6 +16,9 @@ google_closure_compiler(
 
 nodejs_test(
     name = "test",
-    data = ["bundle.js"],
+    data = [
+        "bundle.js",
+        "@build_bazel_rules_nodejs//:runfiles",
+    ],
     entry_point = "test.js",
 )

--- a/examples/closure/test.js
+++ b/examples/closure/test.js
@@ -1,4 +1,4 @@
-const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
+const runfiles = require('@bazel/runfiles');
 
 const closureOutput = runfiles.resolve('examples_closure/bundle.js');
 

--- a/internal/linker/BUILD.bazel
+++ b/internal/linker/BUILD.bazel
@@ -20,10 +20,7 @@ bzl_library(
 )
 
 # END-INTERNAL
-exports_files([
-    "index.js",
-    "runfiles_helper.js",
-])
+exports_files(["index.js"])
 
 filegroup(
     name = "package_contents",

--- a/internal/linker/index.js
+++ b/internal/linker/index.js
@@ -28,10 +28,10 @@
     const VERBOSE_LOGS = !!process.env['VERBOSE_LOGS'];
     function log_verbose(...m) {
         if (VERBOSE_LOGS)
-            console.error('[link_node_modules.js]', ...m);
+            console.error('[link_node_modules.ts]', ...m);
     }
     function log_error(...m) {
-        console.error('[link_node_modules.js]', ...m);
+        console.error('[link_node_modules.ts]', ...m);
     }
     function panic(m) {
         throw new Error(`Internal error! Please run again with

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -10,11 +10,11 @@ import * as path from 'path';
 const VERBOSE_LOGS = !!process.env['VERBOSE_LOGS'];
 
 function log_verbose(...m: string[]) {
-  if (VERBOSE_LOGS) console.error('[link_node_modules.js]', ...m);
+  if (VERBOSE_LOGS) console.error('[link_node_modules.ts]', ...m);
 }
 
 function log_error(...m: string[]) {
-  console.error('[link_node_modules.js]', ...m);
+  console.error('[link_node_modules.ts]', ...m);
 }
 
 function panic(m: string) {

--- a/internal/linker/runfiles_helper.js
+++ b/internal/linker/runfiles_helper.js
@@ -1,1 +1,0 @@
-module.exports = require('./index.js').runfiles;

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -473,7 +473,7 @@ jasmine_node_test(
         allow_single_file = True,
     ),
     "_runfiles_helper_script": attr.label(
-        default = Label("//internal/linker:runfiles_helper.js"),
+        default = Label("//internal/runfiles:index.js"),
         allow_single_file = True,
     ),
     "_source_map_support_files": attr.label_list(

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -250,6 +250,7 @@ nodejs_test(
     data = [
         "dir_output",
         "minified.js",
+        "//:runfiles",
     ],
     entry_point = "npm_package_bin.spec.js",
 )

--- a/internal/node/test/npm_package_bin.spec.js
+++ b/internal/node/test/npm_package_bin.spec.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
+const runfiles = require('@bazel/runfiles');
 
 const min_js = path.join(runfiles.resolvePackageRelative('minified.js'));
 const content = fs.readFileSync(min_js, 'utf-8');

--- a/internal/runfiles/BUILD.bazel
+++ b/internal/runfiles/BUILD.bazel
@@ -1,0 +1,23 @@
+load("//internal/js_library:js_library.bzl", "js_library")
+
+exports_files(
+    ["index.js"],
+)
+
+js_library(
+    name = "runfiles_helper",
+    srcs = ["index.js"],
+    module_name = "@bazel/runfiles",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package_contents",
+    srcs = glob([
+        "*.bzl",
+        "*.js",
+    ]) + [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__pkg__"],
+)

--- a/internal/runfiles/index.js
+++ b/internal/runfiles/index.js
@@ -1,0 +1,1 @@
+module.exports = require('build_bazel_rules_nodejs/internal/linker').runfiles;


### PR DESCRIPTION
Adds a `@build_bazel_rules_nodejs//:runfiles` target that when added as a dep to nodejs_binary or nodejs_test makes the `@bazel/runfiles` module available.

For example (from /examples/closure):
BUILD.bazel
```
nodejs_test(
    name = "test",
    data = [
        "bundle.js",
        "@build_bazel_rules_nodejs//:runfiles",
    ],
    entry_point = "test.js",
)
```

test.js
```
const runfiles = require('@bazel/runfiles');
const closureOutput = runfiles.resolve('examples_closure/bundle.js');
```

