### PR TITLE
feat(builtin): more idiomatic pkg_npm

### DIFF
--- a/index.bzl
+++ b/index.bzl
@@ -30,7 +30,7 @@ load(
 load("//internal/node:node_repositories.bzl", _node_repositories = "node_repositories")
 load("//internal/node:npm_package_bin.bzl", _npm_bin = "npm_package_bin")
 load("//internal/npm_install:npm_install.bzl", _npm_install = "npm_install", _yarn_install = "yarn_install")
-load("//internal/pkg_npm:pkg_npm.bzl", _pkg_npm = "pkg_npm")
+load("//internal/pkg_npm:pkg_npm.bzl", _pkg_npm = "pkg_npm_macro")
 load("//internal/pkg_web:pkg_web.bzl", _pkg_web = "pkg_web")
 
 check_bazel_version = _check_bazel_version

--- a/internal/pkg_npm/BUILD.bazel
+++ b/internal/pkg_npm/BUILD.bazel
@@ -13,6 +13,12 @@ bzl_library(
 exports_files(["pkg_npm.bzl"])
 
 nodejs_binary(
+    name = "validator",
+    entry_point = "pkg_npm_validator.js",
+    visibility = ["//visibility:public"],
+)
+
+nodejs_binary(
     name = "packager",
     data = ["//third_party/github.com/gjtorikian/isBinaryFile"],
     entry_point = ":packager.js",

--- a/internal/pkg_npm/pkg_npm_validator.js
+++ b/internal/pkg_npm/pkg_npm_validator.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+
+function main([packageJsonPath, packageName, target, output]) {
+  const failures = [], buildozerCmds = [];
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  if (packageJson.name !== packageName) {
+    failures.push(`attribute package_name=${packageName} does not match package.json name = "${
+        packageJson.name}"`);
+    buildozerCmds.push(`set package_name "${packageJson.name}"`)
+  }
+
+  if (failures.length > 0) {
+    console.error(`ERROR: pkg_npm rule ${
+        target} was configured with attributes that don't match the package.json file:`);
+    failures.forEach(f => console.error(' - ' + f));
+    console.error('\nYou can automatically fix this by running:');
+    console.error(
+        `    npx @bazel/buildozer ${buildozerCmds.map(c => `'${c}'`).join(' ')} ${target}`);
+    console.error('Or to suppress this error, run:');
+    console.error(`    npx @bazel/buildozer 'set validate False' ${target}`);
+    return 1;
+  }
+
+  // We have to write an output so that Bazel needs to execute this action.
+  // Make the output change whenever the attributes changed.
+  require('fs').writeFileSync(
+      output, `
+  // ${process.argv[1]} checked attributes for ${target}
+  // packageName:           ${packageName}
+  `,
+      'utf-8');
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main(process.argv.slice(2));
+  } catch (e) {
+    console.error(process.argv[1], e);
+  }
+}

--- a/internal/pkg_npm/test/BUILD.bazel
+++ b/internal/pkg_npm/test/BUILD.bazel
@@ -40,6 +40,7 @@ node_context_data(
 
 pkg_npm(
     name = "test_pkg",
+    package_name = "test-pkg",
     srcs = [
         "package.json",
         "some_file",

--- a/internal/pkg_npm/test/linking/bar/BUILD.bazel
+++ b/internal/pkg_npm/test/linking/bar/BUILD.bazel
@@ -19,5 +19,6 @@ pkg_npm(
         "main.js",
         "package.json",
     ],
+    validate = False,
     visibility = ["//internal/pkg_npm/test/linking:__pkg__"],
 )

--- a/internal/pkg_npm/test/linking/feb/BUILD.bazel
+++ b/internal/pkg_npm/test/linking/feb/BUILD.bazel
@@ -21,6 +21,7 @@ pkg_npm(
     name = "scoped_feb",
     package_name = "@scoped/feb",
     srcs = ["package.json"],
+    validate = False,
     visibility = ["//internal/pkg_npm/test/linking:__pkg__"],
     deps = [":feb_lib"],
 )

--- a/internal/pkg_npm/test/linking/fub/BUILD.bazel
+++ b/internal/pkg_npm/test/linking/fub/BUILD.bazel
@@ -32,6 +32,7 @@ pkg_npm(
     name = "scoped_fub",
     package_name = "@scoped/fub",
     srcs = ["package.json"],
+    validate = False,
     visibility = ["//internal/pkg_npm/test/linking:__pkg__"],
     deps = [":fub_lib"],
 )

--- a/packages/create/BUILD.bazel
+++ b/packages/create/BUILD.bazel
@@ -16,6 +16,7 @@ copy_file(
 
 pkg_npm(
     name = "npm_package",
+    package_name = "@bazel/create",
     srcs = [
         "README.md",
         "index.js",

--- a/packages/karma/BUILD.bazel
+++ b/packages/karma/BUILD.bazel
@@ -105,6 +105,7 @@ copy_file(
 
 pkg_npm(
     name = "npm_package",
+    package_name = "@bazel/karma",
     srcs = [
         "index.bzl",
         "karma.conf.js",

--- a/packages/protractor/BUILD.bazel
+++ b/packages/protractor/BUILD.bazel
@@ -85,6 +85,7 @@ copy_file(
 
 pkg_npm(
     name = "npm_package",
+    package_name = "@bazel/protractor",
     srcs = [
         "index.bzl",
         "package.bzl",

--- a/packages/rollup/BUILD.bazel
+++ b/packages/rollup/BUILD.bazel
@@ -86,6 +86,7 @@ copy_file(
 
 pkg_npm(
     name = "npm_package",
+    package_name = "@bazel/rollup",
     srcs = [
         "index.bzl",
         "index.js",

--- a/packages/terser/BUILD.bazel
+++ b/packages/terser/BUILD.bazel
@@ -62,6 +62,7 @@ copy_file(
 
 pkg_npm(
     name = "npm_package",
+    package_name = "@bazel/terser",
     srcs = [
         "index.bzl",
         "index.js",

--- a/packages/typescript/BUILD.bazel
+++ b/packages/typescript/BUILD.bazel
@@ -80,6 +80,7 @@ copy_file(
 
 pkg_npm(
     name = "npm_package",
+    package_name = "@bazel/typescript",
     srcs = [
         "index.bzl",
         "package.bzl",

--- a/packages/worker/BUILD.bazel
+++ b/packages/worker/BUILD.bazel
@@ -53,6 +53,7 @@ copy_file(
 
 pkg_npm(
     name = "npm_package",
+    package_name = "@bazel/worker",
     srcs = [
         "README.md",
         "package.json",

--- a/rules_typescript_pr_496.patch
+++ b/rules_typescript_pr_496.patch
@@ -2,10 +2,11 @@ diff BUILD.bazel BUILD.bazel
 index 3a519c5..6121ef6 100644
 --- BUILD.bazel
 +++ BUILD.bazel
-@@ -38,6 +38,7 @@ pkg_npm(
+@@ -38,6 +38,8 @@ pkg_npm(
          "//internal:npm_package_assets",
          "//third_party/github.com/bazelbuild/bazel/src/main/protobuf:npm_package_assets",
      ],
++    validate = False,
 +    vendor_external = ["build_bazel_rules_typescript"],
      visibility = ["//visibility:public"],
      deps = [


### PR DESCRIPTION
- require that we know the package_name (defaults to name)
- require that we know the package.json file (or generate one if not)
- give a buildozer command to sync the package.json name field into the BUILd file
