### PR TITLE
change ts_proto_library to default es5 wrapping

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -276,3 +276,8 @@ load("@build_bazel_integration_testing//tools:repositories.bzl", "bazel_binaries
 
 # Depend on the Bazel binaries
 bazel_binaries(versions = [BAZEL_VERSION])
+
+# Install labs dependencies
+load("@npm_bazel_labs//:package.bzl", "npm_bazel_labs_dependencies")
+
+npm_bazel_labs_dependencies()

--- a/packages/labs/src/protobufjs/ts_proto_library.bzl
+++ b/packages/labs/src/protobufjs/ts_proto_library.bzl
@@ -15,7 +15,7 @@
 
 load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "JSEcmaScriptModuleInfo", "JSNamedModuleInfo")
 
-def _run_pbjs(actions, executable, var, output_name, proto_files, suffix = ".js", wrap = "amd", amd_name = ""):
+def _run_pbjs(actions, executable, var, output_name, proto_files, suffix = ".js", wrap = "default", amd_name = ""):
     js_file = actions.declare_file(output_name + suffix)
 
     # Create an intermediate file so that we can do some manipulation of the

--- a/packages/labs/test/protobufjs/BUILD.bazel
+++ b/packages/labs/test/protobufjs/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@npm_bazel_jasmine//:index.from_src.bzl", "jasmine_node_test")
+load("@npm_bazel_labs//:index.bzl", "ts_proto_library")
+load("@npm_bazel_typescript//:index.from_src.bzl", "ts_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+ts_library(
+    name = "test",
+    srcs = ["test.ts"],
+    deps = [
+        ":test_ts_proto",
+        "@npm//@types/jasmine",
+    ],
+)
+
+proto_library(
+    name = "test_proto",
+    srcs = [":test.proto"],
+)
+
+ts_proto_library(
+    name = "test_ts_proto",
+    deps = [":test_proto"],
+)
+
+jasmine_node_test(
+    name = "protobuf_test",
+    srcs = [":test"],
+    deps = [
+        "@npm//protobufjs",
+    ],
+)

--- a/packages/labs/test/protobufjs/test.proto
+++ b/packages/labs/test/protobufjs/test.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message TestMessage {
+  string test_field = 1;
+}

--- a/packages/labs/test/protobufjs/test.ts
+++ b/packages/labs/test/protobufjs/test.ts
@@ -1,7 +1,5 @@
 import {TestMessage} from 'build_bazel_rules_nodejs/packages/labs/test/protobufjs/test_ts_proto';
 
-// const TestMessage = build_bazel_rules_nodejs.packages.labs.test.protobufjs.TestMessage;
-
 describe('protobufjs', () => {
   it('should work in node', () => {
     expect(TestMessage.verify({

--- a/packages/labs/test/protobufjs/test.ts
+++ b/packages/labs/test/protobufjs/test.ts
@@ -1,0 +1,11 @@
+import {TestMessage} from 'build_bazel_rules_nodejs/packages/labs/test/protobufjs/test_ts_proto';
+
+// const TestMessage = build_bazel_rules_nodejs.packages.labs.test.protobufjs.TestMessage;
+
+describe('protobufjs', () => {
+  it('should work in node', () => {
+    expect(TestMessage.verify({
+      testField: 'Hello',
+    })).toBeFalsy();  // verify returns an error if failed
+  });
+});


### PR DESCRIPTION
This change wraps es5 sources generated with `ts_proto_library` to be wrapped in "default" mode. The "default" mode behaves like UMD, supporting both AMD and CommonJS. This change is necessary to support Node, as Node does not use AMD. Fixes #562

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using `ts_proto_library`, the application fails at runtime with `ReferenceError: define is not defined`
Issue Number: #562


## What is the new behavior?
Works in Node - `ts_proto_library` will now emit UMD modules instead of AMD.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

