### PR TITLE
chore: add bazel-out and dist folders to bazelignore

### DIFF
--- a/e2e/jasmine/.bazelignore
+++ b/e2e/jasmine/.bazelignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+bazel-out

--- a/examples/angular/.bazelignore
+++ b/examples/angular/.bazelignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+bazel-out

--- a/examples/angular_bazel_architect/.bazelignore
+++ b/examples/angular_bazel_architect/.bazelignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+bazel-out

--- a/examples/angular_view_engine/.bazelignore
+++ b/examples/angular_view_engine/.bazelignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+bazel-out

--- a/examples/app/.bazelignore
+++ b/examples/app/.bazelignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+bazel-out

--- a/examples/closure/.bazelignore
+++ b/examples/closure/.bazelignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+bazel-out

--- a/examples/jest/.bazelignore
+++ b/examples/jest/.bazelignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+bazel-out

--- a/examples/nestjs/.bazelignore
+++ b/examples/nestjs/.bazelignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+bazel-out

--- a/examples/parcel/.bazelignore
+++ b/examples/parcel/.bazelignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+bazel-out

--- a/examples/protocol_buffers/.bazelignore
+++ b/examples/protocol_buffers/.bazelignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+bazel-out

--- a/examples/react_webpack/.bazelignore
+++ b/examples/react_webpack/.bazelignore
@@ -1,1 +1,3 @@
 node_modules
+bazel-out
+dist

--- a/examples/vendored_node/.bazelignore
+++ b/examples/vendored_node/.bazelignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+bazel-out

--- a/examples/vendored_node_and_yarn/.bazelignore
+++ b/examples/vendored_node_and_yarn/.bazelignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+bazel-out

--- a/examples/web_testing/.bazelignore
+++ b/examples/web_testing/.bazelignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+bazel-out

--- a/examples/webapp/.bazelignore
+++ b/examples/webapp/.bazelignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+bazel-out

--- a/packages/create/index.js
+++ b/packages/create/index.js
@@ -174,7 +174,10 @@ load("@npm_bazel_typescript//:index.bzl", "ts_setup_workspace")
 ts_setup_workspace()`;
   }
   write('WORKSPACE.bazel', workspaceContent);
-  write('.bazelignore', `node_modules`);
+  write('.bazelignore', `node_modules
+dist
+bazel-out
+`);
   write(
       'package.json',
       JSON.stringify(


### PR DESCRIPTION
In the projects created with @bazel/create and in our examples.
Fixes issue reported on slack, where building examples/react_webpack fails on the second run
(because a glob in ts_project was picking up sources under bazel-out)
