### PR TITLE
fix(typescript): include extended tsconfigs in _TsConfigInfo

### DIFF
--- a/packages/typescript/src/internal/ts_project.bzl
+++ b/packages/typescript/src/internal/ts_project.bzl
@@ -123,7 +123,7 @@ def _ts_project_impl(ctx):
                 collect_default = True,
             ),
         ),
-        _TsConfigInfo(tsconfigs = depset([ctx.file.tsconfig], transitive = [
+        _TsConfigInfo(tsconfigs = depset([ctx.file.tsconfig] + ctx.files.extends, transitive = [
             dep[_TsConfigInfo].tsconfigs
             for dep in ctx.attr.deps
             if _TsConfigInfo in dep

--- a/packages/typescript/test/ts_project/a/BUILD.bazel
+++ b/packages/typescript/test/ts_project/a/BUILD.bazel
@@ -2,7 +2,10 @@ load("@npm_bazel_typescript//:index.bzl", "ts_project")
 
 ts_project(
     composite = True,
-    extends = ["//packages/typescript/test/ts_project:tsconfig-base.json"],
+    extends = [
+        ":tsconfig-extended.json",
+        "//packages/typescript/test/ts_project:tsconfig-base.json",
+    ],
     # Intentionally not syncing this option from tsconfig, to test validator suppression
     # source_map = True,
     validate = False,

--- a/packages/typescript/test/ts_project/a/tsconfig-extended.json
+++ b/packages/typescript/test/ts_project/a/tsconfig-extended.json
@@ -1,0 +1,4 @@
+// This file is an extra hop of indirection, regression test for #1754
+{
+    "extends": "../tsconfig-base"
+}

--- a/packages/typescript/test/ts_project/a/tsconfig.json
+++ b/packages/typescript/test/ts_project/a/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../tsconfig-base.json",
+    "extends": "./tsconfig-extended.json",
     "compilerOptions": {
         "sourceMap": true,
         // WORKAROUND https://github.com/microsoft/TypeScript/issues/37378


### PR DESCRIPTION
Allows ts_project to work with extra tsconfig indirections

Fixes #1754

