### PR TITLE
refactor: use new label workspace_name

### DIFF
--- a/internal/common/module_mappings.bzl
+++ b/internal/common/module_mappings.bzl
@@ -130,14 +130,7 @@ module_mappings_aspect = aspect(
 # the runfiles directory. This requires the workspace_name to be prefixed on
 # each module root.
 def _module_mappings_runtime_aspect_impl(target, ctx):
-    if target.label.workspace_root:
-        # We need the workspace_name for the target being visited.
-        # Skylark doesn't have this - instead they have a workspace_root
-        # which looks like "external/repo_name" - so grab the second path segment.
-        # TODO(alexeagle): investigate a better way to get the workspace name
-        workspace_name = target.label.workspace_root.split("/")[1]
-    else:
-        workspace_name = ctx.workspace_name
+    workspace_name = target.label.workspace_name if target.label.workspace_name else ctx.workspace_name
     mappings = get_module_mappings(
         target.label,
         ctx.rule.attr,

--- a/internal/linker/link_node_modules.bzl
+++ b/internal/linker/link_node_modules.bzl
@@ -93,7 +93,7 @@ def write_node_modules_manifest(ctx, extra_data = []):
     ctx.actions.write(modules_manifest, str(content))
     return modules_manifest
 
-def get_module_mappings(label, attrs, vars, rule_kind, srcs = [], workspace_name = None):
+def _get_module_mappings(target, ctx):
     """Returns the module_mappings from the given attrs.
 
     Collects a {module_name - module_root} hash from all transitive dependencies,
@@ -102,10 +102,8 @@ def get_module_mappings(label, attrs, vars, rule_kind, srcs = [], workspace_name
     `module_name`.
 
     Args:
-      label: label
-      attrs: attributes
-      srcs: sources (defaults to [])
-      workspace_name: workspace name (defaults to None)
+      target: target
+      ctx: ctx
 
     Returns:
       The module mappings
@@ -113,7 +111,7 @@ def get_module_mappings(label, attrs, vars, rule_kind, srcs = [], workspace_name
     mappings = {}
 
     for name in _MODULE_MAPPINGS_DEPS_NAMES:
-        for dep in getattr(attrs, name, []):
+        for dep in getattr(ctx.rule.attr, name, []):
             for k, v in getattr(dep, _ASPECT_RESULT_NAME, {}).items():
                 # A package which was reachable transitively via a *_binary or *_test
                 # rule is assumed to be in the runfiles of that binary,
@@ -122,63 +120,45 @@ def get_module_mappings(label, attrs, vars, rule_kind, srcs = [], workspace_name
                 # propagated through the runfiles output of the target we are visiting
                 # but it seems that this info is only available in Bazel Java internals.
                 # TODO: revisit whether this is the correct condition after downstream testing
-                if rule_kind.endswith("_binary") or rule_kind.endswith("_test"):
+                if ctx.rule.kind.endswith("_binary") or ctx.rule.kind.endswith("_test"):
                     v = ["runfiles", v[1]]
-                if _link_mapping(label, mappings, k, v):
+                if _link_mapping(target.label, mappings, k, v):
                     mappings[k] = v
-                    _debug(vars, "target %s propagating module mapping %s: %s" % (dep, k, v))
+                    _debug(ctx.var, "target %s propagating module mapping %s: %s" % (dep, k, v))
 
-    if not getattr(attrs, "module_name", None) and not getattr(attrs, "module_root", None):
+    if not getattr(ctx.rule.attr, "module_name", None) and not getattr(ctx.rule.attr, "module_root", None):
         # No mappings contributed here, short-circuit with the transitive ones we collected
-        _debug(vars, "No module_name or module_root attr for", label)
+        _debug(ctx.var, "No module_name or module_root attr for", target.label)
         return mappings
 
-    mn = getattr(attrs, "module_name", label.name)
-    mr = label.package
+    # When building a mapping for use at runtime, we need paths to be relative to
+    # the runfiles directory. This requires the workspace_name to be prefixed on
+    # each module root.
+    workspace_name = target.label.workspace_name if target.label.workspace_name else ctx.workspace_name
 
-    if workspace_name:
-        mr = "%s/%s" % (workspace_name, mr)
-    elif label.workspace_root:
-        mr = "%s/%s" % (label.workspace_root, mr)
+    mn = getattr(ctx.rule.attr, "module_name", target.label.name)
+    mr = "%s/%s" % (workspace_name, target.label.package)
 
     # since our module mapping is currently based on attribute names,
     # allow a special one to instruct the linker that the package has no output
     # directory and is therefore meant to be used as sources.
     # TODO: This belongs in a different mechanism like a package.json field.
-    if getattr(attrs, "module_from_src", False):
+    if getattr(ctx.rule.attr, "module_from_src", False):
         mr = ["src", mr]
     else:
         mr = ["bin", mr]
 
-    if _link_mapping(label, mappings, mn, mr):
-        _debug(vars, "target %s adding module mapping %s: %s" % (label, mn, mr))
+    if _link_mapping(target.label, mappings, mn, mr):
+        _debug(ctx.var, "target %s adding module mapping %s: %s" % (target.label, mn, mr))
         mappings[mn] = mr
 
     return mappings
 
-# When building a mapping for use at runtime, we need paths to be relative to
-# the runfiles directory. This requires the workspace_name to be prefixed on
-# each module root.
 def _module_mappings_aspect_impl(target, ctx):
-    if target.label.workspace_root:
-        # We need the workspace_name for the target being visited.
-        # Skylark doesn't have this - instead they have a workspace_root
-        # which looks like "external/repo_name" - so grab the second path segment.
-        # TODO(alexeagle): investigate a better way to get the workspace name
-        workspace_name = target.label.workspace_root.split("/")[1]
-    else:
-        workspace_name = ctx.workspace_name
-
     # Use a dictionary to construct the result struct
     # so that we can reference the _ASPECT_RESULT_NAME variable
     return struct(**{
-        _ASPECT_RESULT_NAME: get_module_mappings(
-            target.label,
-            ctx.rule.attr,
-            ctx.var,
-            ctx.rule.kind,
-            workspace_name = workspace_name,
-        ),
+        _ASPECT_RESULT_NAME: _get_module_mappings(target, ctx),
     })
 
 module_mappings_aspect = aspect(

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -54,9 +54,9 @@ def _compute_node_modules_root(ctx):
             node_modules_root = "/".join([ctx.attr.node_modules[NpmPackageInfo].workspace, "node_modules"])
         elif ctx.files.node_modules:
             # ctx.files.node_modules is not an empty list
-            workspace = ctx.attr.node_modules.label.workspace_root.split("/")[1] if ctx.attr.node_modules.label.workspace_root else ctx.workspace_name
+            workspace_name = ctx.attr.node_modules.label.workspace_name if ctx.attr.node_modules.label.workspace_name else ctx.workspace_name
             node_modules_root = "/".join([f for f in [
-                workspace,
+                workspace_name,
                 _trim_package_node_modules(ctx.attr.node_modules.label.package),
                 "node_modules",
             ] if f])
@@ -70,9 +70,9 @@ def _compute_node_modules_root(ctx):
     if not node_modules_root:
         # there are no fine grained deps and the node_modules attribute is an empty filegroup
         # but we still need a node_modules_root even if its empty
-        workspace = ctx.attr.node_modules.label.workspace_root.split("/")[1] if ctx.attr.node_modules.label.workspace_root else ctx.workspace_name
+        workspace_name = ctx.attr.node_modules.label.workspace_name if ctx.attr.node_modules.label.workspace_name else ctx.workspace_name
         node_modules_root = "/".join([f for f in [
-            workspace,
+            workspace_name,
             ctx.attr.node_modules.label.package,
             "node_modules",
         ] if f])

--- a/internal/npm_install/node_module_library.bzl
+++ b/internal/npm_install/node_module_library.bzl
@@ -18,7 +18,7 @@
 load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "NpmPackageInfo", "js_named_module_info")
 
 def _node_module_library_impl(ctx):
-    workspace = ctx.label.workspace_root.split("/")[1] if ctx.label.workspace_root else ctx.workspace_name
+    workspace_name = ctx.label.workspace_name if ctx.label.workspace_name else ctx.workspace_name
 
     direct_sources = depset(ctx.files.srcs)
     sources_depsets = [direct_sources]
@@ -64,7 +64,7 @@ def _node_module_library_impl(ctx):
             NpmPackageInfo(
                 direct_sources = direct_sources,
                 sources = depset(transitive = sources_depsets),
-                workspace = workspace,
+                workspace = workspace_name,
             ),
             DeclarationInfo(
                 declarations = declarations,

--- a/packages/typescript/src/internal/devserver/ts_devserver.bzl
+++ b/packages/typescript/src/internal/devserver/ts_devserver.bzl
@@ -49,14 +49,7 @@ def _ts_devserver(ctx):
             node_modules_depsets.append(dep[NpmPackageInfo].sources)
     node_modules = depset(transitive = node_modules_depsets)
 
-    if ctx.label.workspace_root:
-        # We need the workspace_name for the target being visited.
-        # Skylark doesn't have this - instead they have a workspace_root
-        # which looks like "external/repo_name" - so grab the second path segment.
-        # TODO(alexeagle): investigate a better way to get the workspace name
-        workspace_name = ctx.label.workspace_root.split("/")[1]
-    else:
-        workspace_name = ctx.workspace_name
+    workspace_name = ctx.label.workspace_name if ctx.label.workspace_name else ctx.workspace_name
 
     # Create a manifest file with the sources in arbitrary order, and without
     # bazel-bin prefixes ("root-relative paths").


### PR DESCRIPTION
workspace_name function was added back in 0.21.0 looks like so we can cleanup the TODOs now.

Pre-factor for #1715.