### PR TITLE
fix(builtin): fix for nodejs_binary entry point in bazel-out logic

### DIFF
--- a/internal/node/launcher.sh
+++ b/internal/node/launcher.sh
@@ -191,7 +191,10 @@ for ARG in "${ALL_ARGS[@]:-}"; do
   case "$ARG" in
     --bazel_node_modules_manifest=*) MODULES_MANIFEST="${ARG#--bazel_node_modules_manifest=}" ;;
     --nobazel_patch_module_resolver)
-      MAIN="TEMPLATED_script_path"
+      declare MAIN=$(rlocation "TEMPLATED_entry_point_manifest_path")
+      if [[ ! -f "$MAIN" ]]; then
+        MAIN="TEMPLATED_entry_point_execroot_path"
+      fi
       LAUNCHER_NODE_OPTIONS=( "--require" "$node_patches_script" )
 
       # In this case we should always run the linker

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -216,6 +216,8 @@ def _nodejs_binary_impl(ctx):
             expand_location_into_runfiles(ctx, a, ctx.attr.data)
             for a in ctx.attr.templated_args
         ]),
+        "TEMPLATED_entry_point_execroot_path": _to_execroot_path(ctx, ctx.file.entry_point),
+        "TEMPLATED_entry_point_manifest_path": _to_manifest_path(ctx, ctx.file.entry_point),
         "TEMPLATED_env_vars": env_vars,
         "TEMPLATED_expected_exit_code": str(expected_exit_code),
         "TEMPLATED_link_modules_script": _to_manifest_path(ctx, ctx.file._link_modules_script),
@@ -225,7 +227,6 @@ def _nodejs_binary_impl(ctx):
         "TEMPLATED_repository_args": _to_manifest_path(ctx, ctx.file._repository_args),
         "TEMPLATED_require_patch_script": _to_manifest_path(ctx, ctx.outputs.require_patch_script),
         "TEMPLATED_runfiles_helper_script": _to_manifest_path(ctx, ctx.file._runfiles_helper_script),
-        "TEMPLATED_script_path": _to_execroot_path(ctx, ctx.file.entry_point),
         "TEMPLATED_vendored_node": "" if is_builtin else strip_external(ctx.file._node.path),
     }
     ctx.actions.expand_template(

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary", "nodejs_test", "npm_package_bin")
 load("@build_bazel_rules_nodejs//internal/golden_file_test:golden_file_test.bzl", "golden_file_test")
+load("@npm//typescript:index.bzl", "tsc")
 load("//internal/js_library:js_library.bzl", "js_library")
 load("//internal/node:node_repositories.bzl", "BUILT_IN_NODE_PLATFORMS")
 load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "copy_file")
@@ -341,4 +342,29 @@ nodejs_test(
     data = ["empty_args_fail.js"],
     entry_point = "empty_args_fail.js",
     expected_exit_code = 0,
+)
+
+tsc(
+    name = "main_lib",
+    outs = [
+        "main.js",
+    ],
+    args = [
+        "-p",
+        "$(execpath tsconfig.json)",
+        "--outDir",
+        # $(RULEDIR) is a shorthand for the dist/bin directory where Bazel requires we write outputs
+        "$(RULEDIR)",
+    ],
+    data = [
+        "main.ts",
+        "tsconfig.json",
+    ],
+)
+
+nodejs_test(
+    name = "main_test",
+    data = [":main_lib"],
+    entry_point = ":main.js",
+    templated_args = ["--nobazel_patch_module_resolver"],
 )

--- a/internal/node/test/main.ts
+++ b/internal/node/test/main.ts
@@ -1,0 +1,1 @@
+console.log('hello world' as string);

--- a/internal/node/test/tsconfig.json
+++ b/internal/node/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "include": ["main.ts"]
+}


### PR DESCRIPTION
Pre-factor out of https://github.com/bazelbuild/rules_nodejs/pull/1715

If entry point is a generated file in bazel-out nodejs_binary fails with
```
Error: Cannot find module '/private/var/tmp/_bazel/.../foobar.sh.runfiles/wksp/bazel-out/plat-form/bin/path/to/entry_point.js'
```