### PR TITLE
fix(builtin): look in the execroot for nodejs_binary source entry_points

### DIFF
--- a/internal/node/launcher.sh
+++ b/internal/node/launcher.sh
@@ -191,10 +191,7 @@ for ARG in "${ALL_ARGS[@]:-}"; do
   case "$ARG" in
     --bazel_node_modules_manifest=*) MODULES_MANIFEST="${ARG#--bazel_node_modules_manifest=}" ;;
     --nobazel_patch_module_resolver)
-      declare MAIN="TEMPLATED_entry_point_execroot_path"
-      if [[ ! -f "$MAIN" ]]; then
-        MAIN=$(rlocation "TEMPLATED_entry_point_manifest_path")
-      fi
+      MAIN=TEMPLATED_entry_point_execroot_path
       LAUNCHER_NODE_OPTIONS=( "--require" "$node_patches_script" )
 
       # In this case we should always run the linker
@@ -211,6 +208,11 @@ done
 # Link the first-party modules into node_modules directory before running the actual program
 if [[ -n "${MODULES_MANIFEST:-}" ]]; then
   "${node}" "${link_modules_script}" "${MODULES_MANIFEST:-}"
+fi
+
+# TODO: after we link-all-bins we should not need this extra lookup
+if [[ ! -f "$MAIN" ]]; then
+  MAIN=TEMPLATED_entry_point_manifest_path
 fi
 
 # Tell the node_patches_script that programs should not escape the execroot


### PR DESCRIPTION
In a6e29c2add19dd487035b0951f5271053a0a11e2 we added support for generated entry_point by adding a secondary lookup.
In 863c7de48046c35dfe29f6a4f625ca3e7057b030 we reversed the order of the lookups to make rollup work in a certain use case.
Neither of these was principled, because we know ahead of time whether the entry_point is generated. We can use a single lookup.

This also makes sure that programs run in the location where the linker will put them (note that the logic in question runs before the linker has created the node_modules directory in the execroot.)
This is why #1787 observes that some node programs were broken - we were running the entry point as
bazel-out/host/bin/external/npm/@graphql-codegen/cli/bin/graphql-codegen.sh.runfiles/npm/node_modules/@graphql-codegen/cli/bin.js
when it should have been
node_modules/@graphql-codegen/cli/bin.js

Fixes #1787