### PR TITLE
feat(builtin): add DeclarationInfo to js_library

### DIFF
--- a/internal/providers/declaration_info.bzl
+++ b/internal/providers/declaration_info.bzl
@@ -36,8 +36,14 @@ This prevents needing an aspect in rules that consume the typings, which improve
 def declaration_info(declarations, deps = []):
     """Constructs a DeclarationInfo including all transitive declarations from DeclarationInfo providers in a list of deps.
 
-Returns a single DeclarationInfo.
-"""
+    # TODO: add some checking actions to ensure the declarations are well-formed and don't have semantic diagnostics
+
+    Args:
+        declarations: list of .d.ts files
+        deps: list of labels of dependencies where we should collect their DeclarationInfo to pass transitively
+    Returns:
+        a single DeclarationInfo provider
+    """
     transitive_depsets = [declarations]
     for dep in deps:
         if DeclarationInfo in dep:

--- a/internal/providers/declaration_info.bzl
+++ b/internal/providers/declaration_info.bzl
@@ -14,20 +14,11 @@
 
 """This module contains a provider for TypeScript typings files (.d.ts)"""
 
-def provide_declarations(**kwargs):
-    """Factory function for creating checked declarations with externs.
-
-    Do not directly construct DeclarationInfo()
-    """
-
-    # TODO: add some checking actions to ensure the declarations are well-formed
-    return DeclarationInfo(**kwargs)
-
 DeclarationInfo = provider(
     doc = """The DeclarationInfo provider allows JS rules to communicate typing information.
 TypeScript's .d.ts files are used as the interop format for describing types.
 
-Do not create DeclarationInfo instances directly, instead use the provide_declarations factory function.
+Do not create DeclarationInfo instances directly, instead use the declaration_info factory function.
 
 TODO(alexeagle): The ts_library#deps attribute should require that this provider is attached.
 
@@ -41,3 +32,21 @@ This prevents needing an aspect in rules that consume the typings, which improve
         "type_blacklisted_declarations": """A depset of .d.ts files that we should not use to infer JSCompiler types (via tsickle)""",
     },
 )
+
+def declaration_info(declarations, deps = []):
+    """Constructs a DeclarationInfo including all transitive declarations from DeclarationInfo providers in a list of deps.
+
+Returns a single DeclarationInfo.
+"""
+    transitive_depsets = [declarations]
+    for dep in deps:
+        if DeclarationInfo in dep:
+            transitive_depsets.append(dep[DeclarationInfo].transitive_declarations)
+
+    return DeclarationInfo(
+        declarations = declarations,
+        transitive_declarations = depset(transitive = transitive_depsets),
+        # Downstream ts_library rules will fail if they don't find this field
+        # Even though it is only for Google Closure Compiler externs generation
+        type_blacklisted_declarations = depset(),
+    )

--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -1,6 +1,6 @@
 "ts_project rule"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "NpmPackageInfo", "run_node")
+load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "NpmPackageInfo", "declaration_info", "run_node")
 
 _DEFAULT_TSC = (
     # BEGIN-INTERNAL
@@ -131,18 +131,7 @@ def _ts_project_impl(ctx):
     # Don't provide DeclarationInfo if there are no typings to provide.
     # Improves error messaging if a ts_project needs declaration = True
     if len(typings_outputs) or len(ctx.attr.deps):
-        providers.append(
-            DeclarationInfo(
-                declarations = depset(typings_outputs),
-                transitive_declarations = depset(typings_outputs, transitive = [
-                    dep[DeclarationInfo].transitive_declarations
-                    for dep in ctx.attr.deps
-                ]),
-                # Downstream ts_library rules will fail if they don't find this field
-                # Even though it is only for Google Closure Compiler externs generation
-                type_blacklisted_declarations = depset(),
-            ),
-        )
+        providers.append(declaration_info(depset(typings_outputs), ctx.attr.deps))
 
     return providers
 

--- a/packages/typescript/test/ts_project/js_library/BUILD.bazel
+++ b/packages/typescript/test/ts_project/js_library/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@npm_bazel_typescript//:index.bzl", "ts_project")
 load("//internal/js_library:js_library.bzl", "js_library")
+load("//packages/typescript:index.bzl", "ts_project")
 
 js_library(
     name = "lib_a",

--- a/packages/typescript/test/ts_project/js_library/BUILD.bazel
+++ b/packages/typescript/test/ts_project/js_library/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@npm_bazel_typescript//:index.bzl", "ts_project")
+load("//internal/js_library:js_library.bzl", "js_library")
+
+js_library(
+    name = "lib_a",
+    srcs = [
+        "a.d.ts",
+        "a.js",
+    ],
+)
+
+ts_project(
+    name = "tsconfig",
+    srcs = ["b.ts"],
+    deps = ["lib_a"],
+)

--- a/packages/typescript/test/ts_project/js_library/a.d.ts
+++ b/packages/typescript/test/ts_project/js_library/a.d.ts
@@ -1,0 +1,1 @@
+export declare const a: string;

--- a/packages/typescript/test/ts_project/js_library/a.js
+++ b/packages/typescript/test/ts_project/js_library/a.js
@@ -1,0 +1,3 @@
+'use strict';
+exports.__esModule = true;
+exports.a = 'a';

--- a/packages/typescript/test/ts_project/js_library/b.ts
+++ b/packages/typescript/test/ts_project/js_library/b.ts
@@ -1,0 +1,2 @@
+import {a} from './a';
+console.log(a.toLowerCase());

--- a/packages/typescript/test/ts_project/js_library/tsconfig.json
+++ b/packages/typescript/test/ts_project/js_library/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "files": ["b.ts"],
+    "compilerOptions": {
+        // Help TypeScript locate the a.d.ts file from dep. Needed when running in a sandbox or remote.
+        "rootDirs": [
+            ".",
+            "../../../../../bazel-out/darwin-fastbuild/bin/packages/typescript/test/ts_project/js_library",
+            "../../../../../bazel-out/k8-fastbuild/bin/packages/typescript/test/ts_project/js_library",
+            "../../../../../bazel-out/x64_windows-fastbuild/bin/packages/typescript/test/ts_project/js_library",
+            "../../../../../bazel-out/darwin-dbg/bin/packages/typescript/test/ts_project/js_library",
+            "../../../../../bazel-out/k8-dbg/bin/packages/typescript/test/ts_project/js_library",
+            "../../../../../bazel-out/x64_windows-dbg/bin/packages/typescript/test/ts_project/js_library",
+        ],
+    }
+}

--- a/packages/typescript/test/ts_project/js_library/tsconfig.json
+++ b/packages/typescript/test/ts_project/js_library/tsconfig.json
@@ -1,7 +1,10 @@
 {
     "files": ["b.ts"],
     "compilerOptions": {
-        // Help TypeScript locate the a.d.ts file from dep. Needed when running in a sandbox or remote.
+        "types": [],
+        // Help TypeScript locate the a.d.ts file from dep.
+        // Note that it comes from a js_library which means the .d.ts file is copied to the bazel-out folder.
+        // Needed when running in a sandbox or remote.
         "rootDirs": [
             ".",
             "../../../../../bazel-out/darwin-fastbuild/bin/packages/typescript/test/ts_project/js_library",

--- a/providers.bzl
+++ b/providers.bzl
@@ -20,7 +20,7 @@ Users should not load files under "/internal"
 load(
     "//internal/providers:declaration_info.bzl",
     _DeclarationInfo = "DeclarationInfo",
-    _provide_declarations = "provide_declarations",
+    _declaration_info = "declaration_info",
 )
 load(
     "//internal/providers:js_providers.bzl",
@@ -44,8 +44,8 @@ load(
     _node_modules_aspect = "node_modules_aspect",
 )
 
-provide_declarations = _provide_declarations
 DeclarationInfo = _DeclarationInfo
+declaration_info = _declaration_info
 JSNamedModuleInfo = _JSNamedModuleInfo
 js_named_module_info = _js_named_module_info
 JSEcmaScriptModuleInfo = _JSEcmaScriptModuleInfo


### PR DESCRIPTION
Adds a declaration_info provider factory which simplifies ts_project. Also add a ts_project test to validate that js_library be a dep to ts_project.

BREAKING CHANGE:

Removed provide_declarations() factory function for DeclarationInfo. Use declaration_info() factory function instead.

To discuss is whether or not to promote js_library to public API for 2.0?