### PR TITLE
Docs: Add mandatory argument to `npm init @bazel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ This is the fastest way to get started.
 See the [installation documentation](https://bazelbuild.github.io/rules_nodejs/install.html) for details and alternative methods, or if you already have a Bazel project and you're adding Node/JavaScript support to it.
 
 ```sh
-$ npm init @bazel
+$ npm init @bazel myproject   # creates './myproject/', sets up Bazel workspace
 ```
 
 or if you prefer yarn,
 
 ```sh
-$ yarn create @bazel
+$ yarn create @bazel myproject
 ```
 
 > These commands are equivalent to `npx @bazel/create` which downloads the latest version of the `@bazel/create` package from npm and runs the program contained.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ yarn create @bazel myproject
 
 > These commands are equivalent to `npx @bazel/create` which downloads the latest version of the `@bazel/create` package from npm and runs the program contained.
 
-See the output of the tool for command-line options and next steps.
+See the output of `npm init @bazel` or `yarn create @bazel` for command-line options and next steps.
 
 ## Adopters
 


### PR DESCRIPTION
It seems that `npm init @bazel` requires an argument, the name of the subdirectory which will be created. Changing the README to reflect that requirement.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

The "Quickstart" section of the the README instructs users to run `npm init @bazel`, but that command, if run as specified, will print an error message that may be confusing to people who are new to Bazel.

Issue Number: N/A

## What is the new behavior?

Updates the README to say `npm init @bazel myproject`, along with a very short bit of documentation saying basically what that will do.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

