### PR TITLE
feat(builtin): add JSModuleInfo provider

### DIFF
--- a/internal/js_library/js_library.bzl
+++ b/internal/js_library/js_library.bzl
@@ -17,7 +17,7 @@
 DO NOT USE - this is not fully designed, and exists only to enable testing within this repo.
 """
 
-load("//:providers.bzl", "LinkablePackageInfo", "declaration_info")
+load("//:providers.bzl", "LinkablePackageInfo", "declaration_info", "js_module_info")
 load("//third_party/github.com/bazelbuild/bazel-skylib:rules/private/copy_file_private.bzl", "copy_bash", "copy_cmd")
 
 _AMD_NAMES_DOC = """Mapping from require module names to global variables.
@@ -52,6 +52,7 @@ def write_amd_names_shim(actions, amd_names_shim, targets):
 def _impl(ctx):
     files = []
     typings = []
+    js_files = []
 
     for src in ctx.files.srcs:
         if src.is_source and not src.path.startswith("external/"):
@@ -69,6 +70,10 @@ def _impl(ctx):
         else:
             files.append(src)
 
+    for p in files:
+        if p.basename.endswith(".js") or p.basename.endswith(".js.map") or p.basename.endswith(".json"):
+            js_files.append(p)
+
     files_depset = depset(files)
 
     providers = [
@@ -77,6 +82,7 @@ def _impl(ctx):
             runfiles = ctx.runfiles(files = ctx.files.srcs),
         ),
         AmdNamesInfo(names = ctx.attr.amd_names),
+        js_module_info(depset(js_files)),
     ]
 
     if ctx.attr.package_name:

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -20,7 +20,7 @@ They support module mapping: any targets in the transitive dependencies with
 a `module_name` attribute can be `require`d by that name.
 """
 
-load("//:providers.bzl", "JSNamedModuleInfo", "NodeRuntimeDepsInfo", "NpmPackageInfo", "node_modules_aspect")
+load("//:providers.bzl", "JSModuleInfo", "NodeRuntimeDepsInfo", "NpmPackageInfo", "node_modules_aspect")
 load("//internal/common:expand_into_runfiles.bzl", "expand_location_into_runfiles")
 load("//internal/common:module_mappings.bzl", "module_mappings_runtime_aspect")
 load("//internal/common:path_utils.bzl", "strip_external")
@@ -165,9 +165,8 @@ def _nodejs_binary_impl(ctx):
     sources_depsets = []
 
     for d in ctx.attr.data:
-        # TODO: switch to JSModuleInfo when it is available
-        if JSNamedModuleInfo in d:
-            sources_depsets.append(d[JSNamedModuleInfo].sources)
+        if JSModuleInfo in d:
+            sources_depsets.append(d[JSModuleInfo].sources)
         if hasattr(d, "files"):
             sources_depsets.append(d.files)
     sources = depset(transitive = sources_depsets)

--- a/internal/node/npm_package_bin.bzl
+++ b/internal/node/npm_package_bin.bzl
@@ -1,6 +1,6 @@
 "A generic rule to run a tool that appears in node_modules/.bin"
 
-load("//:providers.bzl", "NpmPackageInfo", "node_modules_aspect", "run_node")
+load("//:providers.bzl", "JSModuleInfo", "NpmPackageInfo", "node_modules_aspect", "run_node")
 load("//internal/common:expand_variables.bzl", "expand_variables")
 load("//internal/linker:link_node_modules.bzl", "module_mappings_aspect")
 
@@ -33,6 +33,8 @@ def _inputs(ctx):
     for d in ctx.attr.data:
         if NpmPackageInfo in d:
             inputs_depsets.append(d[NpmPackageInfo].sources)
+        if JSModuleInfo in d:
+            inputs_depsets.append(d[JSModuleInfo].sources)
     return depset(ctx.files.data, transitive = inputs_depsets).to_list()
 
 def _impl(ctx):

--- a/internal/npm_install/node_module_library.bzl
+++ b/internal/npm_install/node_module_library.bzl
@@ -15,7 +15,7 @@
 """Contains the node_module_library which is used by yarn_install & npm_install.
 """
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "NpmPackageInfo", "js_named_module_info")
+load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "NpmPackageInfo", "js_module_info", "js_named_module_info")
 
 def _node_module_library_impl(ctx):
     workspace_name = ctx.label.workspace_name if ctx.label.workspace_name else ctx.workspace_name
@@ -70,6 +70,10 @@ def _node_module_library_impl(ctx):
                 declarations = declarations,
                 transitive_declarations = transitive_declarations,
                 type_blacklisted_declarations = depset([]),
+            ),
+            js_module_info(
+                sources = direct_sources,
+                deps = ctx.attr.deps,
             ),
             js_named_module_info(
                 sources = depset(ctx.files.named_module_srcs),

--- a/internal/pkg_npm/pkg_npm.bzl
+++ b/internal/pkg_npm/pkg_npm.bzl
@@ -6,7 +6,7 @@ If all users of your library code use Bazel, they should just add your library
 to the `deps` of one of their targets.
 """
 
-load("//:providers.bzl", "DeclarationInfo", "JSNamedModuleInfo", "LinkablePackageInfo", "NodeContextInfo")
+load("//:providers.bzl", "DeclarationInfo", "JSModuleInfo", "LinkablePackageInfo", "NodeContextInfo")
 
 _DOC = """The pkg_npm rule creates a directory containing a publishable npm artifact.
 
@@ -253,9 +253,8 @@ def _pkg_npm(ctx):
         deps_files_depsets.append(dep.files)
 
         # All direct & transitive JavaScript-producing deps
-        # TODO: switch to JSModuleInfo when it is available
-        if JSNamedModuleInfo in dep:
-            deps_files_depsets.append(dep[JSNamedModuleInfo].sources)
+        if JSModuleInfo in dep:
+            deps_files_depsets.append(dep[JSModuleInfo].sources)
 
         # Include all transitive declerations
         if DeclarationInfo in dep:

--- a/internal/providers/js_providers.bzl
+++ b/internal/providers/js_providers.bzl
@@ -36,6 +36,29 @@ If users really need to produce both in a single build, they'll need two rules w
 differing 'debug' attributes.
 """
 
+JSModuleInfo = provider(
+    doc = """JavaScript files and sourcemaps.""",
+    fields = {
+        "direct_sources": "Depset of direct JavaScript files and sourcemaps",
+        "sources": "Depset of direct and transitive JavaScript files and sourcemaps",
+    },
+)
+
+def js_module_info(sources, deps = []):
+    """Constructs a JSModuleInfo including all transitive sources from JSModuleInfo providers in a list of deps.
+
+Returns a single JSModuleInfo.
+"""
+    transitive_depsets = [sources]
+    for dep in deps:
+        if JSModuleInfo in dep:
+            transitive_depsets.append(dep[JSModuleInfo].sources)
+
+    return JSModuleInfo(
+        direct_sources = sources,
+        sources = depset(transitive = transitive_depsets),
+    )
+
 JSNamedModuleInfo = provider(
     doc = """JavaScript files whose module name is self-contained.
 

--- a/packages/karma/karma_web_test.bzl
+++ b/packages/karma/karma_web_test.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 "Unit testing with Karma"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo", "NpmPackageInfo", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSModuleInfo", "JSNamedModuleInfo", "NpmPackageInfo", "node_modules_aspect")
 load("@build_bazel_rules_nodejs//internal/js_library:js_library.bzl", "write_amd_names_shim")
 load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_suite")
 load("@io_bazel_rules_webtesting//web/internal:constants.bzl", "DEFAULT_WRAPPED_TEST_TAGS")
@@ -128,9 +128,8 @@ def _write_karma_config(ctx, files, amd_names_shim):
     config_file = None
 
     if ctx.attr.config_file:
-        # TODO: switch to JSModuleInfo when it is available
-        if JSNamedModuleInfo in ctx.attr.config_file:
-            config_file = _filter_js(ctx.attr.config_file[JSNamedModuleInfo].direct_sources.to_list())[0]
+        if JSModuleInfo in ctx.attr.config_file:
+            config_file = _filter_js(ctx.attr.config_file[JSModuleInfo].direct_sources.to_list())[0]
         else:
             config_file = ctx.file.config_file
 
@@ -295,9 +294,8 @@ ${{COMMAND}}
     config_sources = []
 
     if ctx.attr.config_file:
-        # TODO: switch to JSModuleInfo when it is available
-        if JSNamedModuleInfo in ctx.attr.config_file:
-            config_sources = ctx.attr.config_file[JSNamedModuleInfo].sources.to_list()
+        if JSModuleInfo in ctx.attr.config_file:
+            config_sources = ctx.attr.config_file[JSModuleInfo].sources.to_list()
         else:
             config_sources = [ctx.file.config_file]
 

--- a/packages/labs/grpc_web/ts_proto_library.bzl
+++ b/packages/labs/grpc_web/ts_proto_library.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 "Protocol Buffers"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "JSEcmaScriptModuleInfo", "JSNamedModuleInfo")
+load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "JSEcmaScriptModuleInfo", "JSModuleInfo", "JSNamedModuleInfo")
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 
 typescript_proto_library_aspect = provider(
@@ -242,6 +242,10 @@ def _ts_proto_library_impl(ctx):
                 declarations = dts_outputs,
                 transitive_declarations = transitive_declarations,
                 type_blacklisted_declarations = depset([]),
+            ),
+            JSModuleInfo(
+                direct_sources = es5_srcs,
+                sources = es5_srcs,
             ),
             JSNamedModuleInfo(
                 direct_sources = es5_srcs,

--- a/packages/labs/protobufjs/ts_proto_library.bzl
+++ b/packages/labs/protobufjs/ts_proto_library.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 "Protocol Buffers"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "JSEcmaScriptModuleInfo", "JSNamedModuleInfo")
+load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "JSEcmaScriptModuleInfo", "JSModuleInfo", "JSNamedModuleInfo")
 
 def _run_pbjs(actions, executable, var, output_name, proto_files, suffix = ".js", wrap = "default", amd_name = ""):
     js_file = actions.declare_file(output_name + suffix)
@@ -123,6 +123,10 @@ def _ts_proto_library(ctx):
                 declarations = declarations,
                 transitive_declarations = declarations,
                 type_blacklisted_declarations = depset([]),
+            ),
+            JSModuleInfo(
+                direct_sources = es5_sources,
+                sources = es5_sources,
             ),
             JSNamedModuleInfo(
                 direct_sources = es5_sources,

--- a/packages/protractor/protractor_web_test.bzl
+++ b/packages/protractor/protractor_web_test.bzl
@@ -14,7 +14,7 @@
 "Run end-to-end tests with Protractor"
 
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo", "NpmPackageInfo", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSModuleInfo", "JSNamedModuleInfo", "NpmPackageInfo", "node_modules_aspect")
 load("@build_bazel_rules_nodejs//internal/common:windows_utils.bzl", "create_windows_native_launcher_script", "is_windows")
 load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_suite")
 load("@io_bazel_rules_webtesting//web/internal:constants.bzl", "DEFAULT_WRAPPED_TEST_TAGS")
@@ -80,10 +80,9 @@ def _protractor_web_test_impl(ctx):
     configuration_sources = []
     configuration_file = None
     if ctx.attr.configuration:
-        # TODO: switch to JSModuleInfo when it is available
-        if JSNamedModuleInfo in ctx.attr.configuration:
-            configuration_sources = ctx.attr.configuration[JSNamedModuleInfo].sources.to_list()
-            configuration_file = _filter_js(ctx.attr.configuration[JSNamedModuleInfo].direct_sources.to_list())[0]
+        if JSModuleInfo in ctx.attr.configuration:
+            configuration_sources = ctx.attr.configuration[JSModuleInfo].sources.to_list()
+            configuration_file = _filter_js(ctx.attr.configuration[JSModuleInfo].direct_sources.to_list())[0]
         else:
             configuration_sources = [ctx.file.configuration]
             configuration_file = ctx.file.configuration
@@ -91,10 +90,9 @@ def _protractor_web_test_impl(ctx):
     on_prepare_sources = []
     on_prepare_file = None
     if ctx.attr.on_prepare:
-        # TODO: switch to JSModuleInfo when it is available
-        if JSNamedModuleInfo in ctx.attr.on_prepare:
-            on_prepare_sources = ctx.attr.on_prepare[JSNamedModuleInfo].sources.to_list()
-            on_prepare_file = _filter_js(ctx.attr.on_prepare[JSNamedModuleInfo].direct_sources.to_list())[0]
+        if JSModuleInfo in ctx.attr.on_prepare:
+            on_prepare_sources = ctx.attr.on_prepare[JSModuleInfo].sources.to_list()
+            on_prepare_file = _filter_js(ctx.attr.on_prepare[JSModuleInfo].direct_sources.to_list())[0]
         else:
             on_prepare_sources = [ctx.file.on_prepare]
             on_prepare_file = ctx.file.on_prepare

--- a/packages/rollup/rollup_bundle.bzl
+++ b/packages/rollup/rollup_bundle.bzl
@@ -1,6 +1,6 @@
 "Rules for running Rollup under Bazel"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSEcmaScriptModuleInfo", "NodeContextInfo", "NpmPackageInfo", "node_modules_aspect", "run_node")
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSEcmaScriptModuleInfo", "JSModuleInfo", "NodeContextInfo", "NpmPackageInfo", "node_modules_aspect", "run_node")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "module_mappings_aspect")
 
 _DOC = """Runs the Rollup.js CLI under Bazel.
@@ -308,6 +308,8 @@ def _rollup_bundle(ctx):
     for dep in ctx.attr.deps:
         if JSEcmaScriptModuleInfo in dep:
             deps_depsets.append(dep[JSEcmaScriptModuleInfo].sources)
+        elif JSModuleInfo in dep:
+            deps_depsets.append(dep[JSModuleInfo].sources)
         elif hasattr(dep, "files"):
             deps_depsets.append(dep.files)
 
@@ -397,8 +399,11 @@ def _rollup_bundle(ctx):
         env = {"COMPILATION_MODE": ctx.var["COMPILATION_MODE"]},
     )
 
+    outputs_depset = depset(outputs)
+
     return [
-        DefaultInfo(files = depset(outputs)),
+        DefaultInfo(files = outputs_depset),
+        JSModuleInfo(sources = outputs_depset),
     ]
 
 rollup_bundle = rule(

--- a/packages/terser/test/js_srcs/BUILD.bazel
+++ b/packages/terser/test/js_srcs/BUILD.bazel
@@ -1,0 +1,41 @@
+load("//packages/jasmine:index.bzl", "jasmine_node_test")
+load("//packages/terser:index.bzl", "terser_minified")
+
+# Case 2: get the JS file from DefaultInfo of a dep
+load(":produces_js_as_defaultinfo.bzl", "produces_js_as_defaultinfo")
+
+filegroup(
+    name = "src1_in",
+    srcs = [
+        "src1.js",
+        "src1b.js",
+    ],
+)
+
+terser_minified(
+    name = "case1",
+    src = ":src1_in",
+    sourcemap = False,
+)
+
+produces_js_as_defaultinfo(
+    name = "src2_in",
+    srcs = ["src2.js"],
+)
+
+terser_minified(
+    name = "case2",
+    src = ":src2_in",
+    sourcemap = False,
+)
+
+jasmine_node_test(
+    name = "test",
+    srcs = [
+        "terser_spec.js",
+    ],
+    deps = [
+        ":case1",
+        ":case2",
+    ],
+)

--- a/packages/terser/test/js_srcs/produces_js_as_defaultinfo.bzl
+++ b/packages/terser/test/js_srcs/produces_js_as_defaultinfo.bzl
@@ -1,0 +1,9 @@
+"test fixture"
+
+def _produces_js_as_defaultinfo(ctx):
+    return DefaultInfo(files = depset(ctx.files.srcs))
+
+produces_js_as_defaultinfo = rule(
+    _produces_js_as_defaultinfo,
+    attrs = {"srcs": attr.label_list(allow_files = True)},
+)

--- a/packages/terser/test/js_srcs/src1.js
+++ b/packages/terser/test/js_srcs/src1.js
@@ -1,0 +1,5 @@
+/**
+ * @fileoverview Description of this file.
+ */
+
+console.error('here is non-optimized JS');

--- a/packages/terser/test/js_srcs/src1b.js
+++ b/packages/terser/test/js_srcs/src1b.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/packages/terser/test/js_srcs/src2.js
+++ b/packages/terser/test/js_srcs/src2.js
@@ -1,0 +1,1 @@
+console.log('src2');

--- a/packages/terser/test/js_srcs/terser_spec.js
+++ b/packages/terser/test/js_srcs/terser_spec.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
+
+describe('terser rule', () => {
+  it('should accept InputArtifact (file in project)', () => {
+    const file = runfiles.resolvePackageRelative('case1.js');
+    const debugBuild = /\/bazel-out\/[^/\s]*-dbg\//.test(file);
+    const expected = debugBuild ?
+        'console.error("here is non-optimized JS");\n\nexport const a = 1;' :
+        'console.error("here is non-optimized JS");export const a=1;';
+    expect(fs.readFileSync(file, 'utf-8')).toBe(expected);
+  });
+  it('should accept a rule that produces JS files in DefaultInfo', () => {
+    const file = runfiles.resolvePackageRelative('case2.js');
+    expect(fs.readFileSync(file, 'utf-8')).toBe('console.log("src2");');
+  });
+});

--- a/packages/typescript/internal/build_defs.bzl
+++ b/packages/typescript/internal/build_defs.bzl
@@ -14,7 +14,7 @@
 
 "TypeScript compilation"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "LinkablePackageInfo", "NpmPackageInfo", "js_ecma_script_module_info", "js_named_module_info", "node_modules_aspect", "run_node")
+load("@build_bazel_rules_nodejs//:providers.bzl", "LinkablePackageInfo", "NpmPackageInfo", "js_ecma_script_module_info", "js_module_info", "js_named_module_info", "node_modules_aspect", "run_node")
 
 # pylint: disable=unused-argument
 # pylint: disable=missing-docstring
@@ -314,6 +314,10 @@ def _ts_library_impl(ctx):
     # See design doc https://docs.google.com/document/d/1ggkY5RqUkVL4aQLYm7esRW978LgX3GUCnQirrk5E1C0/edit#
     # and issue https://github.com/bazelbuild/rules_nodejs/issues/57 for more details.
     ts_providers["providers"].extend([
+        js_module_info(
+            sources = ts_providers["typescript"]["es5_sources"],
+            deps = ctx.attr.deps,
+        ),
         js_named_module_info(
             sources = ts_providers["typescript"]["es5_sources"],
             deps = ctx.attr.deps,
@@ -322,8 +326,7 @@ def _ts_library_impl(ctx):
             sources = ts_providers["typescript"]["es6_sources"],
             deps = ctx.attr.deps,
         ),
-        # TODO: Add remaining shared JS provider from design doc
-        # (JSModuleInfo) and remove legacy "typescript" provider
+        # TODO: remove legacy "typescript" provider
         # once it is no longer needed.
     ])
 

--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -1,6 +1,6 @@
 "ts_project rule"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "NpmPackageInfo", "declaration_info", "run_node")
+load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "NpmPackageInfo", "declaration_info", "js_module_info", "run_node")
 
 _DEFAULT_TSC = (
     # BEGIN-INTERNAL
@@ -127,6 +127,10 @@ def _ts_project_impl(ctx):
                 transitive_files = runtime_outputs,
                 collect_default = True,
             ),
+        ),
+        js_module_info(
+            sources = runtime_outputs,
+            deps = ctx.attr.deps,
         ),
         _TsConfigInfo(tsconfigs = depset([ctx.file.tsconfig] + ctx.files.extends, transitive = [
             dep[_TsConfigInfo].tsconfigs

--- a/providers.bzl
+++ b/providers.bzl
@@ -25,8 +25,10 @@ load(
 load(
     "//internal/providers:js_providers.bzl",
     _JSEcmaScriptModuleInfo = "JSEcmaScriptModuleInfo",
+    _JSModuleInfo = "JSModuleInfo",
     _JSNamedModuleInfo = "JSNamedModuleInfo",
     _js_ecma_script_module_info = "js_ecma_script_module_info",
+    _js_module_info = "js_module_info",
     _js_named_module_info = "js_named_module_info",
 )
 load(
@@ -46,6 +48,8 @@ load(
 
 DeclarationInfo = _DeclarationInfo
 declaration_info = _declaration_info
+JSModuleInfo = _JSModuleInfo
+js_module_info = _js_module_info
 JSNamedModuleInfo = _JSNamedModuleInfo
 js_named_module_info = _js_named_module_info
 JSEcmaScriptModuleInfo = _JSEcmaScriptModuleInfo


### PR DESCRIPTION
**BREAKING CHANGE**

Adds JSModuleInfo provider as the common provider for passing & consuming javascript sources and related files such as .js.map, .json, etc.

For 1.0 we added JSNamedModuleInfo and JSEcmaScriptModuleInfo which were provided by ts_library and consumed by rules that needed to differentiate between the two default flavors of ts_library outputs (named-UMD & esm). We left out JSModuleInfo as its use case was unclear at the time.

For 2.0 we're adding JSModuleInfo as generic javascript provided for the rules_nodejs ecosystem. It is not currently opinionated about the module format of the sources or the language level. Consumers of JSModuleInfo should be aware of what module format & language level is being produced if necessary.

The following rules provide JSModuleInfo:

* ts_library (devmode named-UMD .js output flavor)
* ts_proto_library (devmode named-UMD .js output flavor)
* node_module_library (this is a behind the scenes rule used by yarn_install & npm_install)
* js_library (.js, .js.map & . json files)
* rollup_bundle
* terser_minfied
* ts_project

The following rules consume JSModuleInfo:

* nodejs_binary & nodejs_test (along with derivate macros such as jasmine_node_test); these rules no longer consume JSNamedModuleInfo
* npm_package_bin
* pkg_npm; no longer consumes JSNamedModuleInfo
* karma_web_test (for config file instead of JSNamedModuleInfo; JSNamedModuleInfo still used for test files)
* protractor_web_test (for config & on_prepare files instead of JSModuleInfo; JSNamedModuleInfo still used for test files)
* rollup_bundle (if JSEcmaScriptModuleInfo not provided)
* terser_minified
