### PR TITLE
ci: fix broken master

### DIFF
--- a/package.bzl
+++ b/package.bzl
@@ -108,8 +108,11 @@ def rules_nodejs_dev_dependencies():
 
     http_archive(
         name = "rules_pkg",
-        url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.6/rules_pkg-0.2.6.tar.gz",
-        sha256 = "a5cca9cf01c7fcfe4aab8ef54ce590e49c4921fa0d4d194b5f0ad732a8b207c4",
+        urls = [
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.6-1/rules_pkg-0.2.6.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.2.6/rules_pkg-0.2.6.tar.gz",
+        ],
+        sha256 = "aeca78988341a2ee1ba097641056d168320ecc51372ef7ff8e64b139516a4937",
     )
 
 def _maybe(repo_rule, name, **kwargs):


### PR DESCRIPTION
Someone deleted a published release from github
