### PR TITLE
fix(builtin): fix logic error in linker conflict resolution

### DIFF
--- a/internal/linker/link_node_modules.bzl
+++ b/internal/linker/link_node_modules.bzl
@@ -43,7 +43,7 @@ def _link_mapping(label, mappings, k, v):
             #    v           = ["bin", "angular/packages/compiler"]
             if mappings[k][0] == "runfiles":
                 return True
-            elif v[0] != "runfiles":
+            elif v[0] == "runfiles":
                 return False
         fail(("conflicting mapping at %s: %s maps to both %s and %s" % (label, k, mappings[k], v)), "deps")
     else:

--- a/internal/linker/test/integration/BUILD.bazel
+++ b/internal/linker/test/integration/BUILD.bazel
@@ -77,9 +77,13 @@ linked(
     testonly = True,
     out = "actual_with_conflicts",
     program = ":run_program",
+    # do not sort
     deps = [
         # NB: reference the copy of index.js in the output folder
         "//%s/absolute_import:copy_to_bin" % package_name(),
+        # Intentinally include this before static_linked_pkg as order matters for the linker.
+        # The order here exercises a different code path in the linker conflict resolution logic
+        # than `example_with_conflicts_alt`.
         ":run_program",
         # NB: static_linked maps to both
         # ["runfiles", "build_bazel_rules_nodejs/internal/linker/test/integration/static_linked_pkg"] and
@@ -97,6 +101,35 @@ linked(
     ],
 )
 
+linked(
+    name = "example_with_conflicts_alt",
+    testonly = True,
+    out = "actual_with_conflicts_alt",
+    program = ":run_program",
+    # do not sort
+    deps = [
+        # NB: reference the copy of index.js in the output folder
+        "//%s/absolute_import:copy_to_bin" % package_name(),
+        # NB: static_linked maps to both
+        # ["runfiles", "build_bazel_rules_nodejs/internal/linker/test/integration/static_linked_pkg"] and
+        # ["bin", "build_bazel_rules_nodejs/internal/linker/test/integration/static_linked_pkg"]
+        # as the "runfiles" mapping comes from `:run_program`
+        "//internal/linker/test/integration/static_linked_pkg",
+        # NB: @linker_scoped/static_linked maps to both
+        # ["runfiles", "build_bazel_rules_nodejs/internal/linker/test/integration/static_linked_scoped_pkg"] and
+        # ["src", "build_bazel_rules_nodejs/internal/linker/test/integration/static_linked_scoped_pkg"]
+        # as the "runfiles" mapping comes from `:run_program`
+        "//internal/linker/test/integration/static_linked_scoped_pkg",
+        # Intentinally include this before static_linked_pkg as order matters for the linker.
+        # The order here exercises a different code path in the linker conflict resolution logic
+        # than `example_with_conflicts`.
+        ":run_program",
+        "//internal/linker/test/integration/dynamic_linked_pkg",
+        "//internal/linker/test/integration/dynamic_linked_scoped_pkg",
+        "@npm//semver",
+    ],
+)
+
 golden_file_test(
     # default rule in this package
     name = "integration",
@@ -108,5 +141,12 @@ golden_file_test(
     # default rule in this package
     name = "integration_conflicts",
     actual = "actual_with_conflicts",
+    golden = "golden.txt",
+)
+
+golden_file_test(
+    # default rule in this package
+    name = "integration_conflicts_alt",
+    actual = "actual_with_conflicts_alt",
     golden = "golden.txt",
 )


### PR DESCRIPTION
Fixes #1595.

The `elif` path in
```
            if mappings[k][0] == "runfiles":
                return True
            elif v[0] == "runfiles":
                return False
```
is now exercised by the linker integration tests.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

