### PR TITLE
test: check that ts_library @npm strict deps work

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "@types/hammerjs": "2.0.35",
         "@types/jasmine": "~3.3.13",
         "@types/node": "10.12.20",
+        "@types/semver": "6.2.0",
         "bazel_workspaces": "file:./tools/npm_packages/bazel_workspaces",
         "clang-format": "1.2.2",
         "conventional-changelog-cli": "^2.0.21",

--- a/packages/typescript/test/strict_deps/BUILD
+++ b/packages/typescript/test/strict_deps/BUILD
@@ -22,7 +22,17 @@ ts_library(
 ts_library(
     name = "parent",
     srcs = ["parent.ts"],
-    deps = [":grandparent"],
+    # NB: We don't require the `@npm//semver` package for the typescript compile
+    # action as the .d.ts files live in @types/semver. If the resulting
+    # .js file is run downstream in a nodejs_binary rule, however, the
+    # `@npm//semver` dep will be required at that point.
+    # TODO: Is it desirable to automatically add @npm//semver as a transitive
+    #       dep if @npm//@types/semver is a dep so that downtream nodejs_binary
+    #       rules get this automatically?
+    deps = [
+        ":grandparent",
+        "@npm//@types/semver",
+    ],
 )
 
 ts_library(
@@ -30,6 +40,15 @@ ts_library(
     srcs = ["child.ts"],
     expected_diagnostics = [
         "TS2307:child\.ts\(2,.*transitive dependency.*not allowed",
+    ],
+    deps = [":parent"],
+)
+
+ts_library(
+    name = "strict_deps_npm",
+    srcs = ["child2.ts"],
+    expected_diagnostics = [
+        "TS2307:child2\.ts\(2,.*transitive dependency.*not allowed",
     ],
     deps = [":parent"],
 )

--- a/packages/typescript/test/strict_deps/child.ts
+++ b/packages/typescript/test/strict_deps/child.ts
@@ -1,4 +1,4 @@
-// The line below is a strict deps violation:
+// The line below is a strict deps violation of a ts_library dep
 import {Symbol} from './grandparent';
 
 console.log(Symbol);

--- a/packages/typescript/test/strict_deps/child2.ts
+++ b/packages/typescript/test/strict_deps/child2.ts
@@ -1,5 +1,5 @@
+// The line below is a strict deps violation of an @npm dep
 import * as semver from 'semver';
-import {Symbol} from './grandparent';
 semver.valid('1.2.3');
-export const x = 1;
+
 console.log(Symbol);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,6 +1050,11 @@
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.16.tgz#50a4755f8e33edacd9c406729e9b930d2451902a"
   integrity sha512-lMC2G0ItF2xv4UCiwbJGbnJlIuUixHrioOhNGHSCsYCJ8l4t9hMCUimCytvFv7qy6AfSzRxhRHoGa+UqaqwyeA==
 
+"@types/semver@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.0.tgz#d688d574400d96c5b0114968705366f431831e1a"
+  integrity sha512-1OzrNb4RuAzIT7wHSsgZRlMBlNsJl+do6UblR7JMW4oB7bbR+uBEYtUh7gEc/jM84GGilh68lSOokyM/zNUlBA==
+
 "@types/semver@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.0.1.tgz#a984b405c702fa5a7ec6abc56b37f2ba35ef5af6"
@@ -2403,7 +2408,7 @@ debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -3723,7 +3728,7 @@ import-lazy@^2.1.0:
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
   integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -4610,11 +4615,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4623,32 +4623,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -4669,11 +4647,6 @@ lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.template@^4.0.2:
   version "4.5.0"


### PR DESCRIPTION
Add missing coverage to verify that ts_library strict deps of @npm dependencies works

I added a comment as something to think about:
```
    # NB: We don't require the `@npm//semver` package for the typescript compile
    # action as the .d.ts files live in @types/semver. If the resulting
    # .js file is run downstream in a nodejs_binary rule, however, the
    # `@npm//semver` dep will be required at that point.
    # TODO: Is it desirable to automatically add @npm//semver as a transitive
    #       dep if @npm//@types/semver is a dep so that downtream nodejs_binary
    #       rules get this automatically?
```
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Missing test coverage added for existing feature


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

