### PR TITLE
fix(rollup): fix worker not picking up config file changes

### DIFF
--- a/packages/rollup/src/index.js
+++ b/packages/rollup/src/index.js
@@ -39,10 +39,10 @@ try {
 // Store the cache forever to re-use on each build
 let cacheMap = Object.create(null);
 
-// Generate a unique cache ID based on the input/outputOptions
-function computeCacheKey(inputOptions, outputOptions) {
+// Generate a unique cache ID based on the given json data
+function computeCacheKey(cacheKeyData) {
   const hash = crypto.createHash('sha256');
-  const hashContent = JSON.stringify(inputOptions) + JSON.stringify(outputOptions);
+  const hashContent = JSON.stringify(cacheKeyData);
   return hash.update(hashContent).digest('hex');
 }
 

--- a/packages/rollup/src/index.js
+++ b/packages/rollup/src/index.js
@@ -105,6 +105,10 @@ async function loadConfigFile(configFile) {
 
   await runRollup(configFile, inputOptions, outputOptions);
 
+  // Ensure node isn't caching a previous version of the config file
+  // https://github.com/rollup/rollup/blob/v1.31.0/cli/run/loadConfigFile.ts#L52
+  delete require.cache[require.resolve(cjsConfigFile)];
+
   // Read the config file:
   // https://github.com/rollup/rollup/blob/v1.31.0/cli/run/loadConfigFile.ts#L54-L61
   //


### PR DESCRIPTION
Node caches `require()` calls, so when we re-`require()` the potentially changed `rollup.config.cjs.js` we need to ensure it's not cached.

Basically copying: https://github.com/rollup/rollup/blob/v1.31.0/cli/run/loadConfigFile.ts#L52