### PR TITLE
ci: increase no_output_timeout to 30m for integration job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
 
       - run:
           command: ./scripts/ci/run_integration_tests.sh ${CIRCLE_NODE_INDEX} ${CIRCLE_NODE_TOTAL}
-          no_output_timeout: 10m
+          no_output_timeout: 30m
 
   test_integration_manual:
     <<: *job_defaults

--- a/scripts/ci/run_integration_tests.sh
+++ b/scripts/ci/run_integration_tests.sh
@@ -33,4 +33,4 @@ done
 echo "Shard index ${SHARD_INDEX} of ${MAX_SHARDS} shards"
 echo "Targets: ${SHARD_TARGETS[@]:-}"
 echo
-bazel test --local_ram_resources=792 --test_arg=--local_ram_resources=13312 --test_arg=--local_cpu_resources=7 ${SHARD_TARGETS[@]:-}
+bazel test --local_ram_resources=792 --test_arg=--local_ram_resources=13312 --test_arg=--local_cpu_resources=7 ${SHARD_TARGETS[@]:-} --test_output=streamed


### PR DESCRIPTION
If an integration test is failing, retries can hit the no_output_time. Also add test_output=streamed to integration test CI.
