### PR TITLE
fix(builtin): strip leading v prefix from stamp

### DIFF
--- a/internal/pkg_npm/packager.js
+++ b/internal/pkg_npm/packager.js
@@ -96,7 +96,7 @@ function main(args) {
                              .find(s => s.startsWith('BUILD_SCM_VERSION'));
       // Don't assume BUILD_SCM_VERSION exists
       if (versionTag) {
-        version = versionTag.split(' ')[1].trim();
+        version = versionTag.split(' ')[1].replace(/^v/, '').trim();
       }
     }
     substitutions.push([new RegExp(replaceWithVersion, 'g'), version]);


### PR DESCRIPTION
Some repos like bazelisk use a --workspace_status_command that returns tags from the repo, and their tagging scheme starts with a v prefix. We should strip that before turning it into an npm version number, which should always be numeric.