### PR TITLE
fix(builtin): fix for pkg_npm single directory artifact dep case

### DIFF
--- a/examples/angular_bazel_architect/BUILD.bazel
+++ b/examples/angular_bazel_architect/BUILD.bazel
@@ -35,7 +35,7 @@ architect(
         "@npm//@angular/platform-browser-dynamic",
         "@npm//@angular-devkit/architect-cli",
         "@npm//@angular-devkit/build-angular",
-        "//projects/frontend-lib:npm_package",
+        "//projects/frontend-lib",
     ],
     output_dir = True,
 )
@@ -64,7 +64,7 @@ architect_test(
         "@npm//karma-coverage-istanbul-reporter",
         "@npm//karma-jasmine",
         "@npm//karma-jasmine-html-reporter",
-        "//projects/frontend-lib:npm_package",
+        "//projects/frontend-lib",
     ],
     tags = [
         "browser:chromium-local",
@@ -110,7 +110,7 @@ architect_test(
         "@npm//@types/jasmine",
         "@npm//@types/jasminewd2",
         "@npm//@types/node",
-        "//projects/frontend-lib:npm_package",
+        "//projects/frontend-lib",
     ],
     tags = [
         "browser:chromium-local",
@@ -170,7 +170,7 @@ architect(
         "@npm//@angular/router",
         "@npm//@angular/platform-browser-dynamic",
         "@npm//@angular-devkit/build-angular",
-        "//projects/frontend-lib:npm_package",
+        "//projects/frontend-lib",
     ],
     tags = ["ibazel_notify_changes"],
 )

--- a/examples/angular_bazel_architect/projects/frontend-lib/BUILD.bazel
+++ b/examples/angular_bazel_architect/projects/frontend-lib/BUILD.bazel
@@ -78,10 +78,7 @@ architect_test(
 )
 
 pkg_npm(
-    name = "npm_package",
+    name = "frontend-lib",
     package_name = "frontend-lib",
-    # This is a workaround for the Linker When using `output_dir = True`.
-    # the ':build' target dependency has an output directory so it will end up at 'npm_package/build' instead of
-    # the root of the pkg_npm output directory.
-    nested_packages = [":build"],
+    srcs = [":build"],
 )

--- a/internal/pkg_npm/BUILD.bazel
+++ b/internal/pkg_npm/BUILD.bazel
@@ -14,14 +14,15 @@ exports_files(["pkg_npm.bzl"])
 
 nodejs_binary(
     name = "packager",
-    data = [
-        "packager.js",
-        "//third_party/github.com/gjtorikian/isBinaryFile",
-        "@nodejs//:run_npm.sh.template",
-    ],
+    data = ["//third_party/github.com/gjtorikian/isBinaryFile"],
     entry_point = ":packager.js",
     install_source_map_support = False,
-    visibility = ["//visibility:public"],
+)
+
+nodejs_binary(
+    name = "npm_script_generator",
+    entry_point = ":npm_script_generator.js",
+    install_source_map_support = False,
 )
 
 filegroup(

--- a/internal/pkg_npm/npm_script_generator.js
+++ b/internal/pkg_npm/npm_script_generator.js
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @fileoverview This script generates npm pack & publish shell scripts from
+ * a template.
+ */
+'use strict';
+
+const fs = require('fs');
+
+function main(args) {
+  const [outDir, packPath, publishPath, runNpmTemplatePath] = args;
+  const npmTemplate = fs.readFileSync(runNpmTemplatePath, {encoding: 'utf-8'});
+  const cwd = process.cwd();
+  if (/[\//]sandbox[\//]/.test(cwd)) {
+    console.error('Error: npm_script_generator must be run with no sandbox');
+    process.exit(1);
+  }
+  fs.writeFileSync(packPath, npmTemplate.replace('TMPL_args', `pack "${cwd}/${outDir}"`));
+  fs.writeFileSync(publishPath, npmTemplate.replace('TMPL_args', `publish "${cwd}/${outDir}"`));
+}
+
+if (require.main === module) {
+  process.exitCode = main(process.argv.slice(2));
+}

--- a/internal/pkg_npm/test/BUILD.bazel
+++ b/internal/pkg_npm/test/BUILD.bazel
@@ -60,10 +60,35 @@ pkg_npm(
     ],
 )
 
+pkg_npm(
+    name = "test_noop_pkg",
+    # Special case where these is a single dep that is a directory artifact
+    # then we assume the package is contained within that single directory
+    # and the pkg_npm rules does not need to copy any files
+    deps = [":rollup/bundle/subdirectory"],
+)
+
+pkg_npm(
+    name = "test_noop2_pkg",
+    # Special case where these is a single dep that is a directory artifact
+    # then we assume the package is contained within that single directory
+    # and the pkg_npm rules does not need to copy any files
+    srcs = [":rollup/bundle/subdirectory"],
+)
+
 jasmine_node_test(
     name = "test",
     srcs = ["pkg_npm.spec.js"],
-    data = [":test_pkg"],
+    data = [
+        ":test_noop2_pkg",
+        ":test_noop_pkg",
+        ":test_pkg",
+    ],
+    templated_args = [
+        "$(rootpath :test_pkg)",
+        "$(rootpath :test_noop_pkg)",
+        "$(rootpath :test_noop2_pkg)",
+    ],
 )
 
 genrule(

--- a/internal/pkg_npm/test/pkg_npm.spec.js
+++ b/internal/pkg_npm/test/pkg_npm.spec.js
@@ -1,50 +1,62 @@
 const fs = require('fs');
-const path = require('path');
 const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
+const args = process.argv.slice(2);
+const testPkgRootpath = args[0];
+const testNoopPkgRootpath = args[1];
+const testNoop2PkgRootpath = args[2];
+const testPkgPath = runfiles.resolveWorkspaceRelative(testPkgRootpath);
+const testNoopPkgPath = runfiles.resolveWorkspaceRelative(testNoopPkgRootpath);
+const testNoop2PkgPath = runfiles.resolveWorkspaceRelative(testNoop2PkgRootpath);
 
-function read(p) {
-  // We want to look up the test_pkg directory artifact in the runfiles.
-  // The manifest does have an entry for it, but since it's a directory we cannot use
-  // require.resolve to lookup that entry. So instead we lookup the sibling file in runfiles and
-  // bootstrap the filesystem lookup from there.
-  const dir = path.dirname(runfiles.resolvePackageRelative('test_loader.js'));
-  return fs.readFileSync(path.join(dir, 'test_pkg', p), {encoding: 'utf-8'}).trim();
+function readFromPkg(p) {
+  return fs.readFileSync(`${testPkgPath}/${p}`, {encoding: 'utf-8'}).trim();
 }
 
-describe('pkg_npm srcs', () => {
+function readFromNoopPkg(p) {
+  return fs.readFileSync(`${testNoopPkgPath}/${p}`, {encoding: 'utf-8'}).trim();
+}
+
+function readFromNoop2Pkg(p) {
+  return fs.readFileSync(`${testNoop2PkgPath}/${p}`, {encoding: 'utf-8'}).trim();
+}
+
+describe('pkg_npm', () => {
+  it('creates an output directory after the rule name', () => {
+    expect(testPkgRootpath).toEqual('internal/pkg_npm/test/test_pkg');
+  });
   it('copies srcs and replaces contents', () => {
-    expect(read('some_file')).toEqual('replaced');
+    expect(readFromPkg('some_file')).toEqual('replaced');
   });
   it('copies dependencies from bazel-genfiles', () => {
-    expect(read('a_dep')).toEqual('a_dep content');
+    expect(readFromPkg('a_dep')).toEqual('a_dep content');
   });
   it('copies files from other packages', () => {
-    expect(read('dependent_file')).toEqual('dependent_file content');
+    expect(readFromPkg('dependent_file')).toEqual('dependent_file content');
   });
   it('copies js files from ts_library', () => {
-    expect(read('foo.js')).toContain('exports.a = \'\';');
+    expect(readFromPkg('foo.js')).toContain('exports.a = \'\';');
   });
   it('copies declaration files from ts_library', () => {
-    expect(read('foo.d.ts')).toContain('export declare const a: string;');
+    expect(readFromPkg('foo.d.ts')).toContain('export declare const a: string;');
   });
   it('copies data dependencies', () => {
-    expect(read('data.json')).toEqual('[]');
+    expect(readFromPkg('data.json')).toEqual('[]');
   });
   it('replaced 0.0.0-PLACEHOLDER', () => {
-    expect(JSON.parse(read('package.json')).version).toEqual('1.2.3');
+    expect(JSON.parse(readFromPkg('package.json')).version).toEqual('1.2.3');
   });
   it('copies files from deps', () => {
-    expect(read('bundle.min.js')).toBe('bundle content');
+    expect(readFromPkg('bundle.min.js')).toBe('bundle content');
   });
   it('copies files from external workspace if included in srcs', () => {
-    expect(read('vendored_external_file')).toEqual('vendored_external_file content');
+    expect(readFromPkg('vendored_external_file')).toEqual('vendored_external_file content');
   });
   it('copies js files from external workspace ts_library if included in vendor_external', () => {
-    expect(read('external.js')).toContain('exports.b = \'\';');
+    expect(readFromPkg('external.js')).toContain('exports.b = \'\';');
   });
   it('copies declaration files from external workspace ts_library if included in vendor_external',
      () => {
-       expect(read('external.d.ts')).toContain('export declare const b: string;');
+       expect(readFromPkg('external.d.ts')).toContain('export declare const b: string;');
      });
   it('vendors external workspaces',
      () => {
@@ -52,6 +64,16 @@ describe('pkg_npm srcs', () => {
          // has to live in the root of the repository in order for external/foo to appear inside it
      });
   it('copies entire contents of directories',
-     () => {expect(read('rollup/bundle/subdirectory/index.js'))
+     () => {expect(readFromPkg('rollup/bundle/subdirectory/index.js'))
                 .toContain(`const a = '';\n\nexport { a }`)});
+  it('does not create an output directory if single dep is a directory artifact', () => {
+    expect(testNoopPkgRootpath).toEqual('internal/pkg_npm/test/rollup/bundle/subdirectory');
+  });
+  it('re-roots to directory artifact if single dep is a directory artifact',
+     () => {expect(readFromNoopPkg('index.js')).toContain(`const a = '';\n\nexport { a }`)});
+  it('does not create an output directory if single dep is a directory artifact', () => {
+    expect(testNoop2PkgRootpath).toEqual('internal/pkg_npm/test/rollup/bundle/subdirectory');
+  });
+  it('re-roots to directory artifact if single dep is a directory artifact',
+     () => {expect(readFromNoop2Pkg('index.js')).toContain(`const a = '';\n\nexport { a }`)});
 });


### PR DESCRIPTION
This fixes an issue where pkg_npm has a single dep which is a directory artifact but the contents of that dep are not re-rooted. Re-rooting is the expected behaviour as the only way to create a valid npm package with a package.json at the root is to re-root to the output directory of the dep as that is the only place a package.json may live in this case.

The fix is actually to not copy anything but to just forward the directory artifact dep onto the default info of pkg_npm. Some refactoring done so that the npm scripts are generated in a separate action from the package.js which is not run in the single directory artifact dep case.

**Also fixes the dependency on bazel-out symlink for the .pack & .publish scripts. Those script now contain absolute paths to the package root in bazel-out.**

-------

build: simplify examples/angular_bazel_architect now that pkg_npm handles single directory artifact dep

Removes hacky work-around in that example that was using nested_packages attribute