### PR TITLE
fix(labs): handle const/let syntax in generated protoc js

### DIFF
--- a/packages/labs/src/grpc_web/BUILD.bazel
+++ b/packages/labs/src/grpc_web/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("@build_bazel_rules_nodejs//internal/js_library:js_library.bzl", "js_library")
+load("@build_bazel_rules_nodejs//internal/npm_install:npm_umd_bundle.bzl", "npm_umd_bundle")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -17,12 +18,34 @@ nodejs_binary(
     visibility = ["//visibility:public"],
 )
 
+well_known_protos = [
+    "any_pb",
+    "api_pb",
+    "descriptor_pb",
+    "duration_pb",
+    "empty_pb",
+    "field_mask_pb",
+    "source_context_pb",
+    "struct_pb",
+    "timestamp_pb",
+    "type_pb",
+    "wrappers_pb",
+]
+
+[npm_umd_bundle(
+    name = "google-protobuf-%s__umd" % p,
+    package_name = "google-protobuf/google/protobuf/%s" % p,
+    entry_point = "@npm//:node_modules/google-protobuf/google-protobuf.js",
+    excluded = ["google-protobuf"],
+    package = "@npm//google-protobuf",
+) for p in well_known_protos]
+
 js_library(
     name = "bootstrap_scripts",
     srcs = [
         "@npm//google-protobuf:google-protobuf__umd",
         "@npm//grpc-web:grpc-web__umd",
-    ],
+    ] + [":google-protobuf-%s__umd" % p for p in well_known_protos],
 )
 
 filegroup(

--- a/packages/labs/src/grpc_web/change_import_style.js
+++ b/packages/labs/src/grpc_web/change_import_style.js
@@ -67,8 +67,11 @@ function convertToUmd(args, initialContents) {
 `;
   };
 
-  const transformations =
-      [wrapInAMDModule, replaceRecursiveFilePaths(args), removeJsExtensionsFromRequires];
+  const transformations = [
+    wrapInAMDModule,
+    replaceRecursiveFilePaths(args),
+    removeJsExtensionsFromRequires,
+  ];
   return transformations.reduce((currentContents, transform) => {
     return transform(currentContents);
   }, initialContents);
@@ -119,7 +122,8 @@ function convertToESM(args, initialContents) {
   const replaceRequiresWithImports = (contents) => {
     return contents
         .replace(
-            /var ([\w\d_]+) = require\((['"][\.\\]*[\w\d@/_-]+['"])\)/g, 'import * as $1 from $2')
+            /(?:var|const|let) ([\w\d_]+) = require\((['"][\.\\]*[\w\d@/_-]+['"])\)/g,
+            'import * as $1 from $2')
         .replace(
             /([\.\w\d_]+) = require\((['"][\.\w\d@/_-]+['"])\)/g, (_, variable, importPath) => {
               const normalizedVariable = variable.replace(/\./g, '_');
@@ -130,7 +134,7 @@ function convertToESM(args, initialContents) {
 
   const replaceRequiresWithSubpackageImports = (contents) => {
     return contents.replace(
-        /var ([\w\d_]+) = require\((['"][\w\d@/_-]+['"])\)\.([\w\d_]+);/g,
+        /(?:var|const|let) ([\w\d_]+) = require\((['"][\w\d@/_-]+['"])\)\.([\w\d_]+);/g,
         'import * as $1 from $2;');
   };
 
@@ -139,9 +143,13 @@ function convertToESM(args, initialContents) {
   };
 
   const transformations = [
-    replaceRecursiveFilePaths(args), removeJsExtensionsFromRequires, replaceGoogExtendWithExports,
-    replaceRequiresWithImports, replaceRequiresWithSubpackageImports,
-    replaceCMDefaultExportWithExports, replaceCJSExportsWithECMAExports
+    replaceRecursiveFilePaths(args),
+    removeJsExtensionsFromRequires,
+    replaceGoogExtendWithExports,
+    replaceRequiresWithImports,
+    replaceRequiresWithSubpackageImports,
+    replaceCMDefaultExportWithExports,
+    replaceCJSExportsWithECMAExports,
   ];
   return transformations.reduce((currentContents, transform) => {
     return transform(currentContents);

--- a/packages/labs/test/grpc_web/proto/BUILD.bazel
+++ b/packages/labs/test/grpc_web/proto/BUILD.bazel
@@ -23,6 +23,7 @@ proto_library(
     deps = [
         "//packages/labs/test/grpc_web/proto/common:delivery_person_proto",
         "//packages/labs/test/grpc_web/proto/common:pizza_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/packages/labs/test/grpc_web/proto/pizza_service.proto
+++ b/packages/labs/test/grpc_web/proto/pizza_service.proto
@@ -4,6 +4,7 @@ package test.bazel.proto;
 
 import "packages/labs/test/grpc_web/proto/common/pizza.proto";
 import "packages/labs/test/grpc_web/proto/common/delivery_person.proto";
+import "google/protobuf/timestamp.proto";
 
 service PizzaService {
   rpc OrderPizza(OrderPizzaRequest) returns (OrderPizzaResponse) {
@@ -18,4 +19,10 @@ message OrderPizzaRequest {
 message OrderPizzaResponse {
   // The person that will deliver the pizza.
   DeliveryPerson delivery_person = 1;
+
+  Eta eta = 2;
+}
+
+message Eta {
+  google.protobuf.Timestamp time_of_arrival = 1;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently there's an issue when protoc generates code using the const syntax. Previous versions of the proto compiler did not use this syntax, but newer one's do.

Issue Number: N/A


## What is the new behavior?
Update the regexp to handle const syntax.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

