### PR TITLE
docs(talks): add new talk slides and video link

### DIFF
--- a/examples/angular/src/index.html
+++ b/examples/angular/src/index.html
@@ -503,6 +503,12 @@
 
             <h3>Talks</h3>
             <ul>
+	      <li>
+                Building Large Angular applications with Bazel
+                <a href="https://speakerdeck.com/mattem/building-large-angular-applications-with-bazel-angular-toronto">Slides</a>
+                <a href="https://www.youtube.com/watch?v=kzPMll6vB04">Video</a>
+                (AngularToronto, Feb 2020)
+              </li>
               <li>
                 The Bazel Opt-in Preview is Here!
                 <a href="https://docs.google.com/presentation/d/1CZsABQJDjpBLun5Ewk3lNUTAHX2Y-pUb3-dfLMZ22DE/edit?usp=sharing">Slides</a>


### PR DESCRIPTION
This PR adds a link to the talks section of the bazel.angular.io site. The [link](https://www.youtube.com/watch?v=kzPMll6vB04&feature=youtu.be) points to the talk that [@MattMackay](https://twitter.com/MattMackay) recently gave at [AngularTorronto](https://www.youtube.com/channel/UCUlbE1BakJPBVx8OAzc5quA)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No