### PR TITLE
feat(typescript): ts_project is linkable

### DIFF
--- a/packages/typescript/test/ts_project/linkable/app/BUILD.bazel
+++ b/packages/typescript/test/ts_project/linkable/app/BUILD.bazel
@@ -1,0 +1,8 @@
+load("//packages/typescript:index.bzl", "ts_project")
+
+ts_project(
+    # This causes the linker to symlink the output directory into our execroot
+    # execroot/node_modules/@bazel/ts_project_lib ->
+    # bazel-out/[arch]/bin/packages/typescript/test/ts_project/linkable_lib
+    deps = ["//packages/typescript/test/ts_project/linkable/lib:tsconfig"],
+)

--- a/packages/typescript/test/ts_project/linkable/app/index.ts
+++ b/packages/typescript/test/ts_project/linkable/app/index.ts
@@ -1,0 +1,4 @@
+import {a} from '@bazel/ts_project_lib';
+import {b} from '@bazel/ts_project_lib/other';
+
+console.error(`got ${a} ${b}`);

--- a/packages/typescript/test/ts_project/linkable/app/tsconfig.json
+++ b/packages/typescript/test/ts_project/linkable/app/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "types": []
+    }
+}

--- a/packages/typescript/test/ts_project/linkable/lib/BUILD.bazel
+++ b/packages/typescript/test/ts_project/linkable/lib/BUILD.bazel
@@ -1,0 +1,8 @@
+load("//packages/typescript:index.bzl", "ts_project")
+
+# This directory will be linked into downstream rules in node_modules/@bazel/ts_project_lib
+ts_project(
+    package_name = "@bazel/ts_project_lib",
+    declaration = True,
+    visibility = ["//packages/typescript/test:__subpackages__"],
+)

--- a/packages/typescript/test/ts_project/linkable/lib/index.ts
+++ b/packages/typescript/test/ts_project/linkable/lib/index.ts
@@ -1,0 +1,1 @@
+export const a: number = 1;

--- a/packages/typescript/test/ts_project/linkable/lib/other.ts
+++ b/packages/typescript/test/ts_project/linkable/lib/other.ts
@@ -1,0 +1,1 @@
+export const b: string = 'b';

--- a/packages/typescript/test/ts_project/linkable/lib/tsconfig.json
+++ b/packages/typescript/test/ts_project/linkable/lib/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "declaration": true,
+        "types": []
+    }
+}


### PR DESCRIPTION
This doesn't copy a package.json file, so it has to be resolvable with just index.ts
