### PR TITLE
refactor: use runfiles = require(process.env['BAZEL_NODE_RUNFILES_HEL…

### DIFF
--- a/examples/closure/test.js
+++ b/examples/closure/test.js
@@ -1,4 +1,4 @@
-const {runfiles} = require('build_bazel_rules_nodejs/internal/linker');
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
 
 const closureOutput = runfiles.resolve('examples_closure/bundle.js');
 

--- a/internal/node/test/npm_package_bin.spec.js
+++ b/internal/node/test/npm_package_bin.spec.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const {runfiles} = require('build_bazel_rules_nodejs/internal/linker');
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
 
 const min_js = path.join(runfiles.resolvePackageRelative('minified.js'));
 const content = fs.readFileSync(min_js, 'utf-8');

--- a/internal/pkg_npm/test/pkg_npm.spec.js
+++ b/internal/pkg_npm/test/pkg_npm.spec.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const {runfiles} = require('build_bazel_rules_nodejs/internal/linker');
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
 
 function read(p) {
   // We want to look up the test_pkg directory artifact in the runfiles.

--- a/packages/rollup/test/code_splitting/spec.js
+++ b/packages/rollup/test/code_splitting/spec.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const {runfiles} = require('build_bazel_rules_nodejs/internal/linker');
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
 
 describe('rollup code splitting', () => {
   it('should produce a chunk for lazy loaded code', () => {

--- a/packages/rollup/test/multiple_entry_points/spec.js
+++ b/packages/rollup/test/multiple_entry_points/spec.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const {runfiles} = require('build_bazel_rules_nodejs/internal/linker');
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
 
 describe('rollup multiple entry points', () => {
   it('should produce a chunk for each entry point', () => {

--- a/packages/rollup/test/sourcemaps/spec.js
+++ b/packages/rollup/test/sourcemaps/spec.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const sm = require('source-map');
-const {runfiles} = require('build_bazel_rules_nodejs/internal/linker');
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
 
 describe('rollup sourcemap handling', () => {
   it('should produce a sourcemap output', async () => {

--- a/packages/terser/test/directory_input/spec.js
+++ b/packages/terser/test/directory_input/spec.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const {runfiles} = require('build_bazel_rules_nodejs/internal/linker');
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
 
 describe('terser on a directory', () => {
   it('should produce an output for each input', () => {

--- a/packages/terser/test/inline_sourcemap/spec.js
+++ b/packages/terser/test/inline_sourcemap/spec.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const sm = require('source-map');
-const {runfiles} = require('build_bazel_rules_nodejs/internal/linker');
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
 
 describe('terser sourcemap handling', () => {
   it('should produce a sourcemap output', async () => {

--- a/packages/terser/test/sourcemap/directory_spec.js
+++ b/packages/terser/test/sourcemap/directory_spec.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const sm = require('source-map');
-const {runfiles} = require('build_bazel_rules_nodejs/internal/linker');
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
 
 describe('terser on a directory with map files', () => {
   it('should produce an output for each input', () => {

--- a/packages/typescript/test/googmodule/googmodule_output_test.js
+++ b/packages/typescript/test/googmodule/googmodule_output_test.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const {runfiles} = require('build_bazel_rules_nodejs/internal/linker');
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
 
 describe('googmodule', () => {
   let output;


### PR DESCRIPTION
…PER']) in tests

Instead of loading from the linker: const {runfiles} = require('build_bazel_rules_nodejs/internal/linker');

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

