### PR TITLE
fix(builtin): use posix paths in assembler

### DIFF
--- a/internal/pkg_web/BUILD.bazel
+++ b/internal/pkg_web/BUILD.bazel
@@ -31,9 +31,6 @@ nodejs_binary(
 jasmine_node_test(
     name = "assembler_test",
     srcs = ["assembler_spec.js"],
-    tags = [
-        "fix-windows",
-    ],
     deps = [
         "assembler.js",
     ],

--- a/internal/pkg_web/assembler.js
+++ b/internal/pkg_web/assembler.js
@@ -59,7 +59,8 @@ function main(params) {
   function copy(f) {
     if (fs.statSync(f).isDirectory()) {
       for (const file of fs.readdirSync(f)) {
-        copy(path.join(f, file));
+        // Change paths to posix
+        copy(path.join(f, file).replace(/\\/g, '/'));
       }
     } else {
       const dest = path.join(outdir, relative(f));


### PR DESCRIPTION
Fixes #1635
