### PR TITLE
fix(npm_umd_bundle): include all json files

### DIFF
--- a/internal/npm_install/npm_umd_bundle.bzl
+++ b/internal/npm_install/npm_umd_bundle.bzl
@@ -40,7 +40,7 @@ def _npm_umd_bundle(ctx):
     inputs = [
         f
         for f in sources
-        if f.path.endswith(".js") or f.basename == "package.json"
+        if f.path.endswith(".js") or f.path.endswith(".json")
     ]
 
     ctx.actions.run(


### PR DESCRIPTION
To make a UMD bundle of the popular react testing library enzyme, bundling json files from @npm//entities is required

