### PR TITLE
fix(builtin): fix node patches lstat short-circuit logic

### DIFF
--- a/internal/node/node_patches.js
+++ b/internal/node/node_patches.js
@@ -84,7 +84,7 @@ exports.patcher = (fs = fs$1, root, guards) => {
     const origReadlinkSync = fs.readlinkSync.bind(fs);
     const origReaddir = fs.readdir.bind(fs);
     const origReaddirSync = fs.readdirSync.bind(fs);
-    const { isEscape, isOutPath } = exports.escapeFunction(root, guards);
+    const { isEscape } = exports.escapeFunction(root, guards);
     // tslint:disable-next-line:no-any
     fs.lstat = (...args) => {
         let cb = args.length > 1 ? args[args.length - 1] : undefined;
@@ -95,8 +95,7 @@ exports.patcher = (fs = fs$1, root, guards) => {
                 if (err)
                     return cb(err);
                 const linkPath = path.resolve(args[0]);
-                // if this is not a symlink or the path is not inside the root it has no way to escape.
-                if (!stats.isSymbolicLink() || !root || isOutPath(linkPath)) {
+                if (!stats.isSymbolicLink()) {
                     return cb(null, stats);
                 }
                 return origReadlink(args[0], (err, str) => {
@@ -197,9 +196,9 @@ exports.patcher = (fs = fs$1, root, guards) => {
     fs.lstatSync = (...args) => {
         const stats = origLstatSync(...args);
         const linkPath = path.resolve(args[0]);
-        // if this is not a symlink or the path is not inside the root it has no way to escape.
-        if (!stats.isSymbolicLink() || isOutPath(linkPath))
+        if (!stats.isSymbolicLink()) {
             return stats;
+        }
         let linkTarget;
         try {
             linkTarget = path.resolve(path.dirname(args[0]), origReadlinkSync(linkPath));

--- a/packages/node-patches/src/fs.ts
+++ b/packages/node-patches/src/fs.ts
@@ -55,7 +55,7 @@ export const patcher = (fs: any = _fs, root: string, guards: string[]) => {
   const origReaddir = fs.readdir.bind(fs);
   const origReaddirSync = fs.readdirSync.bind(fs);
 
-  const {isEscape, isOutPath} = escapeFunction(root, guards);
+  const {isEscape} = escapeFunction(root, guards);
 
   const logged: {[k: string]: boolean} = {};
 
@@ -74,8 +74,7 @@ export const patcher = (fs: any = _fs, root: string, guards: string[]) => {
         if (err) return cb(err);
 
         const linkPath = path.resolve(args[0]);
-        // if this is not a symlink or the path is not inside the root it has no way to escape.
-        if (!stats.isSymbolicLink() || !root || isOutPath(linkPath)) {
+        if (!stats.isSymbolicLink()) {
           return cb(null, stats);
         }
 
@@ -177,8 +176,9 @@ export const patcher = (fs: any = _fs, root: string, guards: string[]) => {
   fs.lstatSync = (...args: any[]) => {
     const stats = origLstatSync(...args);
     const linkPath = path.resolve(args[0]);
-    // if this is not a symlink or the path is not inside the root it has no way to escape.
-    if (!stats.isSymbolicLink() || isOutPath(linkPath)) return stats;
+    if (!stats.isSymbolicLink()) {
+      return stats;
+    }
     let linkTarget: string;
     try {
       linkTarget = path.resolve(path.dirname(args[0]), origReadlinkSync(linkPath));


### PR DESCRIPTION
Follow up fix to #1800.

The short-circuit logic for lstat and lstatSync needs updating after adding in guards logic. Fixes issue observed in angular-cli with webpack enhanced resolver.
