### PR TITLE
Do not error with unbound variable when running karma web test with `bazel run`

### DIFF
--- a/packages/karma/src/karma_web_test.bzl
+++ b/packages/karma/src/karma_web_test.bzl
@@ -258,7 +258,7 @@ ARGV=( "start" ${{CONF}} )
 # variables. See go/test-encyclopedia
 # Note: in Bazel 0.14 and later, TEST_TMPDIR is set for both bazel test and bazel run
 # so we also check for the BUILD_WORKSPACE_DIRECTORY which is set only for bazel run
-if [[ ! -z "${{TEST_TMPDIR}}" && ! -n "${{BUILD_WORKSPACE_DIRECTORY:-}}" ]]; then
+if [[ ! -z "${{TEST_TMPDIR:-}}" && ! -n "${{BUILD_WORKSPACE_DIRECTORY:-}}" ]]; then
   ARGV+=( "--single-run" )
 fi
 


### PR DESCRIPTION
Previously, running a web test target with `bazel run` worked, and didn't result in an unbound variable exception. Now with the new runfile bash helpers v2, unbound variables are reported, and in `bazel run` the `TEST_TMPDIR` variable is not set.

There are two ways to fix this: (1) allowing unbound variables by running `set +u` after the helpers, or (2) by just properly handling unbound variables. The latter seems more future-proof to me and best practice.