### PR TITLE
docs: add LogiOcean as an adaptor to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Organizations:
 - [Lucidchart](https://www.lucidchart.com)
 - [Webdox](https://www.webdox.cl)
 - [WeMaintain](https://www.wemaintain.com)
+- [LogiOcean](https://www.logiocean.com)
 
 Not on this list? [Send a PR](https://github.com/bazelbuild/rules_nodejs/edit/master/README.md) to add your repo or organization!
 


### PR DESCRIPTION
LogiOcean is a lead fin-tech company in China focusing on powering up analytics and business intelligence.

We are an early adoptor of Angular + Bazel. We are also mentioned as such by Brad Green on May 3rd 2019 at ng-conf.