### PR TITLE
feat(typescript): add devmode_target, devmode_module, prodmode_target & prodmode_module attributes

### DIFF
--- a/packages/typescript/test/target_module_attributes/BUILD.bazel
+++ b/packages/typescript/test/target_module_attributes/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@npm_bazel_jasmine//:index.from_src.bzl", "jasmine_node_test")
+load("@npm_bazel_typescript//:index.from_src.bzl", "ts_library")
+load("//packages/typescript/test/devmode_consumer:devmode_consumer.bzl", "devmode_consumer")
+load("//packages/typescript/test/es6_consumer:es6_consumer.bzl", "es6_consumer")
+
+ts_library(
+    name = "override",
+    srcs = ["a.ts"],
+    devmode_module = "amd",
+    devmode_target = "es5",
+    prodmode_module = "amd",
+    prodmode_target = "es5",
+    tsconfig = ":tsconfig-override.json",
+)
+
+devmode_consumer(
+    name = "override_devmode_output",
+    deps = [":override"],
+)
+
+es6_consumer(
+    name = "override_prodmode_output",
+    deps = [":override"],
+)
+
+jasmine_node_test(
+    name = "override_output_test",
+    srcs = ["override_output_test.js"],
+    data = [
+        ":override_devmode_output",
+        ":override_prodmode_output",
+    ],
+)

--- a/packages/typescript/test/target_module_attributes/a.ts
+++ b/packages/typescript/test/target_module_attributes/a.ts
@@ -1,0 +1,1 @@
+export const a: any = () => 'hello world';

--- a/packages/typescript/test/target_module_attributes/override_output_test.js
+++ b/packages/typescript/test/target_module_attributes/override_output_test.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
+
+describe('googmodule', () => {
+  let devmodeOutput;
+  let prodmodeOutput;
+  beforeAll(() => {
+    devmodeOutput = runfiles.resolvePackageRelative('a.js');
+    prodmodeOutput = runfiles.resolvePackageRelative('a.mjs');
+  });
+
+  it('should have amd module syntax in devmode', () => {
+    expect(fs.readFileSync(devmodeOutput, {encoding: 'utf-8'}))
+        .toContain(
+            `define("build_bazel_rules_nodejs/packages/typescript/test/target_module_attributes/a", ["require", "exports"], function (require, exports) {`);
+  });
+
+  it('should have es5 in devmode', () => {
+    expect(fs.readFileSync(devmodeOutput, {
+      encoding: 'utf-8'
+    })).toContain(`exports.a = function () { return 'hello world'; };`);
+  });
+
+  it('should have amd module syntax in prodmode', () => {
+    expect(fs.readFileSync(prodmodeOutput, {encoding: 'utf-8'}))
+        .toContain(
+            `define("build_bazel_rules_nodejs/packages/typescript/test/target_module_attributes/a", ["require", "exports"], function (require, exports) {`);
+  });
+
+  it('should have es5 in prodmode', () => {
+    expect(fs.readFileSync(prodmodeOutput, {
+      encoding: 'utf-8'
+    })).toContain(`exports.a = function () { return 'hello world'; };`);
+  });
+});

--- a/packages/typescript/test/target_module_attributes/tsconfig-override.json
+++ b/packages/typescript/test/target_module_attributes/tsconfig-override.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        // Explicitly set types settings so typescript doesn't auto-discover types.
+        // If all types are discovered then all types need to be included as deps
+        // or typescript may error out with TS2688: Cannot find type definition file for 'foo'.
+        "types": []
+    },
+}


### PR DESCRIPTION
This allows users control over the language level & module formats produced by both the dev and prod outputs of ts_library

NB: the tsconfig `bazelOpts.googmodule` if set will still override the module format to CommonJS & `bazelOpts.devmodeTargetOverride` will trump the `devmode_target` attribute so this is non-breaking. In a future major release `bazelOpts.devmodeTargetOverride ` will be removed.

Control over devmode module format is requested by @filipesilva for the angular-cli bazel migration.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

