### PR TITLE
test(typescript): add test for including generated json file

### DIFF
--- a/packages/typescript/src/internal/ts_project.bzl
+++ b/packages/typescript/src/internal/ts_project.bzl
@@ -191,7 +191,7 @@ validate_options = rule(
 )
 
 def _out_paths(srcs, ext):
-    return [f[:f.rindex(".")] + ext for f in srcs if not f.endswith(".d.ts")]
+    return [f[:f.rindex(".")] + ext for f in srcs if not f.endswith(".d.ts") and f.endswith(".ts")]
 
 def ts_project_macro(
         name = "tsconfig",

--- a/packages/typescript/test/ts_project/generated_json/BUILD.bazel
+++ b/packages/typescript/test/ts_project/generated_json/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@npm_bazel_typescript//:index.bzl", "ts_project")
+load("//third_party/github.com/bazelbuild/bazel-skylib:rules/write_file.bzl", "write_file")
+
+write_file(
+    name = "dummy",
+    out = "dummy.json",
+    content = ["{ }"],
+)
+
+ts_project(
+    name = "generated",
+    srcs = [
+        "dummy",
+        "test.ts",
+    ],
+    tsconfig = "tsconfig.json",
+)

--- a/packages/typescript/test/ts_project/generated_json/test.ts
+++ b/packages/typescript/test/ts_project/generated_json/test.ts
@@ -1,0 +1,3 @@
+import dummy from './dummy.json'
+
+console.error(dummy)

--- a/packages/typescript/test/ts_project/generated_json/tsconfig.json
+++ b/packages/typescript/test/ts_project/generated_json/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "esModuleInterop": true,
+        "resolveJsonModule": true,
+        "rootDirs": [
+            ".",
+            "../../../../../bazel-out/darwin-fastbuild/bin/packages/typescript/test/ts_project/generated_json/",
+            "../../../../../bazel-out/k8-fastbuild/bin/packages/typescript/test/ts_project/generated_json/",
+            "../../../../../bazel-out/x64_windows-fastbuild/bin/packages/typescript/test/ts_project/generated_json/",
+            "../../../../../bazel-out/darwin-dbg/bin/packages/typescript/test/ts_project/generated_json/",
+            "../../../../../bazel-out/k8-dbg/bin/packages/typescript/test/ts_project/generated_json/",
+            "../../../../../bazel-out/x64_windows-dbg/bin/packages/typescript/test/ts_project/generated_json/",
+        ],
+    },
+}


### PR DESCRIPTION
Adds a reproducer for an issue with loading a generated json file using
ts_project.

Adding the generated json file as a src to the ts_project required
modifying the expects rule outputs (will extract this to a separate
patch).

The test currently fails with:
    'rootDir' is expected to contain all source files.

Signed-off-by: Duarte Nunes <duarte@uma.ni>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Other... Please describe:

Reproducer for an issue.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

