### PR TITLE
fix: html script injection is broken on windows

### DIFF
--- a/e2e/ts_devserver/package.json
+++ b/e2e/ts_devserver/package.json
@@ -6,7 +6,7 @@
     "@types/jasmine": "2.8.2",
     "@types/node": "7.0.18",
     "date-fns": "1.30.1",
-    "html-insert-assets": "^0.4.0",
+    "html-insert-assets": "^0.5.0",
     "jasmine": "2.8.0",
     "protractor": "^5.4.2",
     "rxjs": "^6.5.2",

--- a/e2e/ts_devserver/yarn.lock
+++ b/e2e/ts_devserver/yarn.lock
@@ -606,11 +606,12 @@ highlight.js@^9.6.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.9.tgz#865257da1dbb4a58c4552d46c4b3854f77f0e6d5"
   integrity sha512-M0zZvfLr5p0keDMCAhNBp03XJbKBxUx5AfyfufMdFMEP4N/Xj6dh0IqC75ys7BAzceR34NgcvXjupRVaHBPPVQ==
 
-html-insert-assets@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.4.0.tgz#34a6e1daff93adb5fa15562696095032fdab89cb"
-  integrity sha512-BjCVzZi9hWxSzs/XYMTiWXnX/UyhkhSlNbI9xiR0J/4YGv8foj9a1HkK8Lb3V0Tm/TjaeOCWM8b8mMIdVrEtfA==
+html-insert-assets@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.5.0.tgz#c9bed8f04689c9aad3f2be26077a9e05e678dee5"
+  integrity sha512-HFvbKEkQOUZZkYLOAcMJKxpT7U16wPhIsnHAY1XXtTWR4urusQeRFgkONw3HdAQbKPtONOldq/Nse9KEZyYuqQ==
   dependencies:
+    mkdirp "^0.5.1"
     parse5 "^5.1.1"
 
 http-signature@~1.2.0:

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -47,7 +47,7 @@
         "core-js": "2.6.9",
         "firebase-tools": "7.1.0",
         "history-server": "^1.3.1",
-        "html-insert-assets": "^0.4.0",
+        "html-insert-assets": "^0.5.0",
         "karma": "~4.1.0",
         "karma-chrome-launcher": "2.2.0",
         "karma-firefox-launcher": "1.1.0",

--- a/examples/angular/yarn.lock
+++ b/examples/angular/yarn.lock
@@ -3458,11 +3458,12 @@ hosted-git-info@^3.0.2:
   dependencies:
     lru-cache "^5.1.1"
 
-html-insert-assets@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.4.0.tgz#34a6e1daff93adb5fa15562696095032fdab89cb"
-  integrity sha512-BjCVzZi9hWxSzs/XYMTiWXnX/UyhkhSlNbI9xiR0J/4YGv8foj9a1HkK8Lb3V0Tm/TjaeOCWM8b8mMIdVrEtfA==
+html-insert-assets@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.5.0.tgz#c9bed8f04689c9aad3f2be26077a9e05e678dee5"
+  integrity sha512-HFvbKEkQOUZZkYLOAcMJKxpT7U16wPhIsnHAY1XXtTWR4urusQeRFgkONw3HdAQbKPtONOldq/Nse9KEZyYuqQ==
   dependencies:
+    mkdirp "^0.5.1"
     parse5 "^5.1.1"
 
 http-cache-semantics@^3.8.1:

--- a/examples/angular_view_engine/package.json
+++ b/examples/angular_view_engine/package.json
@@ -47,7 +47,7 @@
         "core-js": "2.6.9",
         "firebase-tools": "7.1.0",
         "history-server": "^1.3.1",
-        "html-insert-assets": "^0.4.0",
+        "html-insert-assets": "^0.5.0",
         "karma": "~4.1.0",
         "karma-chrome-launcher": "2.2.0",
         "karma-firefox-launcher": "1.1.0",

--- a/examples/angular_view_engine/yarn.lock
+++ b/examples/angular_view_engine/yarn.lock
@@ -3540,11 +3540,12 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.6.0, hosted-git-info@^2.7.1:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
   integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
 
-html-insert-assets@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.4.0.tgz#34a6e1daff93adb5fa15562696095032fdab89cb"
-  integrity sha512-BjCVzZi9hWxSzs/XYMTiWXnX/UyhkhSlNbI9xiR0J/4YGv8foj9a1HkK8Lb3V0Tm/TjaeOCWM8b8mMIdVrEtfA==
+html-insert-assets@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.5.0.tgz#c9bed8f04689c9aad3f2be26077a9e05e678dee5"
+  integrity sha512-HFvbKEkQOUZZkYLOAcMJKxpT7U16wPhIsnHAY1XXtTWR4urusQeRFgkONw3HdAQbKPtONOldq/Nse9KEZyYuqQ==
   dependencies:
+    mkdirp "^0.5.1"
     parse5 "^5.1.1"
 
 http-cache-semantics@^3.8.1:

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -6,7 +6,7 @@
     "@bazel/terser": "^1.2.4",
     "@bazel/typescript": "^1.2.4",
     "@types/jasmine": "3.3.15",
-    "html-insert-assets": "^0.4.0",
+    "html-insert-assets": "^0.5.0",
     "http-server": "^0.11.1",
     "less": "^3.10.3",
     "protractor": "^5.4.2",

--- a/examples/app/yarn.lock
+++ b/examples/app/yarn.lock
@@ -589,11 +589,12 @@ he@^1.1.1:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-html-insert-assets@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.4.0.tgz#34a6e1daff93adb5fa15562696095032fdab89cb"
-  integrity sha512-BjCVzZi9hWxSzs/XYMTiWXnX/UyhkhSlNbI9xiR0J/4YGv8foj9a1HkK8Lb3V0Tm/TjaeOCWM8b8mMIdVrEtfA==
+html-insert-assets@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.5.0.tgz#c9bed8f04689c9aad3f2be26077a9e05e678dee5"
+  integrity sha512-HFvbKEkQOUZZkYLOAcMJKxpT7U16wPhIsnHAY1XXtTWR4urusQeRFgkONw3HdAQbKPtONOldq/Nse9KEZyYuqQ==
   dependencies:
+    mkdirp "^0.5.1"
     parse5 "^5.1.1"
 
 http-proxy@^1.8.1:
@@ -848,7 +849,7 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
-mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@~0.5.x:
+mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.x:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=


### PR DESCRIPTION
`html-insert-assets` version `0.5.0` includes the following fix: https://github.com/jbedard/html-insert-assets/pull/6 which is needed for better Windows support.

Closes #1604
