### PR TITLE
Configures detailed output to XML_OUTPUT_FILE

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "is-builtin-module": "3.0.0",
         "jasmine": "~3.4.0",
         "jasmine-core": "~3.4.0",
+        "jasmine-reporters": "~2.3.2",
         "karma": "~4.1.0",
         "karma-chrome-launcher": "2.2.0",
         "karma-firefox-launcher": "1.1.0",

--- a/packages/jasmine/src/index.from_src.bzl
+++ b/packages/jasmine/src/index.from_src.bzl
@@ -19,7 +19,7 @@ load(":index.bzl", _jasmine_node_test = "jasmine_node_test")
 
 def jasmine_node_test(
         deps = [],
-        jasmine_deps = ["@npm//jasmine", "@npm//jasmine-core", "@npm//v8-coverage"],
+        jasmine_deps = ["@npm//jasmine", "@npm//jasmine-core", "@npm//jasmine-reporters", "@npm//v8-coverage"],
         **kwargs):
     _jasmine_node_test(
         # When there is no @npm//@bazel/jasmine package we use @npm_bazel_jasmine instead.

--- a/packages/jasmine/src/index.js
+++ b/packages/jasmine/src/index.js
@@ -10,3 +10,11 @@ exports.boot = boot;
 // re-export jasmine and its transitive dep jasmine-core
 exports.jasmine = require('jasmine');
 exports.jasmineCore = jasmineCore;
+
+let JUnitXmlReporter = null;
+try {
+  JUnitXmlReporter = require('jasmine-reporters').JUnitXmlReporter;
+} catch (err) {
+  // fail quietly if jasmine-reporters is not available
+}
+exports.JUnitXmlReporter = JUnitXmlReporter;

--- a/packages/jasmine/src/jasmine_node_test.bzl
+++ b/packages/jasmine/src/jasmine_node_test.bzl
@@ -35,6 +35,10 @@ def jasmine_node_test(
         **kwargs):
     """Runs tests in NodeJS using the Jasmine test runner.
 
+    Detailed XML test results are found in the standard `bazel-testlogs`
+    directory. This may be symlinked in your workspace.
+    See https://docs.bazel.build/versions/master/output_directories.html
+
     To debug the test, see debugging notes in `nodejs_test`.
 
     Args:

--- a/packages/jasmine/src/jasmine_runner.js
+++ b/packages/jasmine/src/jasmine_runner.js
@@ -3,6 +3,7 @@ const path = require('path');
 const bazelJasmine = require('@bazel/jasmine');
 
 const JasmineRunner = bazelJasmine.jasmine;
+const JUnitXmlReporter = bazelJasmine.JUnitXmlReporter;
 
 let jasmineCore = null
 if (global.jasmine) {
@@ -112,6 +113,21 @@ function main(args) {
       noSpecsFound = false
     },
   });
+
+  if (JUnitXmlReporter) {
+    const testOutputFile = process.env.XML_OUTPUT_FILE;
+    if (testOutputFile) {
+      jrunner.addReporter(new JUnitXmlReporter({
+        filePrefix: path.basename(testOutputFile),
+        savePath: path.dirname(testOutputFile),
+        consolidate: true,
+        consolidateAll: true
+      }));
+    } else {
+      console.warn('Skipping XML Test Result: $XML_OUTPUT_FILE not found.')
+    }
+  }
+
   // addReporter throws away the default console reporter
   // so we need to add it back
   jrunner.configureDefaultReporter({});

--- a/packages/jasmine/src/package.json
+++ b/packages/jasmine/src/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "jasmine": "~3.5.0",
         "jasmine-core": "~3.5.0",
+        "jasmine-reporters": "~2.3.2",
         "v8-coverage": "1.0.9"
     },
     "bazelWorkspaces": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4265,6 +4265,14 @@ jasmine-core@~3.4.0:
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.4.0.tgz#2a74618e966026530c3518f03e9f845d26473ce3"
   integrity sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg==
 
+jasmine-reporters@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/jasmine-reporters/-/jasmine-reporters-2.3.2.tgz#898818ffc234eb8b3f635d693de4586f95548d43"
+  integrity sha512-u/7AT9SkuZsUfFBLLzbErohTGNsEUCKaQbsVYnLFW1gEuL2DzmBL4n8v90uZsqIqlWvWUgian8J6yOt5Fyk/+A==
+  dependencies:
+    mkdirp "^0.5.1"
+    xmldom "^0.1.22"
+
 jasmine@2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-2.8.0.tgz#6b089c0a11576b1f16df11b80146d91d4e8b8a3e"
@@ -8154,6 +8162,11 @@ xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+
+xmldom@^0.1.22:
+  version "0.1.31"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
+  integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
 
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

I think this is considered a bugfix since a test runner is expected to write results to the `XML_OUTPUT_FILE`, however there was no explicit error that this is fixing. 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, no test details are written to the testlogs directory, rather the output is captured via bazel core and written into a default file.


## What is the new behavior?

The `$XML_OUTPUT_FILE` is populated with proper test results detailing times/statuses/results from specs/suites from jasmine.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

It could be considered a breaking change if a consumer has changed the param `jasmine` which defaults `@npm//@bazel/jasmine` to a different package altogether (as opposed to just changing the repository label from the default `@npm`. If a consumer has done this, they should be responsible for keeping up to date with changes here 


## Other information

I considered making this an opt-in reporter, but it seems like this is always the desired behavior. I'd be happy to change it or move it behind a flag if other uses cases are presented. 

I also did not know how to test this well. It seemed as though most of jasmine_node_test own tests used various functionality but did not necessarily assert on the results. This led me to thinking that this did not need testing rather by virtue of not failing it was considered working. 

