### PR TITLE
feat(rollup): add `args` attribute to rollup_bundle rule

### DIFF
--- a/packages/rollup/src/rollup_bundle.bzl
+++ b/packages/rollup/src/rollup_bundle.bzl
@@ -65,6 +65,16 @@ You must not repeat file(s) passed to entry_point/entry_points.
         # Don't try to constrain the filenames, could be json, svg, whatever
         allow_files = True,
     ),
+    "args": attr.string_list(
+        doc = """Command line arguments to pass to rollup. Can be used to override config file settings.
+
+These argument passed on the command line before all arguments that are always added by the
+rule such as `--output.dir` or `--output.file`, `--format`, `--config` and `--preserveSymlinks` and
+also those that are optionally added by the rule such as `--sourcemap`.
+
+See rollup CLI docs https://rollupjs.org/guide/en/#command-line-flags for complete list of supported arguments.""",
+        default = [],
+    ),
     "config_file": attr.label(
         doc = """A rollup.config.js file
 
@@ -285,6 +295,9 @@ def _rollup_bundle(ctx):
 
     # See CLI documentation at https://rollupjs.org/guide/en/#command-line-reference
     args = ctx.actions.args()
+
+    # Add user specified arguments *before* rule supplied arguments
+    args.add_all(ctx.attr.args)
 
     # List entry point argument first to save some argv space
     # Rollup doc says

--- a/packages/rollup/test/sourcemaps/BUILD.bazel
+++ b/packages/rollup/test/sourcemaps/BUILD.bazel
@@ -4,6 +4,11 @@ load("@npm_bazel_rollup//:index.from_src.bzl", "rollup_bundle")
 rollup_bundle(
     name = "bundle",
     srcs = ["s.js"],
+    # Test existance of args attribute
+    args = [
+        "--environment",
+        "FOO,BAR:baz",
+    ],
     # Use the desugared form to assert that it works
     entry_points = {"input.js": "bundle"},
     sourcemap = "true",


### PR DESCRIPTION
Arguments passed to rollup. These can be used to override config file settings.

These argument are appended to the command line before all arguments that are always added by the
rule such as `--output.dir` or `--output.file`, `--format`, `--config` and `--preserveSymlinks` and
also those that are optionally added by the rule such as `--sourcemap`.

See rollup CLI docs https://rollupjs.org/guide/en/#command-line-flags for complete list of supported arguments.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

