### PR TITLE
feat(rollup): update the peerDependencies version range to >=2.3.0 <3.0.0

### DIFF
--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@bazel/rollup",
     "peerDependencies": {
-        "rollup": ">=1.0.0 <2.0.0"
+        "rollup": ">=2.3.0 <3.0.0"
     },
     "description": "Run rollup.js bundler under Bazel",
     "license": "Apache-2.0",


### PR DESCRIPTION
>=2.3.0 adds API support for CLI/config parsing: https://github.com/rollup/rollup/pull/3445

Is that the right commit message (feat)?