### PR TITLE
fix(builtin): fix linker issue when running test with "local" tag on osx & linux

### DIFF
--- a/internal/linker/index.js
+++ b/internal/linker/index.js
@@ -89,6 +89,10 @@ function resolveRoot(root, startCwd, isExecroot, runfiles) {
             return fromManifest;
         }
         else {
+            const maybe = path.resolve(`${symlinkRoot}/external/${root}`);
+            if (fs.existsSync(maybe)) {
+                return maybe;
+            }
             return path.resolve(`${startCwd}/../${root}`);
         }
     });

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -142,8 +142,17 @@ async function resolveRoot(
   if (fromManifest) {
     return fromManifest;
   } else {
-    // Under runfiles, the root will be one folder up from the startCwd `runfiles/my_wksp`.
-    // This is true whether legacy external runfiles are on or off.
+    const maybe = path.resolve(`${symlinkRoot}/external/${root}`);
+    if (fs.existsSync(maybe)) {
+      // Under runfiles, when not in the sandbox we must symlink node_modules down at the execroot
+      // `execroot/my_wksp/external/npm/node_modules` since `runfiles/npm/node_modules` will be a
+      // directory and not a symlink back to the root node_modules where we expect
+      // to resolve from. This case is tested in internal/linker/test/local.
+      return maybe;
+    }
+    // However, when in the sandbox, `execroot/my_wksp/external/npm/node_modules` does not exist,
+    // so we must symlink into `runfiles/npm/node_modules`. This directory exists whether legacy
+    // external runfiles are on or off.
     return path.resolve(`${startCwd}/../${root}`)
   }
 }

--- a/internal/linker/test/local/BUILD.bazel
+++ b/internal/linker/test/local/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@npm_bazel_jasmine//:index.from_src.bzl", "jasmine_node_test")
+
+jasmine_node_test(
+    name = "test",
+    srcs = ["test.js"],
+    tags = ["local"],
+    templated_args = ["--nobazel_patch_module_resolver"],
+    deps = ["//internal/linker/test/local/fit"],
+)

--- a/internal/linker/test/local/fit/BUILD.bazel
+++ b/internal/linker/test/local/fit/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+load("@npm//typescript:index.bzl", "tsc")
+
+tsc(
+    name = "fit_lib",
+    outs = [
+        "main.d.ts",
+        "main.js",
+    ],
+    args = [
+        "-p",
+        "$(execpath tsconfig.json)",
+        "--outDir",
+        # $(RULEDIR) is a shorthand for the dist/bin directory where Bazel requires we write outputs
+        "$(RULEDIR)",
+    ],
+    data = [
+        "main.ts",
+        "tsconfig.json",
+    ],
+)
+
+pkg_npm(
+    name = "fit",
+    package_name = "fit",
+    srcs = ["package.json"],
+    visibility = ["//internal/linker/test/local:__pkg__"],
+    deps = [":fit_lib"],
+)

--- a/internal/linker/test/local/fit/main.ts
+++ b/internal/linker/test/local/fit/main.ts
@@ -1,0 +1,1 @@
+export const fit: string = 'fit';

--- a/internal/linker/test/local/fit/package.json
+++ b/internal/linker/test/local/fit/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "fit",
+  "main": "main.js",
+  "typings": "main.d.ts"
+}

--- a/internal/linker/test/local/fit/tsconfig.json
+++ b/internal/linker/test/local/fit/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "declaration": true
+  }
+}

--- a/internal/linker/test/local/test.js
+++ b/internal/linker/test/local/test.js
@@ -1,0 +1,6 @@
+describe('linker', () => {
+  it('should work when job run with "local" tag', () => {
+    const fit = require('fit');
+    expect(fit.fit).toBe('fit');
+  });
+});


### PR DESCRIPTION
```
    const maybe = path.resolve(`${symlinkRoot}/external/${root}`);
    if (fs.existsSync(maybe)) {
      // Under runfiles, when not in the sandbox we must symlink node_modules down at the execroot
      // `execroot/my_wksp/external/npm/node_modules` since `runfiles/npm/node_modules` will be a
      // directory and not a symlink back to the root node_modules where we expect
      // to resolve from. This case is tested in internal/linker/test/local.
      return maybe;
    }
    // However, when in the sandbox, `execroot/my_wksp/external/npm/node_modules` does not exist,
    // so we must symlink into `runfiles/npm/node_modules`. This directory exists whether legacy
    // external runfiles are on or off.
    return path.resolve(`${startCwd}/../${root}`)
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

