### PR TITLE
fix(terser): allow fallback binary resolution

### DIFF
--- a/packages/terser/index.js
+++ b/packages/terser/index.js
@@ -164,7 +164,7 @@ function main() {
   try {
     // If necessary, get the new `terser` binary, added for >=4.3.0
     terserBinary = terserBinary || require.resolve('terser/bin/terser');
-  } finally {
+  } catch (e) {
     // If necessary, get the old `uglifyjs` binary from <4.3.0
     terserBinary = terserBinary || require.resolve('terser/bin/uglifyjs');
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Running `terser_minifed` with old version of terser does not have binary `terser` will fail to resolve binary:

```
 bazel-out/k8-fastbuild/bin/build.min --config-file ... (remaining 1 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
Error: Cannot find module 'terser/bin/terser'. Please verify that the package.json has a valid "main" entry
    at Function.module.constructor._resolveFilename
```

peeking it, binary resolution fallback is wrapped like below:

```
try {
} finally {
}
```

and depends on runtime, this will execute `finally` but also does not suppress exception thrown in `try` ends up execution fails. PR amends fallback to catch exception instead.


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

