### PR TITLE
fix: unset YARN_IGNORE_PATH in yarn_install before calling yarn

### DIFF
--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -339,12 +339,18 @@ def _yarn_install_impl(repository_ctx):
 
     # The entry points for npm install for osx/linux and windows
     if not is_windows_host:
-        # Prefix filenames with _ so they don't conflict with the npm packages
+        # Prefix filenames with _ so they don't conflict with the npm packages.
+        # Unset YARN_IGNORE_PATH before calling yarn incase it is set so that
+        # .yarnrc yarn-path is followed if set. This is for the case when calling
+        # bazel from yarn with `yarn bazel ...` and yarn follows yarn-path in
+        # .yarnrc it will set YARN_IGNORE_PATH=1 which will prevent the bazel
+        # call into yarn from also following the yarn-path as desired.
         repository_ctx.file(
             "_yarn.sh",
             content = """#!/usr/bin/env bash
 # Immediately exit if any command fails.
 set -e
+unset YARN_IGNORE_PATH
 (cd "{root}"; "{yarn}" {yarn_args})
 """.format(
                 root = root,
@@ -357,6 +363,7 @@ set -e
         repository_ctx.file(
             "_yarn.cmd",
             content = """@echo off
+set "YARN_IGNORE_PATH=" 
 cd "{root}" && "{yarn}" {yarn_args}
 """.format(
                 root = root,


### PR DESCRIPTION
Unset YARN_IGNORE_PATH before calling yarn incase it is set so that
.yarnrc yarn-path is followed if set. This is for the case when calling
bazel from yarn with `yarn bazel ...` and yarn follows yarn-path in
.yarnrc it will set YARN_IGNORE_PATH=1 which will prevent the bazel
call into yarn from also following the yarn-path as desired.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

