### PR TITLE
fix(create): use latest typescript

### DIFF
--- a/packages/create/index.js
+++ b/packages/create/index.js
@@ -107,7 +107,7 @@ function main(argv, error = console.error, log = console.log) {
 
   if (args['typescript']) {
     devDependencies['@bazel/typescript'] = 'latest';
-    devDependencies['typescript'] = '~3.4.0';
+    devDependencies['typescript'] = 'latest';
     write('tsconfig.json', '');
     rootBuildContent += '# Allow any ts_library rules in this workspace to reference the config\n' +
         '# Note: if you move the tsconfig.json file to a subdirectory, you can add an alias() here instead\n' +


### PR DESCRIPTION
Technically this could get us in trouble, if a new TS release isn't compatible with tsc_wrapped.
However we work pretty quickly to resolve these.

Fixes #1602

The alternative is we could populate this version from whatever TS we test against in this repo so we know it will work
