### PR TITLE
feat(builtin): create AssetInfo provider for JS targets

### DIFF
--- a/examples/react_webpack/BUILD.bazel
+++ b/examples/react_webpack/BUILD.bazel
@@ -14,6 +14,9 @@ sass(
 )
 
 ts_project(
+    assets = [
+        "styles.css",
+    ],
     deps = [
         "@npm//@types",
         "@npm//csstype",
@@ -32,8 +35,8 @@ webpack(
     ],
     data = [
         "index.js",
-        "styles.css",
         "webpack.config.js",
+        ":tsconfig",
         "@npm//:node_modules",
     ],
 )

--- a/internal/js_library/js_library.bzl
+++ b/internal/js_library/js_library.bzl
@@ -17,7 +17,7 @@
 DO NOT USE - this is not fully designed, and exists only to enable testing within this repo.
 """
 
-load("//:providers.bzl", "LinkablePackageInfo")
+load("//:providers.bzl", "AssetInfo", "LinkablePackageInfo")
 load("//third_party/github.com/bazelbuild/bazel-skylib:rules/private/copy_file_private.bzl", "copy_bash", "copy_cmd")
 
 _AMD_NAMES_DOC = """Mapping from require module names to global variables.
@@ -71,6 +71,9 @@ def _impl(ctx):
             files = files_depset,
             runfiles = ctx.runfiles(files = ctx.files.srcs),
         ),
+        AssetInfo(
+            assets = depset(ctx.attr.assets),
+        ),
         AmdNamesInfo(names = ctx.attr.amd_names),
     ]
 
@@ -88,11 +91,9 @@ _js_library = rule(
     implementation = _impl,
     attrs = {
         "package_name": attr.string(),
-        "srcs": attr.label_list(
-            allow_files = True,
-            mandatory = True,
-        ),
+        "srcs": attr.label_list(allow_files = True, mandatory = True),
         "amd_names": attr.string_dict(doc = _AMD_NAMES_DOC),
+        "assets": attr.label_list(allow_files = True),
         "is_windows": attr.bool(mandatory = True, doc = "Automatically set by macro"),
         # module_name for legacy ts_library module_mapping support
         # TODO: remove once legacy module_mapping is removed

--- a/internal/node/npm_package_bin.bzl
+++ b/internal/node/npm_package_bin.bzl
@@ -1,6 +1,6 @@
 "A generic rule to run a tool that appears in node_modules/.bin"
 
-load("//:providers.bzl", "NpmPackageInfo", "node_modules_aspect", "run_node")
+load("//:providers.bzl", "AssetInfo", "NpmPackageInfo", "node_modules_aspect", "run_node")
 load("//internal/common:expand_variables.bzl", "expand_variables")
 load("//internal/linker:link_node_modules.bzl", "module_mappings_aspect")
 
@@ -33,6 +33,8 @@ def _inputs(ctx):
     for d in ctx.attr.data:
         if NpmPackageInfo in d:
             inputs_depsets.append(d[NpmPackageInfo].sources)
+        if AssetInfo in d:
+            inputs_depsets.append(d[AssetInfo].assets)
     return depset(ctx.files.data, transitive = inputs_depsets).to_list()
 
 def _impl(ctx):

--- a/internal/providers/asset_info.bzl
+++ b/internal/providers/asset_info.bzl
@@ -1,0 +1,25 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module contains a provider for assets needed for bundling"""
+
+AssetInfo = provider(
+    doc = """The AssetInfo provider allows rules to associate build targets with
+assets to be consumed by downstream bundling targets such as webpack or rollup.
+""",
+    fields = {
+        "assets": """Asset files provided by this rule and all its transitive dependencies.
+This prevents needing an aspect in rules that consume the typings, which improves performance.""",
+    },
+)

--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -1,6 +1,6 @@
 "ts_project rule"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "NpmPackageInfo", "run_node")
+load("@build_bazel_rules_nodejs//:providers.bzl", "AssetInfo", "DeclarationInfo", "NpmPackageInfo", "run_node")
 
 _DEFAULT_TSC = (
     # BEGIN-INTERNAL
@@ -16,6 +16,7 @@ _ATTRS = {
     # that compiler might allow more sources than tsc does.
     "srcs": attr.label_list(allow_files = True, mandatory = True),
     "args": attr.string_list(),
+    "assets": attr.label_list(allow_files = True),
     "extends": attr.label_list(allow_files = [".json"]),
     "tsc": attr.label(default = Label(_DEFAULT_TSC), executable = True, cfg = "host"),
     "tsconfig": attr.label(mandatory = True, allow_single_file = [".json"]),
@@ -120,6 +121,13 @@ def _ts_project_impl(ctx):
                 transitive_files = runtime_outputs,
                 collect_default = True,
             ),
+        ),
+        AssetInfo(
+            assets = depset(direct = ctx.files.assets, transitive = [
+                dep[AssetInfo].assets
+                for dep in ctx.attr.deps
+                if AssetInfo in dep
+            ]),
         ),
         _TsConfigInfo(tsconfigs = depset([ctx.file.tsconfig] + ctx.files.extends, transitive = [
             dep[_TsConfigInfo].tsconfigs

--- a/providers.bzl
+++ b/providers.bzl
@@ -18,6 +18,10 @@ Users should not load files under "/internal"
 """
 
 load(
+    "//internal/providers:asset_info.bzl",
+    _AssetInfo = "AssetInfo",
+)
+load(
     "//internal/providers:declaration_info.bzl",
     _DeclarationInfo = "DeclarationInfo",
     _provide_declarations = "provide_declarations",
@@ -46,6 +50,7 @@ load(
 
 provide_declarations = _provide_declarations
 DeclarationInfo = _DeclarationInfo
+AssetInfo = _AssetInfo
 JSNamedModuleInfo = _JSNamedModuleInfo
 js_named_module_info = _js_named_module_info
 JSEcmaScriptModuleInfo = _JSEcmaScriptModuleInfo


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

Given that JS bundlers such as webpack and rollup both support
the loading of arbitrary files given the appropriate plugins,
it makes sense to associate asset files that will be needed
during bundling with a particular target so that downstream
bundling rules do not need to depend on those assets themselves.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
