### PR TITLE
fix(examples): add fixes to angular architect

### DIFF
--- a/examples/angular_bazel_architect/BUILD.bazel
+++ b/examples/angular_bazel_architect/BUILD.bazel
@@ -113,6 +113,26 @@ architect_test(
 )
 
 architect(
+    name = "lint",
+    args = ["frontend:lint"],
+    data = glob([
+        "src/**/*",
+        "e2e/src/**/*",
+    ]) + [
+        "angular.json",
+        "tsconfig.json",
+        "tsconfig.spec.json",
+        "tsconfig.app.json",
+        "tslint.json",
+        "e2e/tsconfig.json",
+        "@npm//@angular/cli",
+        "@npm//@angular-devkit/build-angular",
+        "@npm//codelyzer",
+        "@npm//tslint",
+    ],
+)
+
+architect(
     name = "serve",
     args = [
         "frontend:serve",

--- a/examples/angular_bazel_architect/angular.json
+++ b/examples/angular_bazel_architect/angular.json
@@ -17,6 +17,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
+            "forkTypeChecker": false,
             "preserveSymlinks": true,
             "outputPath": "dist/frontend",
             "index": "src/index.html",

--- a/examples/angular_bazel_architect/package.json
+++ b/examples/angular_bazel_architect/package.json
@@ -3,11 +3,11 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
-    "build": "bazel build :build",
-    "test": "bazel test :test",
-    "lint": "ng lint",
-    "e2e": "ng e2e",
+    "start": "bazelisk run :serve",
+    "build": "bazelisk build :build",
+    "test": "bazelisk test :test",
+    "lint": "bazelisk run :lint",
+    "e2e": "bazelisk test :e2e",
     "postinstall": "patch-package && ngcc --properties es2015 browser module main --first-only"
   },
   "private": true,


### PR DESCRIPTION
This PR adds;
1)  `lint` as a target
2) Changes npm script to use bazelisk
3) Disables `forkTypeChecker` as under Windows this currently errors out with:
```
Error: spawn C:\users\alag\_bazel_alag\jeen2jsq\external\build_bazel_rules_nodejs\internal\node\_node_bin\node ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:264:19)
    at onErrorNT (internal/child_process.js:456:16)
    at processTicksAndRejections (internal/process/task_queues.js:80:21)
Emitted 'error' event on ChildProcess instance at:
    at Process.ChildProcess._handle.onexit (internal/child_process.js:270:12)
    at onErrorNT (internal/child_process.js:456:16)
    at processTicksAndRejections (internal/process/task_queues.js:80:21) {
  errno: 'ENOENT',
  code: 'ENOENT',
  syscall: 'spawn C:\\users\\alag\\_bazel_alag\\jeen2jsq\\external\\build_bazel_rules_nodejs\\internal\\node\\_node_bin\\node',
  path: 'C:\\users\\alag\\_bazel_alag\\jeen2jsq\\external\\build_bazel_rules_nodejs\\internal\\node\\_node_bin\\node',
  spawnargs: [
    '--require',
    'C:/users/alag/_bazel_alag/jeen2jsq/external/build_bazel_rules_nodejs/internal/node/node_patches.js',
    '--preserve-symlinks',
    '--preserve-symlinks-main',
    'c:\\users\\alag\\_bazel~1\\jeen2jsq\\execroot\\angula~1\\node_modules\\@ngtools\\webpack\\src\\type_checker_worker.js',
    '9d93e901-158a-4cf9-ba1b-2f0582ffcfeb'
  ]
}
```



## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

