### PR TITLE
fix: ensure BAZEL_NODE_RUNFILES_HELPER & BAZEL_NODE_PATCH_REQUIRE are absolute

### DIFF
--- a/internal/node/launcher.sh
+++ b/internal/node/launcher.sh
@@ -142,10 +142,16 @@ fi
 
 # Export the location of the runfiles helpers script
 export BAZEL_NODE_RUNFILES_HELPER=$(rlocation "TEMPLATED_runfiles_helper_script")
+if [[ "${BAZEL_NODE_RUNFILES_HELPER}" != /* ]] && [[ ! "${BAZEL_NODE_RUNFILES_HELPER}" =~ ^[A-Z]:[\\/] ]]; then
+  export BAZEL_NODE_RUNFILES_HELPER=$(pwd)/${BAZEL_NODE_RUNFILES_HELPER}
+fi
 
 # Export the location of the require patch script as it can be used to boostrap
 # node require patch if needed
 export BAZEL_NODE_PATCH_REQUIRE=$(rlocation "TEMPLATED_require_patch_script")
+if [[ "${BAZEL_NODE_PATCH_REQUIRE}" != /* ]] && [[ ! "${BAZEL_NODE_PATCH_REQUIRE}" =~ ^[A-Z]:[\\/] ]]; then
+  export BAZEL_NODE_PATCH_REQUIRE=$(pwd)/${BAZEL_NODE_PATCH_REQUIRE}
+fi
 
 # The main entry point
 MAIN=$(rlocation "TEMPLATED_loader_script")

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -284,6 +284,25 @@ golden_file_test(
     golden = "expand_variables.golden",
 )
 
+nodejs_binary(
+    name = "test_runfiles_helper",
+    data = [":test_runfiles_helper.golden"],
+    entry_point = "test_runfiles_helper.js",
+)
+
+npm_package_bin(
+    name = "test_runfiles_helper_ouput",
+    outs = ["test_runfiles_helper.out"],
+    args = ["$@"],
+    tool = ":test_runfiles_helper",
+)
+
+golden_file_test(
+    name = "test_runfiles_helper_test",
+    actual = ":test_runfiles_helper.out",
+    golden = "test_runfiles_helper.golden",
+)
+
 nodejs_test(
     name = "fail_test",
     entry_point = "fail.spec.js",

--- a/internal/node/test/test_runfiles_helper.golden
+++ b/internal/node/test/test_runfiles_helper.golden
@@ -1,0 +1,1 @@
+hello_world

--- a/internal/node/test/test_runfiles_helper.js
+++ b/internal/node/test/test_runfiles_helper.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+const args = process.argv.slice(2);
+const outfile = args.shift();
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
+const golden =
+    runfiles.resolve('build_bazel_rules_nodejs/internal/node/test/test_runfiles_helper.golden');
+fs.writeFileSync(outfile, fs.readFileSync(golden, 'utf-8'), 'utf-8');


### PR DESCRIPTION
This is for using `BAZEL_NODE_RUNFILES_HELPER ` in `bazel build` when there are no runfiles and with a tool that does not support workers. The cwd is a path such as: `/private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/18/execroot/build_bazel_rules_nodejs`.

```
export BAZEL_NODE_RUNFILES_HELPER=$(rlocation "build_bazel_rules_nodejs/internal/linker/runfiles_helper.js")
```

resolves to `/Users/greg/google/rules_nodejs/internal/linker/runfiles_helper.js` when workers are on as there is no sandbox (such as ts_library).

&

resolves to `bazel-out/host/bin/external/build_bazel_rules_typescript/internal/tsc_wrapped_bin.sh.runfiles/build_bazel_rules_nodejs/internal/linker/runfiles_helper.js` when workers are off as there is a sandbox

The latter is a relative path to the CWD and won't work in a require() statement unless joined with the CWD.

This PR adds the CWD in the launcher.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

