### PR TITLE
feat(rollup): add silent attr to rollup_bundle to support --silent flag

### DIFF
--- a/packages/rollup/src/rollup_bundle.bzl
+++ b/packages/rollup/src/rollup_bundle.bzl
@@ -169,7 +169,12 @@ Otherwise, the outputs are assumed to be a single file.
         default = "@npm//rollup/bin:rollup",
     ),
     "silent": attr.bool(
-        doc = "Whether to execute the rollup binary with the --silent flag",
+        doc = """Whether to execute the rollup binary with the --silent flag, defaults to False.
+
+Using --silent can cause rollup to [ignore errors/warnings](https://github.com/rollup/rollup/blob/master/docs/999-big-list-of-options.md#onwarn) 
+which are only surfaced via logging.  Since bazel expects printing nother on success, setting silent to True
+is a more Bazel-idiomatic experience, however could cause rollup to drop important warnings.
+""",
     ),
     "sourcemap": attr.string(
         doc = """Whether to produce sourcemaps.

--- a/packages/rollup/src/rollup_bundle.bzl
+++ b/packages/rollup/src/rollup_bundle.bzl
@@ -168,6 +168,9 @@ Otherwise, the outputs are assumed to be a single file.
         cfg = "host",
         default = "@npm//rollup/bin:rollup",
     ),
+    "silent": attr.bool(
+        doc = "Whether to execute the rollup binary with the --silent flag",
+    ),
     "sourcemap": attr.string(
         doc = """Whether to produce sourcemaps.
 
@@ -302,6 +305,10 @@ def _rollup_bundle(ctx):
         args.add_all(["--output.file", outputs[0].path])
 
     args.add_all(["--format", ctx.attr.format])
+
+    if ctx.attr.silent:
+        # Run the rollup binary with the --silent flag
+        args.add("--silent")
 
     stamp = ctx.attr.node_context_data[NodeContextInfo].stamp
 

--- a/packages/rollup/src/rollup_bundle.bzl
+++ b/packages/rollup/src/rollup_bundle.bzl
@@ -172,7 +172,7 @@ Otherwise, the outputs are assumed to be a single file.
         doc = """Whether to execute the rollup binary with the --silent flag, defaults to False.
 
 Using --silent can cause rollup to [ignore errors/warnings](https://github.com/rollup/rollup/blob/master/docs/999-big-list-of-options.md#onwarn) 
-which are only surfaced via logging.  Since bazel expects printing nother on success, setting silent to True
+which are only surfaced via logging.  Since bazel expects printing nothing on success, setting silent to True
 is a more Bazel-idiomatic experience, however could cause rollup to drop important warnings.
 """,
     ),


### PR DESCRIPTION
As rollup_bundle already supports specific rollup flags with specific
attributes on the rollup_bundle rule, adding a boolean attribute for
silent makes the most sense.

This boolean determines if the --silent flag is added to the rollup command
when called.


I was unable to add tests for this as its change is to the stdout of the execution
of bazel, not the results of the rollup command.