### PR TITLE
fix: angular example ts_scripts path in Windows

### DIFF
--- a/examples/angular/src/BUILD.bazel
+++ b/examples/angular/src/BUILD.bazel
@@ -88,7 +88,7 @@ html_insert_assets(
         "--assets",
     ] + ["$(execpath %s)" % s for s in _ASSETS] + [
         # This file doesn't exist during the build, but will be served by ts_devserver
-        "_/ts_scripts.js",
+        "./_/ts_scripts.js",
     ],
     data = ["//src:example/index.html"] + _ASSETS,
 )

--- a/examples/angular_view_engine/src/BUILD.bazel
+++ b/examples/angular_view_engine/src/BUILD.bazel
@@ -94,7 +94,7 @@ html_insert_assets(
         "--assets",
     ] + ["$(execpath %s)" % s for s in _ASSETS] + [
         # This file doesn't exist during the build, but will be served by ts_devserver
-        "_/ts_scripts.js",
+        "./_/ts_scripts.js",
     ],
     data = ["//src:example/index.html"] + _ASSETS,
 )


### PR DESCRIPTION
In Windows `_/ts_scripts.js` will be expanded to `C:/Program Files/Git/ts_scripts.js`. 

```
[
  'C:\\users\\alag\\_bazel_alag\\rj2iva3m\\external\\build_bazel_rules_nodejs\\internal\\node\\_node_bin\\node',
  'C:\\users\\alag\\_bazel_alag\\rj2iva3m\\execroot\\examples_angular\\node_modules\\html-insert-assets\\src\\main.js',
  '--html=src/example/index.html',
  '--out=bazel-out/x64_windows-fastbuild/bin/src/index.html',
  '--roots=.',
  'bazel-out/x64_windows-fastbuild/bin/src',
  '--assets',
  'bazel-out/x64_windows-fastbuild/bin/src/styles.css',
  'external/npm/node_modules/@angular/material/prebuilt-themes/deeppurple-amber.css',
  'external/npm/node_modules/zone.js/dist/zone.min.js',
  './_C:/Program Files/Git/ts_scripts.js'
]
```

This seems like some character escaping issue but in general escaping is hell and this is a more straightforward fix.

Partially addresses: #1604


