### PR TITLE
chore: rename a npm dependency to demonstrate that it doesn't need to…

### DIFF
--- a/examples/webapp/BUILD.bazel
+++ b/examples/webapp/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@npm//@bazel/protractor:index.bzl", "protractor_web_test_suite")
-load("@npm//http-server:index.bzl", "http_server")
-load("@npm//mocha:index.bzl", "mocha_test")
+load("@npm_deps//@bazel/protractor:index.bzl", "protractor_web_test_suite")
+load("@npm_deps//http-server:index.bzl", "http_server")
+load("@npm_deps//mocha:index.bzl", "mocha_test")
 load(":differential_loading.bzl", "differential_loading")
 
 differential_loading(
@@ -33,7 +33,7 @@ mocha_test(
         ":app_chunks.min",
         ":app_chunks_es5",
         ":app_chunks_es5.min",
-        "@npm//source-map",
+        "@npm_deps//source-map",
     ],
     tags = [
         # Need to set the pwd to avoid mocha needing a runfiles helper

--- a/examples/webapp/WORKSPACE
+++ b/examples/webapp/WORKSPACE
@@ -14,7 +14,7 @@
 
 workspace(
     name = "examples_webapp",
-    managed_directories = {"@npm": ["node_modules"]},
+    managed_directories = {"@npm_deps": ["node_modules"]},
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -28,12 +28,12 @@ http_archive(
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(
-    name = "npm",
+    name = "npm_deps",
     package_json = "//:package.json",
     yarn_lock = "//:yarn.lock",
 )
 
-load("@npm//@bazel/protractor:package.bzl", "npm_bazel_protractor_dependencies")
+load("@npm_deps//@bazel/protractor:package.bzl", "npm_bazel_protractor_dependencies")
 
 npm_bazel_protractor_dependencies()
 

--- a/examples/webapp/differential_loading.bzl
+++ b/examples/webapp/differential_loading.bzl
@@ -1,10 +1,10 @@
 "Illustrates how a reusable high-level workflow can be assembled from individual tools"
 
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_web")
-load("@npm//@babel/cli:index.bzl", "babel")
-load("@npm//@bazel/rollup:index.bzl", "rollup_bundle")
-load("@npm//@bazel/terser:index.bzl", "terser_minified")
-load("@npm//@bazel/typescript:index.bzl", "ts_library")
+load("@npm_deps//@babel/cli:index.bzl", "babel")
+load("@npm_deps//@bazel/rollup:index.bzl", "rollup_bundle")
+load("@npm_deps//@bazel/terser:index.bzl", "terser_minified")
+load("@npm_deps//@bazel/typescript:index.bzl", "ts_library")
 
 def differential_loading(name, entry_point, srcs):
     "Common workflow to serve TypeScript to modern browsers"
@@ -30,7 +30,7 @@ def differential_loading(name, entry_point, srcs):
         data = [
             name + "_chunks",
             "es5.babelrc",
-            "@npm//@babel/preset-env",
+            "@npm_deps//@babel/preset-env",
         ],
         output_dir = True,
         args = [


### PR DESCRIPTION
… be 'npm'
