### PR TITLE
fix(examples): fix angular examples prod serve doesn't work on windows

### DIFF
--- a/examples/angular/src/BUILD.bazel
+++ b/examples/angular/src/BUILD.bazel
@@ -209,7 +209,7 @@ history_server(
     #   /        => src/prodapp
     templated_args = [
         "-a",
-        "src/prodapp",
+        "$(rlocation examples_angular/src/prodapp)",
     ],
 )
 

--- a/examples/angular_view_engine/src/BUILD.bazel
+++ b/examples/angular_view_engine/src/BUILD.bazel
@@ -217,6 +217,6 @@ history_server(
     #   /        => src/prodapp
     templated_args = [
         "-a",
-        "src/prodapp",
+        "$(rlocation examples_angular_view_engine/src/prodapp)",
     ],
 )


### PR DESCRIPTION
In Windows runfiles are not always available thus we need to use the real location using `rlocation`.

Closes #1606
