### PR TITLE
feat(builtin): add configuration_env_vars to npm_package_bin

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,6 +24,7 @@ build --noincompatible_no_support_tools_in_action_inputs
 # Define environment value used by some tests such as //internal/npm_install/test:bazel_bin_test
 build --define=SOME_TEST_ENV=some_value
 test --define=SOME_TEST_ENV=some_value
+build --action_env=SOME_OTHER_ENV=some_other_value
 
 ###############################
 # Remote Build Execution support

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@
 ## IMPORTANT
 # If you change the `default_docker_image` version, also change the `cache_key` version
 var_1: &default_docker_image circleci/node:10.16
-var_3: &cache_key node-0.16-{{ checksum "yarn.lock" }}
+var_3: &cache_key node-0.16-{{ checksum "yarn.lock" }}-v2
 
 var_4: &init_environment
   run:

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -178,8 +178,13 @@ def _nodejs_binary_impl(ctx):
     env_vars = "export BAZEL_TARGET=%s\n" % ctx.label
     env_vars += "export BAZEL_WORKSPACE=%s\n" % ctx.workspace_name
     for k in ctx.attr.configuration_env_vars + ctx.attr.default_env_vars:
+        # Check ctx.var first & if env var not in there then check
+        # ctx.configuration.default_shell_env. The former will contain values from --define=FOO=BAR
+        # and latter will contain values from --action_env=FOO=BAR (but not from --action_env=FOO).
         if k in ctx.var.keys():
             env_vars += "export %s=\"%s\"\n" % (k, ctx.var[k])
+        elif k in ctx.configuration.default_shell_env.keys():
+            env_vars += "export %s=\"%s\"\n" % (k, ctx.configuration.default_shell_env[k])
 
     expected_exit_code = 0
     if hasattr(ctx.attr, "expected_exit_code"):

--- a/internal/node/npm_package_bin.bzl
+++ b/internal/node/npm_package_bin.bzl
@@ -9,6 +9,7 @@ load("//internal/linker:link_node_modules.bzl", "module_mappings_aspect")
 _ATTRS = {
     "outs": attr.output_list(),
     "args": attr.string_list(mandatory = True),
+    "configuration_env_vars": attr.string_list(default = []),
     "data": attr.label_list(allow_files = True, aspects = [module_mappings_aspect, node_modules_aspect]),
     "output_dir": attr.bool(),
     "tool": attr.label(
@@ -57,6 +58,7 @@ def _impl(ctx):
         inputs = inputs,
         outputs = outputs,
         arguments = [args],
+        configuration_env_vars = ctx.attr.configuration_env_vars,
     )
     return [DefaultInfo(files = depset(outputs))]
 

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -70,7 +70,10 @@ nodejs_binary(
 
 nodejs_test(
     name = "define_var",
-    configuration_env_vars = ["SOME_TEST_ENV"],
+    configuration_env_vars = [
+        "SOME_TEST_ENV",
+        "SOME_OTHER_ENV",
+    ],
     data = glob(["*.spec.js"]),
     entry_point = ":define.spec.js",
 )
@@ -271,6 +274,7 @@ npm_package_bin(
         "$@",
         "$(SOME_TEST_ENV)",
     ],
+    configuration_env_vars = ["SOME_OTHER_ENV"],
     tool = ":expand_variables",
 )
 

--- a/internal/node/test/define.spec.js
+++ b/internal/node/test/define.spec.js
@@ -6,3 +6,11 @@ if (process.env['SOME_TEST_ENV'] !== 'some_value') {
   console.error('should accept vars; must be run with --define=SOME_TEST_ENV=some_value');
   process.exitCode = 1;
 }
+
+// Similar to above but testing another env variable that is expected to be specified with
+// `--action_env=SOME_OTHER_ENV=some_other_value`.
+if (process.env['SOME_OTHER_ENV'] !== 'some_other_value') {
+  console.error(
+      'should accept vars; must be run with --action_env=SOME_OTHER_ENV=some_other_value');
+  process.exitCode = 1;
+}

--- a/internal/node/test/expand_variables.golden
+++ b/internal/node/test/expand_variables.golden
@@ -1,3 +1,4 @@
 [
-  "some_value"
+  "some_value",
+  "some_other_value"
 ]

--- a/internal/node/test/expand_variables.js
+++ b/internal/node/test/expand_variables.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
 const args = process.argv.slice(2);
 const outfile = args.shift();
+args.push(process.env['SOME_OTHER_ENV']);
 fs.writeFileSync(outfile, JSON.stringify(args, null, 2), 'utf-8');

--- a/internal/npm_install/test/bazel_bin_test.sh
+++ b/internal/npm_install/test/bazel_bin_test.sh
@@ -12,8 +12,9 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 # --- end runfiles.bash initialization v2 ---
 
 readonly OUT=$($(rlocation "npm/testy/bin/testy.sh"))
+readonly EXPECTED="Hello some_value && some_other_value"
 
-if [ "$OUT" != "Hello some_value" ]; then
-  echo "Expected output 'Hello world' but was '$OUT'"
+if [ "${OUT}" != "${EXPECTED}" ]; then
+  echo "Expected output '${EXPECTED}' but was '${OUT}'"
   exit 1
 fi

--- a/tools/npm_packages/testy/index.js
+++ b/tools/npm_packages/testy/index.js
@@ -1,1 +1,1 @@
-console.log(`Hello ${process.env['SOME_TEST_ENV']}`);
+console.log(`Hello ${process.env['SOME_TEST_ENV']} && ${process.env['SOME_OTHER_ENV']}`);

--- a/tools/npm_packages/testy/package.json
+++ b/tools/npm_packages/testy/package.json
@@ -7,7 +7,7 @@
   "bazelBin": {
     "testy": {
       "additionalAttributes": {
-        "configuration_env_vars": "[\"SOME_TEST_ENV\"]"
+        "configuration_env_vars": "[\"SOME_TEST_ENV\", \"SOME_OTHER_ENV\"]"
       }
     }
   }


### PR DESCRIPTION
This behaves similarly to `configuration_env_vars` in `nodejs_binary` except it passes the env vars to the process via the `env` attribute of `ctx.actions.run`.

Also add support for picking up env vars from `ctx.configuration.default_shell_env` if they are not found in `ctx.vars`.

* `ctx.vars` will contain values from `--define=FOO=BAR`
* `ctx.configuration.default_shell_env` will `--action_env=FOO=BAR` (but not from `--action_env=FOO`).

-----------

test: add test coverage for npm_package_bin configuration_env_vars

And test coverage for using --action_env=FOO=BAR to pass env variables to npm_package_bin & nodejs_binary