### PR TITLE
fix(builtin): don't include external files when pkg_npm is in root pa…

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -102,6 +102,7 @@ install_bazel_dependencies()
 git_repository(
     name = "build_bazel_rules_typescript",
     commit = "10a5a86885f95ab788fd841ade47b6a16e0c13d6",
+    patches = ["//:rules_typescript.patch"],
     remote = "http://github.com/bazelbuild/rules_typescript.git",
     shallow_since = "1582757372 -0800",
 )

--- a/internal/pkg_npm/pkg_npm.bzl
+++ b/internal/pkg_npm/pkg_npm.bzl
@@ -138,7 +138,7 @@ PKG_NPM_OUTPUTS = {
 def _filter_out_external_files(ctx, files, package_path):
     result = []
     for file in files:
-        if file.short_path.startswith(package_path):
+        if file.short_path.startswith(package_path) and not file.short_path.startswith("../"):
             result.append(file.path)
         else:
             for v in ctx.attr.vendor_external:

--- a/packages/worker/BUILD.bazel
+++ b/packages/worker/BUILD.bazel
@@ -17,7 +17,7 @@ load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "co
 
 # We reach inside the @bazel/typescript npm package to grab this one .js file
 # This avoids a complex refactoring where we extract that .ts file from tsc_wrapped to a common library
-_worker_path = "external/build_bazel_rules_typescript/internal/tsc_wrapped/worker"
+_worker_path = "internal/tsc_wrapped/worker"
 
 # Copy the proto file to a matching third_party/... nested directory
 # so the runtime require() statements still work

--- a/rules_typescript.patch
+++ b/rules_typescript.patch
@@ -1,0 +1,12 @@
+diff BUILD.bazel BUILD.bazel
+index 3a519c5..6121ef6 100644
+--- BUILD.bazel
++++ BUILD.bazel
+@@ -38,6 +38,7 @@ pkg_npm(
+         "//internal:npm_package_assets",
+         "//third_party/github.com/bazelbuild/bazel/src/main/protobuf:npm_package_assets",
+     ],
++    vendor_external = ["build_bazel_rules_typescript"],
+     visibility = ["//visibility:public"],
+     deps = [
+         "//devserver:devserver-darwin",


### PR DESCRIPTION
…ckage

This logic assumed that package_path was non-empty, but when a pkg_npm rule appears in the workspace root, package_path will be empty string and the startswith guard has no effect.

Fixes #1499
