### PR TITLE
fix(builtin): under runfiles linker should link node_modules folder at root of runfiles tree

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'header-max-length': [2, 'always', 100],
+    'header-max-length': [2, 'always', 120],
     'scope-enum': [
       2, 'always',
       [

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -95,6 +95,11 @@ async function symlink(target: string, p: string): Promise<boolean> {
  * @param root a string like 'npm/node_modules'
  */
 async function resolveRoot(root: string|undefined, runfiles: Runfiles) {
+  if (!runfiles.execroot) {
+    // Under runfiles, the repository should be layed out in the parent directory
+    // since bazel sets our working directory to the repository where the build is happening
+    process.chdir('..');
+  }
   // create a node_modules directory if no root
   // this will be the case if only first-party modules are installed
   if (!root) {
@@ -118,7 +123,7 @@ async function resolveRoot(root: string|undefined, runfiles: Runfiles) {
   } else {
     // Under runfiles, the repository should be layed out in the parent directory
     // since bazel sets our working directory to the repository where the build is happening
-    return path.join('..', root);
+    return root;
   }
 }
 
@@ -485,17 +490,16 @@ export async function main(args: string[], runfiles: Runfiles) {
   const [modulesManifest] = args;
   let {bin, root, modules, workspace} = JSON.parse(fs.readFileSync(modulesManifest));
   modules = modules || {};
-  log_verbose(
-      `module manifest '${modulesManifest}': workspace ${workspace}, bin ${bin}, root ${
-          root} with first-party packages\n`,
-      modules);
-
-  const rootDir = await resolveRoot(root, runfiles);
-  log_verbose('resolved root', root, 'to', rootDir);
-  log_verbose('cwd', process.cwd());
+  log_verbose('manifest file', modulesManifest);
+  log_verbose('manifest contents', JSON.stringify({workspace, bin, root, modules}, null, 2));
 
   // Bazel starts actions with pwd=execroot/my_wksp
   const workspaceDir = path.resolve('.');
+
+  // resolveRoot will change the cwd when under runfiles
+  const rootDir = await resolveRoot(root, runfiles);
+  log_verbose('resolved root', root, 'to', rootDir);
+  log_verbose('cwd', process.cwd());
 
   // Create the $pwd/node_modules directory that node will resolve from
   await symlink(rootDir, 'node_modules');

--- a/internal/linker/test/link_node_modules.spec.ts
+++ b/internal/linker/test/link_node_modules.spec.ts
@@ -532,6 +532,6 @@ describe('link_node_modules', () => {
 
     // The linker expects to run as its own process, so it changes the wd
     process.chdir(path.join(process.env['TEST_TMPDIR']!, workspace));
-    expect(fs.readdirSync(path.join('node_modules', 'some-package'))).toContain('index.js');
+    expect(fs.readdirSync(path.join('..', 'node_modules', 'some-package'))).toContain('index.js');
   });
 });

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -251,13 +251,21 @@ npm_package_bin(
     tool = ":copy_to_directory",
 )
 
-nodejs_test(
+jasmine_node_test(
     name = "npm_package_bin_test",
+    srcs = ["npm_package_bin.spec.js"],
     data = [
         "dir_output",
         "minified.js",
     ],
-    entry_point = "npm_package_bin.spec.js",
+    # Turn on the linker & turn off require patches so that the external workspace jasmine_node_test
+    # entry point npm_bazel_jasmine/jasmine_runner.js's require('@bazel/jasmine') is exercised without
+    # require patches.
+    templated_args = select({
+        # TODO: fix this linker assertion on Windows
+        "@bazel_tools//src/conditions:host_windows": [],
+        "//conditions:default": ["--nobazel_patch_module_resolver"],
+    }),
 )
 
 [nodejs_toolchain_test(

--- a/internal/node/test/npm_package_bin.spec.js
+++ b/internal/node/test/npm_package_bin.spec.js
@@ -2,14 +2,15 @@ const fs = require('fs');
 const path = require('path');
 const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
 
-const min_js = path.join(runfiles.resolvePackageRelative('minified.js'));
-const content = fs.readFileSync(min_js, 'utf-8');
-if (!content.includes('{console.error("thing")}')) {
-  console.error(content);
-  process.exitCode = 1;
-}
+describe('npm_package_bin', function() {
+  it('should output a minified.js when output_dir is False', function() {
+    const content = fs.readFileSync(runfiles.resolvePackageRelative('minified.js'), 'utf-8');
+    expect(content).toContain('{console.error("thing")}')
+  });
 
-const dir = fs.readdirSync(path.join(path.dirname(min_js), 'dir_output'));
-if (!dir.includes('terser_input.js')) {
-  console.error(dir), process.exitCode = 1;
-}
+  it('should output a directory artifact named after the target when output_dir is True',
+     function() {
+       const dir = fs.readdirSync(runfiles.resolvePackageRelative('dir_output'));
+       expect(dir).toContain('terser_input.js');
+     });
+});


### PR DESCRIPTION
Currently linker is linking node_modules folder in the cwd which is `runfiles/wksp/node_modules` but this location means that script in external repositories such as `runfiles/external_wksp/path/to/script.js` will not resolve packages. This PR changes the linker to link to `runfiles/node_modules`.

-----------

test added in separate commit that fails without the fix (as expected) with:

```
FAIL: //internal/node/test:npm_package_bin_test (see /private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/execroot/build_bazel_rules_nodejs/bazel-out/darwin-fastbuild/testlogs/internal/node/test/npm_package_bin_test/test.log)
INFO: From Testing //internal/node/test:npm_package_bin_test:
==================== Test output for //internal/node/test:npm_package_bin_test:
internal/modules/cjs/loader.js:797
    throw err;
    ^

Error: Cannot find module '@bazel/jasmine'
Require stack:
- /private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/244/execroot/build_bazel_rules_nodejs/bazel-out/darwin-fastbuild/bin/internal/node/test/npm_package_bin_test.sh.runfiles/npm_bazel_jasmine/jasmine_runner.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:794:15)
    at Function.Module._load (internal/modules/cjs/loader.js:687:27)
    at Module.require (internal/modules/cjs/loader.js:849:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/244/execroot/build_bazel_rules_nodejs/bazel-out/darwin-fastbuild/bin/internal/node/test/npm_package_bin_test.sh.runfiles/npm_bazel_jasmine/jasmine_runner.js:3:22)
    at Module._compile (internal/modules/cjs/loader.js:956:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:973:10)
    at Module.load (internal/modules/cjs/loader.js:812:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1025:10) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/244/execroot/build_bazel_rules_nodejs/bazel-out/darwin-fastbuild/bin/internal/node/test/npm_package_bin_test.sh.runfiles/npm_bazel_jasmine/jasmine_runner.js'
  ]
}
```