### PR TITLE
fix(builtin): rerun yarn_install and npm_install when node version changes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,6 +51,7 @@ load("@build_bazel_rules_nodejs//:index.bzl", "npm_install", "yarn_install")
 yarn_install(
     name = "npm",
     data = [
+        "//:patches/jest-haste-map+25.3.0.patch",
         "//internal/npm_install/test:postinstall.js",
     ],
     environment = {

--- a/examples/vendored_node_and_yarn/WORKSPACE
+++ b/examples/vendored_node_and_yarn/WORKSPACE
@@ -52,7 +52,7 @@ yarn_install(
     name = "npm",
     data = [
         "@vendored_node_10_12_0//:node-v10.12.0-linux-x64/bin/node",
-        "@vendored_yarn_1_10_0//:vendored_yarn_1_10_0/yarn-v1.10.0/bin/yarn.js",
+        "@vendored_yarn_1_10_0//:yarn-v1.10.0/bin/yarn.js",
     ],
     package_json = "//:package.json",
     yarn_lock = "//:yarn.lock",

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -280,6 +280,9 @@ def _download_node(repository_ctx):
       repository_ctx: The repository rule context
     """
     if repository_ctx.attr.vendored_node:
+        repository_ctx.file("node_info", content = "# vendored_node: {vendored_node}".format(
+            vendored_node = repository_ctx.attr.vendored_node,
+        ))
         return
 
     # The host is baked into the repository name by design.
@@ -304,6 +307,15 @@ def _download_node(repository_ctx):
         sha256 = sha256,
     )
 
+    repository_ctx.file("node_info", content = """# filename: {filename}
+# strip_prefix: {strip_prefix}
+# sha256: {sha256}
+""".format(
+        filename = filename,
+        strip_prefix = strip_prefix,
+        sha256 = sha256,
+    ))
+
 def _download_yarn(repository_ctx):
     """Used to download a yarn tool package.
 
@@ -311,6 +323,9 @@ def _download_yarn(repository_ctx):
       repository_ctx: The repository rule context
     """
     if repository_ctx.attr.vendored_yarn:
+        repository_ctx.file("yarn_info", content = "# vendored_yarn: {vendored_yarn}".format(
+            vendored_yarn = repository_ctx.attr.vendored_yarn,
+        ))
         return
 
     yarn_version = repository_ctx.attr.yarn_version
@@ -328,6 +343,15 @@ def _download_yarn(repository_ctx):
         stripPrefix = strip_prefix,
         sha256 = sha256,
     )
+
+    repository_ctx.file("yarn_info", content = """# filename: {filename}
+# strip_prefix: {strip_prefix}
+# sha256: {sha256}
+""".format(
+        filename = filename,
+        strip_prefix = strip_prefix,
+        sha256 = sha256,
+    ))
 
 def _prepare_node(repository_ctx):
     """Sets up BUILD files and shell wrappers for the versions of NodeJS, npm & yarn just set up.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "homepage": "https://github.com/bazelbuild/rules_nodejs",
     "repository": "https://github.com/bazelbuild/rules_nodejs",
     "license": "Apache-2.0",
+    "engines": {
+        "node": ">=12.0.0 < 13",
+        "yarn": ">=1.13.0"
+    },
     "devDependencies": {
         "@angular/common": "^9.1.0",
         "@angular/compiler": "^9.1.0",


### PR DESCRIPTION
Also always symlink package.json and lock file and copy over data files to ensure that yarn_install and npm_install rerun when any of these change and to ensure that all of the labels passed to `data` are evaluated by Bazel to ensure they are regular files. A typo in a label is a very easy error to make as the label must be `//:patches/jest-haste-map+25.3.0.patch` and not `//patches:jest-haste-map+25.3.0.patch` for example if `//patches` is not a package. With this fix, Bazel will check that the labels passed to `data` are valid.

Fixes #1712
Fixes #1714
Fixes #1311
Fixes #1601