### PR TITLE
fixes bazelbuild/rules_nodejs#1567 Recursively copy files from subdir…

### DIFF
--- a/internal/pkg_npm/packager.js
+++ b/internal/pkg_npm/packager.js
@@ -31,7 +31,14 @@ function mkdirp(p) {
 
 function copyWithReplace(src, dest, substitutions, renameBuildFiles) {
   mkdirp(path.dirname(dest));
-  if (!isBinary(src)) {
+  if (fs.lstatSync(src).isDirectory()) {
+    const files = fs.readdirSync(src)
+    files.forEach((relativeChildSrc) => {
+      const childSrc = path.join(src, relativeChildSrc);
+      const childDest = path.join(dest, path.basename(childSrc));
+      copyWithReplace(childSrc, childDest, substitutions, renameBuildFiles);
+    });
+  } else if (!isBinary(src)) {
     let content = fs.readFileSync(src, {encoding: 'utf-8'});
     substitutions.forEach(r => {
       const [regexp, newvalue] = r;

--- a/internal/pkg_npm/test/BUILD.bazel
+++ b/internal/pkg_npm/test/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("@npm_bazel_jasmine//:index.from_src.bzl", "jasmine_node_test")
+load("@npm_bazel_rollup//:index.from_src.bzl", "rollup_bundle")
 load("@npm_bazel_typescript//:index.from_src.bzl", "ts_library")
 load("//internal/node:context.bzl", "node_context_data")
 load("//third_party/github.com/bazelbuild/bazel-skylib:rules/write_file.bzl", "write_file")
@@ -14,6 +15,15 @@ ts_library(
     name = "ts_library",
     srcs = ["foo.ts"],
     data = ["data.json"],
+)
+
+rollup_bundle(
+    name = "rollup/bundle/subdirectory",
+    entry_points = {
+        "foo.ts": "index",
+    },
+    output_dir = True,
+    deps = [":ts_library"],
 )
 
 pkg_npm(
@@ -44,6 +54,7 @@ pkg_npm(
     deps = [
         ":bundle.min.js",
         ":produces_files",
+        ":rollup/bundle/subdirectory",
         ":ts_library",
         "@internal_npm_package_test_vendored_external//:ts_library",
     ],

--- a/internal/pkg_npm/test/pkg_npm.spec.js
+++ b/internal/pkg_npm/test/pkg_npm.spec.js
@@ -51,4 +51,7 @@ describe('pkg_npm srcs', () => {
          // TODO(alexeagle): there isn't a way to test this yet, because the pkg_npm under test
          // has to live in the root of the repository in order for external/foo to appear inside it
      });
+  it('copies entire contents of directories',
+     () => {expect(read('rollup/bundle/subdirectory/index.js'))
+                .toContain(`const a = '';\n\nexport { a }`)});
 });


### PR DESCRIPTION
…ectories into mirrored structure in the npm archive.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) 
> I don't think there are any relevant documentation updates for this fix. I think it was the expected behavior.


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1567 


## What is the new behavior?

Directories can be copied into a mirror structure inside the npm archive. Presumably these directories would be created using the `declare_directory` action.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

