### PR TITLE
chore(examples): upgrade html-insert-assets to 0.6.0

### DIFF
--- a/e2e/ts_devserver/package.json
+++ b/e2e/ts_devserver/package.json
@@ -5,7 +5,7 @@
     "@types/jasmine": "2.8.2",
     "@types/node": "7.0.18",
     "date-fns": "1.30.1",
-    "html-insert-assets": "^0.5.0",
+    "html-insert-assets": "^0.6.0",
     "jasmine": "2.8.0",
     "protractor": "^5.4.2",
     "rxjs": "^6.5.2",

--- a/e2e/ts_devserver/yarn.lock
+++ b/e2e/ts_devserver/yarn.lock
@@ -601,12 +601,12 @@ highlight.js@^9.6.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.9.tgz#865257da1dbb4a58c4552d46c4b3854f77f0e6d5"
   integrity sha512-M0zZvfLr5p0keDMCAhNBp03XJbKBxUx5AfyfufMdFMEP4N/Xj6dh0IqC75ys7BAzceR34NgcvXjupRVaHBPPVQ==
 
-html-insert-assets@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.5.0.tgz#c9bed8f04689c9aad3f2be26077a9e05e678dee5"
-  integrity sha512-HFvbKEkQOUZZkYLOAcMJKxpT7U16wPhIsnHAY1XXtTWR4urusQeRFgkONw3HdAQbKPtONOldq/Nse9KEZyYuqQ==
+html-insert-assets@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.6.0.tgz#af4d5a6ab473dce05f8630f7957a17b2e8efa26c"
+  integrity sha512-DfSuSjK9g4vdnIusj4ibog9xi6kFK0lZkNpqVKtvlVoeez8Zb7nFHSTLzJrZR0MgfZGzYNyBFz783CTckqFvmg==
   dependencies:
-    mkdirp "^0.5.1"
+    mkdirp "^1.0.3"
     parse5 "^5.1.1"
 
 http-signature@~1.2.0:
@@ -844,6 +844,11 @@ mkdirp@^0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkdirp@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
+  integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
 
 ms@^2.1.1:
   version "2.1.2"

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -46,7 +46,7 @@
         "core-js": "2.6.9",
         "firebase-tools": "7.1.0",
         "history-server": "^1.3.1",
-        "html-insert-assets": "^0.5.0",
+        "html-insert-assets": "^0.6.0",
         "karma": "~4.1.0",
         "karma-chrome-launcher": "2.2.0",
         "karma-firefox-launcher": "1.1.0",

--- a/examples/angular/yarn.lock
+++ b/examples/angular/yarn.lock
@@ -3498,12 +3498,12 @@ hosted-git-info@^3.0.2:
   dependencies:
     lru-cache "^5.1.1"
 
-html-insert-assets@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.5.0.tgz#c9bed8f04689c9aad3f2be26077a9e05e678dee5"
-  integrity sha512-HFvbKEkQOUZZkYLOAcMJKxpT7U16wPhIsnHAY1XXtTWR4urusQeRFgkONw3HdAQbKPtONOldq/Nse9KEZyYuqQ==
+html-insert-assets@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.6.0.tgz#af4d5a6ab473dce05f8630f7957a17b2e8efa26c"
+  integrity sha512-DfSuSjK9g4vdnIusj4ibog9xi6kFK0lZkNpqVKtvlVoeez8Zb7nFHSTLzJrZR0MgfZGzYNyBFz783CTckqFvmg==
   dependencies:
-    mkdirp "^0.5.1"
+    mkdirp "^1.0.3"
     parse5 "^5.1.1"
 
 http-cache-semantics@^3.8.1:
@@ -4758,6 +4758,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkdirp@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
+  integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
 
 morgan@^1.8.2:
   version "1.9.1"

--- a/examples/angular_view_engine/package.json
+++ b/examples/angular_view_engine/package.json
@@ -46,7 +46,7 @@
         "core-js": "2.6.9",
         "firebase-tools": "7.1.0",
         "history-server": "^1.3.1",
-        "html-insert-assets": "^0.5.0",
+        "html-insert-assets": "^0.6.0",
         "karma": "~4.1.0",
         "karma-chrome-launcher": "2.2.0",
         "karma-firefox-launcher": "1.1.0",

--- a/examples/angular_view_engine/yarn.lock
+++ b/examples/angular_view_engine/yarn.lock
@@ -3535,12 +3535,12 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.6.0, hosted-git-info@^2.7.1:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
   integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
 
-html-insert-assets@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.5.0.tgz#c9bed8f04689c9aad3f2be26077a9e05e678dee5"
-  integrity sha512-HFvbKEkQOUZZkYLOAcMJKxpT7U16wPhIsnHAY1XXtTWR4urusQeRFgkONw3HdAQbKPtONOldq/Nse9KEZyYuqQ==
+html-insert-assets@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.6.0.tgz#af4d5a6ab473dce05f8630f7957a17b2e8efa26c"
+  integrity sha512-DfSuSjK9g4vdnIusj4ibog9xi6kFK0lZkNpqVKtvlVoeez8Zb7nFHSTLzJrZR0MgfZGzYNyBFz783CTckqFvmg==
   dependencies:
-    mkdirp "^0.5.1"
+    mkdirp "^1.0.3"
     parse5 "^5.1.1"
 
 http-cache-semantics@^3.8.1:
@@ -4791,6 +4791,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkdirp@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
+  integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
 
 morgan@^1.8.2:
   version "1.9.1"

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -5,7 +5,7 @@
     "@bazel/terser": "^1.4.1",
     "@bazel/typescript": "^1.4.1",
     "@types/jasmine": "3.3.15",
-    "html-insert-assets": "^0.5.0",
+    "html-insert-assets": "^0.6.0",
     "http-server": "^0.11.1",
     "less": "^3.10.3",
     "protractor": "^5.4.2",

--- a/examples/app/yarn.lock
+++ b/examples/app/yarn.lock
@@ -584,12 +584,12 @@ he@^1.1.1:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-html-insert-assets@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.5.0.tgz#c9bed8f04689c9aad3f2be26077a9e05e678dee5"
-  integrity sha512-HFvbKEkQOUZZkYLOAcMJKxpT7U16wPhIsnHAY1XXtTWR4urusQeRFgkONw3HdAQbKPtONOldq/Nse9KEZyYuqQ==
+html-insert-assets@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/html-insert-assets/-/html-insert-assets-0.6.0.tgz#af4d5a6ab473dce05f8630f7957a17b2e8efa26c"
+  integrity sha512-DfSuSjK9g4vdnIusj4ibog9xi6kFK0lZkNpqVKtvlVoeez8Zb7nFHSTLzJrZR0MgfZGzYNyBFz783CTckqFvmg==
   dependencies:
-    mkdirp "^0.5.1"
+    mkdirp "^1.0.3"
     parse5 "^5.1.1"
 
 http-proxy@^1.8.1:
@@ -844,12 +844,17 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
-mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.x:
+mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@~0.5.x:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkdirp@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
+  integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
@alexeagle we discussed this on slack a bit and I went with a change to make paths relative to the html file: https://github.com/jbedard/html-insert-assets/commit/26d7118eaa73f0a3ee2b9bbcbcdf3388b298b182

This seems to work well. The only real difference in all the example apps is the css/js files are relative (`./` instead of `/`). This way the app can be placed in a subdirectory and a `<base href>` or just plain relative paths will work correctly.

FYI @gregmagolan 