### PR TITLE
fix(labs): handle const/let syntax in generated protoc js

### DIFF
--- a/packages/labs/src/grpc_web/change_import_style.js
+++ b/packages/labs/src/grpc_web/change_import_style.js
@@ -67,8 +67,11 @@ function convertToUmd(args, initialContents) {
 `;
   };
 
-  const transformations =
-      [wrapInAMDModule, replaceRecursiveFilePaths(args), removeJsExtensionsFromRequires];
+  const transformations = [
+    wrapInAMDModule,
+    replaceRecursiveFilePaths(args),
+    removeJsExtensionsFromRequires,
+  ];
   return transformations.reduce((currentContents, transform) => {
     return transform(currentContents);
   }, initialContents);
@@ -119,7 +122,8 @@ function convertToESM(args, initialContents) {
   const replaceRequiresWithImports = (contents) => {
     return contents
         .replace(
-            /var ([\w\d_]+) = require\((['"][\.\\]*[\w\d@/_-]+['"])\)/g, 'import * as $1 from $2')
+            /(?:var|const|let) ([\w\d_]+) = require\((['"][\.\\]*[\w\d@/_-]+['"])\)/g,
+            'import * as $1 from $2')
         .replace(
             /([\.\w\d_]+) = require\((['"][\.\w\d@/_-]+['"])\)/g, (_, variable, importPath) => {
               const normalizedVariable = variable.replace(/\./g, '_');
@@ -130,7 +134,7 @@ function convertToESM(args, initialContents) {
 
   const replaceRequiresWithSubpackageImports = (contents) => {
     return contents.replace(
-        /var ([\w\d_]+) = require\((['"][\w\d@/_-]+['"])\)\.([\w\d_]+);/g,
+        /(?:var|const|let) ([\w\d_]+) = require\((['"][\w\d@/_-]+['"])\)\.([\w\d_]+);/g,
         'import * as $1 from $2;');
   };
 
@@ -139,9 +143,13 @@ function convertToESM(args, initialContents) {
   };
 
   const transformations = [
-    replaceRecursiveFilePaths(args), removeJsExtensionsFromRequires, replaceGoogExtendWithExports,
-    replaceRequiresWithImports, replaceRequiresWithSubpackageImports,
-    replaceCMDefaultExportWithExports, replaceCJSExportsWithECMAExports
+    replaceRecursiveFilePaths(args),
+    removeJsExtensionsFromRequires,
+    replaceGoogExtendWithExports,
+    replaceRequiresWithImports,
+    replaceRequiresWithSubpackageImports,
+    replaceCMDefaultExportWithExports,
+    replaceCJSExportsWithECMAExports,
   ];
   return transformations.reduce((currentContents, transform) => {
     return transform(currentContents);

--- a/packages/labs/test/grpc_web/proto/BUILD.bazel
+++ b/packages/labs/test/grpc_web/proto/BUILD.bazel
@@ -23,10 +23,28 @@ proto_library(
     deps = [
         "//packages/labs/test/grpc_web/proto/common:delivery_person_proto",
         "//packages/labs/test/grpc_web/proto/common:pizza_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 
 ts_proto_library(
     name = "pizza_service_ts_proto",
     proto = ":pizza_service_proto",
+)
+
+proto_library(
+    name = "files_proto",
+    srcs = [
+        "files.proto",
+    ],
+    deps = [
+        "//packages/labs/test/grpc_web/proto/common:delivery_person_proto",
+        "//packages/labs/test/grpc_web/proto/common:pizza_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+ts_proto_library(
+    name = "files_ts_proto",
+    proto = ":files_proto",
 )

--- a/packages/labs/test/grpc_web/proto/files.proto
+++ b/packages/labs/test/grpc_web/proto/files.proto
@@ -1,0 +1,49 @@
+syntax = "proto3";
+
+option go_package = "stairwell/foundation/vt/api/v3";
+
+import "google/protobuf/timestamp.proto";
+
+message GetFileRequest {
+  // File hash (SHA256, SHA1, MD5) or UUID
+  string id = 1;
+}
+
+enum Type {
+  UNKNOWN = 0;
+  FILE = 1;
+}
+
+message GetFileResponse {
+  Type type = 1;
+  string id = 2;
+  Links links = 3;
+  FileData data = 4;
+}
+
+message Links {
+  // URL to fetch the object again in the future.
+  string self = 1;
+}
+
+message FileData {
+  Attributes attributes = 1;
+}
+
+message Attributes {
+  google.protobuf.Timestamp last_submission_date = 1;
+  repeated string names = 2;
+
+  string md5 = 3;
+  string sha1 = 4;
+  string sha256 = 5;
+  string sha3_256 = 6;
+
+  uint64 size = 7;
+  uint32 times_submitted = 8;
+}
+
+service Files {
+  rpc GetFile(GetFileRequest) returns (GetFileResponse) {
+  }
+}

--- a/packages/labs/test/grpc_web/proto/pizza_service.proto
+++ b/packages/labs/test/grpc_web/proto/pizza_service.proto
@@ -4,6 +4,7 @@ package test.bazel.proto;
 
 import "packages/labs/test/grpc_web/proto/common/pizza.proto";
 import "packages/labs/test/grpc_web/proto/common/delivery_person.proto";
+import "google/protobuf/timestamp.proto";
 
 service PizzaService {
   rpc OrderPizza(OrderPizzaRequest) returns (OrderPizzaResponse) {
@@ -18,4 +19,6 @@ message OrderPizzaRequest {
 message OrderPizzaResponse {
   // The person that will deliver the pizza.
   DeliveryPerson delivery_person = 1;
+
+  google.protobuf.Timestamp eta = 2;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently there's an issue when protoc generates code using the const syntax. Previous versions of the proto compiler did not use this syntax, but newer one's do.

Issue Number: N/A


## What is the new behavior?
Update the regexp to handle const syntax.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

