### PR TITLE
feat(builtin): make npm_package_bin output linkable with package_name attribute

### DIFF
--- a/examples/angular_bazel_architect/BUILD.bazel
+++ b/examples/angular_bazel_architect/BUILD.bazel
@@ -35,7 +35,7 @@ architect(
         "@npm//@angular/platform-browser-dynamic",
         "@npm//@angular-devkit/architect-cli",
         "@npm//@angular-devkit/build-angular",
-        "//projects/frontend-lib:npm_package",
+        "//projects/frontend-lib",
     ],
     output_dir = True,
 )
@@ -64,7 +64,7 @@ architect_test(
         "@npm//karma-coverage-istanbul-reporter",
         "@npm//karma-jasmine",
         "@npm//karma-jasmine-html-reporter",
-        "//projects/frontend-lib:npm_package",
+        "//projects/frontend-lib",
     ],
     tags = [
         "browser:chromium-local",
@@ -110,7 +110,7 @@ architect_test(
         "@npm//@types/jasmine",
         "@npm//@types/jasminewd2",
         "@npm//@types/node",
-        "//projects/frontend-lib:npm_package",
+        "//projects/frontend-lib",
     ],
     tags = [
         "browser:chromium-local",
@@ -170,7 +170,7 @@ architect(
         "@npm//@angular/router",
         "@npm//@angular/platform-browser-dynamic",
         "@npm//@angular-devkit/build-angular",
-        "//projects/frontend-lib:npm_package",
+        "//projects/frontend-lib",
     ],
     tags = ["ibazel_notify_changes"],
 )

--- a/examples/angular_bazel_architect/projects/frontend-lib/BUILD.bazel
+++ b/examples/angular_bazel_architect/projects/frontend-lib/BUILD.bazel
@@ -1,10 +1,10 @@
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("@npm//@angular-devkit/architect-cli:index.bzl", "architect", "architect_test")
 
 package(default_visibility = ["//visibility:public"])
 
 architect(
-    name = "build",
+    name = "frontend-lib",
+    package_name = "frontend-lib",
     args = [
         "frontend-lib:build",
         "--",
@@ -75,13 +75,4 @@ architect_test(
         # 29 01 2020 23:32:46.822:WARN [launcher]: ChromeHeadless was not killed by SIGKILL in 2000 ms, continuing.
         "no-bazelci-mac",
     ],
-)
-
-pkg_npm(
-    name = "npm_package",
-    package_name = "frontend-lib",
-    # This is a workaround for the Linker When using `output_dir = True`.
-    # the ':build' target dependency has an output directory so it will end up at 'npm_package/build' instead of
-    # the root of the pkg_npm output directory.
-    nested_packages = [":build"],
 )

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -224,6 +224,7 @@ nodejs_test(
 
 npm_package_bin(
     name = "run_terser",
+    package_name = "@rules_nodejs_tests/internal_node_test_run_terser",
     outs = ["minified.js"],
     args = [
         "$(execpath terser_input.js)",
@@ -241,6 +242,7 @@ nodejs_binary(
 
 npm_package_bin(
     name = "dir_output",
+    package_name = "@rules_nodejs_tests/internal_node_test_dir_output",
     args = [
         "--output-dir",
         "$(@D)",
@@ -255,8 +257,8 @@ jasmine_node_test(
     name = "npm_package_bin_test",
     srcs = ["npm_package_bin.spec.js"],
     data = [
-        "dir_output",
-        "minified.js",
+        ":dir_output",
+        ":run_terser",
     ],
     # Turn on the linker & turn off require patches so that the external workspace jasmine_node_test
     # entry point npm_bazel_jasmine/jasmine_runner.js's require('@bazel/jasmine') is exercised without

--- a/internal/node/test/npm_package_bin.spec.js
+++ b/internal/node/test/npm_package_bin.spec.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
-const path = require('path');
 const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
+const isWindows = process.platform === 'win32';
 
 describe('npm_package_bin', function() {
   it('should output a minified.js when output_dir is False', function() {
@@ -8,9 +8,31 @@ describe('npm_package_bin', function() {
     expect(content).toContain('{console.error("thing")}')
   });
 
+  if (!isWindows) {
+    // TODO: fix this linker assertion on Windows
+    it('should be linkable via package_name to the package output directory when output_dir is False',
+       function() {
+         const content = fs.readFileSync(
+             require.resolve('@rules_nodejs_tests/internal_node_test_run_terser/minified.js'),
+             'utf-8');
+         expect(content).toContain('{console.error("thing")}')
+       });
+  }
+
   it('should output a directory artifact named after the target when output_dir is True',
      function() {
        const dir = fs.readdirSync(runfiles.resolvePackageRelative('dir_output'));
        expect(dir).toContain('terser_input.js');
      });
+
+  if (!isWindows) {
+    // TODO: fix this linker assertion on Windows
+    it('should be linkable via package_name to the rule output directory when output_dir is True',
+       function() {
+         const content = fs.readFileSync(
+             require.resolve('@rules_nodejs_tests/internal_node_test_dir_output/terser_input.js'),
+             'utf-8');
+         expect(content).toContain('    console.error(\'thing\');')
+       });
+  }
 });


### PR DESCRIPTION
This will allow for a simplified pattern for npm_package_bin rules that make fully linkable packages such as `architect()`:

previously:
```
architect(
    name = "build",
    args = [
        "frontend-lib:build",
        "--",
        "$(@D)"
    ],
    data = ...,
    output_dir = True,
)

 pkg_npm(
     name = "npm_package",
     package_name = "frontend-lib",
     nested_packages = [":build"],
 )
```

with this feature:
```
architect(
    name = "build",
    args = [
        "frontend-lib:build",
        "--",
        "$(@D)"
    ],
    data = ...,
    package_name = "frontend-lib",
    output_dir = True,
)
```

Since the output of `pkg_npm` above is identical to that of `architect`, unless you want the pack & publish functionality of `pkg_npm` you can simplify and save copying the files around by using `package_name` on `architect` instead.