### PR TITLE
build: add bazel-out to .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,4 +1,5 @@
 node_modules
 dist
+bazel-out
 e2e/symlinked_node_modules_yarn/node_modules
 e2e/symlinked_node_modules_npm/node_modules/


### PR DESCRIPTION
This shouldn't be necessary as Bazel normally ignores this since it manages the symlink but I keep getting into a state where I can't build without doing a bazel clean in this repo with bazel complaining about the contents of bazel-out so adding this here as it prevents this from happening.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

