### PR TITLE
Add linux arm64 support

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -421,6 +421,7 @@ If you have an advanced use-case you can also register your own toolchains and c
 Toolchains allow us to support cross-compilation, e.g. building a linux binary from mac or windows. To tell Bazel to provide a toolchain for a different platform you have to pass in  the `--platforms` flag. Currently supported values are:
 
 - `@build_bazel_rules_nodejs//toolchains/node:linux_amd64`
+- `@build_bazel_rules_nodejs//toolchains/node:linux_arm64`
 - `@build_bazel_rules_nodejs//toolchains/node:darwin_amd64`
 - `@build_bazel_rules_nodejs//toolchains/node:windows_amd64`
 

--- a/internal/common/os_name.bzl
+++ b/internal/common/os_name.bzl
@@ -19,6 +19,7 @@ OS_ARCH_NAMES = [
     ("darwin", "amd64"),
     ("windows", "amd64"),
     ("linux", "amd64"),
+    ("linux", "arm64"),
 ]
 
 OS_NAMES = ["_".join(os_arch_name) for os_arch_name in OS_ARCH_NAMES]
@@ -38,6 +39,10 @@ def os_name(rctx):
     elif os_name.find("windows") != -1:
         return OS_NAMES[1]
     elif os_name.startswith("linux"):
+        # This is not ideal, but bazel doesn't directly expose arch.
+        arch = rctx.execute(["uname", "-m"]).stdout.strip()
+        if arch == "aarch64":
+            return OS_NAMES[3]
         return OS_NAMES[2]
     else:
         fail("Unsupported operating system: " + os_name)
@@ -49,4 +54,5 @@ def is_windows_os(rctx):
     return os_name(rctx) == OS_NAMES[1]
 
 def is_linux_os(rctx):
-    return os_name(rctx) == OS_NAMES[2]
+    name = os_name(rctx)
+    return name == OS_NAMES[2] or name == OS_NAMES[3]

--- a/internal/node/launcher.sh
+++ b/internal/node/launcher.sh
@@ -108,15 +108,16 @@ if [ -n "${vendored_node}" ]; then
   fi
 else
   # Check environment for which node path to use
-  unameOut="$(uname -s)"
-  case "${unameOut}" in
+  unameOs="$(uname -s)"
+  unameArch="$(uname -m)"
+  case "${unameOs}" in
       Linux*)     machine=linux ;;
       Darwin*)    machine=darwin ;;
       CYGWIN*)    machine=windows ;;
       MINGW*)     machine=windows ;;
       MSYS_NT*)   machine=windows ;;
       *)          machine=linux
-                  printf "\nUnrecongized uname '${unameOut}'; defaulting to use node for linux.\n" >&2
+                  printf "\nUnrecongized uname '${unameOs}'; defaulting to use node for linux.\n" >&2
                   printf "Please file an issue to https://github.com/bazelbuild/rules_nodejs/issues if \n" >&2
                   printf "you would like to add your platform to the supported rules_nodejs node platforms.\n\n" >&2
                   ;;
@@ -126,14 +127,19 @@ else
     # The following paths must match up with _download_node in node_repositories
     darwin) readonly node_toolchain="nodejs_darwin_amd64/bin/nodejs/bin/node" ;;
     windows) readonly node_toolchain="nodejs_windows_amd64/bin/nodejs/node.exe" ;;
-    *) readonly node_toolchain="nodejs_linux_amd64/bin/nodejs/bin/node" ;;
+    *)
+      case "${unameArch}" in
+        aarch64*) readonly node_toolchain="nodejs_linux_arm64/bin/nodejs/bin/node" ;;
+        *) readonly node_toolchain="nodejs_linux_amd64/bin/nodejs/bin/node" ;;
+      esac
+      ;;
   esac
 
   readonly node=$(rlocation "${node_toolchain}")
 
   if [ ! -f "${node}" ]; then
       printf "\n>>>> FAIL: The node binary '${node_toolchain}' not found in runfiles.\n" >&2
-      printf "This node toolchain was chosen based on your uname '${unameOut}'.\n" >&2
+      printf "This node toolchain was chosen based on your uname '${unameOs} ${unameArch}'.\n" >&2
       printf "Please file an issue to https://github.com/bazelbuild/rules_nodejs/issues if \n" >&2
       printf "you would like to add your platform to the supported rules_nodejs node platforms. <<<<\n\n" >&2
       exit 1

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -64,6 +64,7 @@ Running `bazel run @nodejs//:yarn_node_repositories` in this repo would create `
 Note that the dependency installation scripts will run in each subpackage indicated by the `package_json` attribute.
 """
 
+# TODO(kgreenek): Add arm64 versions for all of these.
 _ATTRS = {
     "node_repositories": attr.string_list_dict(
         # @unsorted-dict-items
@@ -107,6 +108,7 @@ _ATTRS = {
             # 12.13.0
             "12.13.0-darwin_amd64": ("node-v12.13.0-darwin-x64.tar.gz", "node-v12.13.0-darwin-x64", "49a7374670a111b033ce16611b20fd1aafd3296bbc662b184fe8fb26a29c22cc"),
             "12.13.0-linux_amd64": ("node-v12.13.0-linux-x64.tar.xz", "node-v12.13.0-linux-x64", "7a57ef2cb3036d7eacd50ae7ba07245a28336a93652641c065f747adb2a356d9"),
+            "12.13.0-linux_arm64": ("node-v12.13.0-linux-arm64.tar.xz", "node-v12.13.0-linux-arm64", "d65b3ce27639f15ae22941e3ff98a1c900aa9049fcc15518038615b0676037d5"),
             "12.13.0-windows_amd64": ("node-v12.13.0-win-x64.zip", "node-v12.13.0-win-x64", "6f920cebeecb4957b4ef0def6d9b04c49d4582864f8d1a207ce8d0665865781a"),
             # When adding a new version. please update /docs/install.md
         },
@@ -253,6 +255,7 @@ and expect the file to have sha256sum `09bea8f4ec41e9079fa03093d3b2db7ac5c533185
 BUILT_IN_NODE_PLATFORMS = [
     "darwin_amd64",
     "linux_amd64",
+    "linux_arm64",
     "windows_amd64",
 ]
 
@@ -754,7 +757,7 @@ def node_repositories(**kwargs):
             name = node_repository_name,
             **kwargs
         )
-        native.register_toolchains("@build_bazel_rules_nodejs//toolchains/node:node_%s_toolchain" % os_arch_name[0])
+        native.register_toolchains("@build_bazel_rules_nodejs//toolchains/node:node_%s_toolchain" % os_name)
         node_toolchain_configure(
             name = "%s_config" % node_repository_name,
             target_tool = "@%s//:node_bin" % node_repository_name,

--- a/internal/node/test/nodejs_toolchain_test.bzl
+++ b/internal/node/test/nodejs_toolchain_test.bzl
@@ -32,7 +32,7 @@ fi
 
 _ATTRS = {
     "platform": attr.string(
-        values = ["linux_amd64", "darwin_amd64", "windows_amd64"],
+        values = ["linux_amd64", "linux_arm64", "darwin_amd64", "windows_amd64"],
     ),
 }
 

--- a/packages/typescript/devserver/BUILD.bazel
+++ b/packages/typescript/devserver/BUILD.bazel
@@ -29,6 +29,14 @@ filegroup(
 )
 
 filegroup(
+    name = "devserver_linux_arm64",
+    srcs = ["devserver-linux_arm64"],
+    # Don't build on CI
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
     name = "devserver_windows_amd64",
     srcs = ["devserver-windows_x64.exe"],
     # Don't build on CI
@@ -53,6 +61,14 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_arm64",
+    constraint_values = [
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//platforms:aarch64",
+    ],
+)
+
+config_setting(
     name = "windows_x64",
     constraint_values = [
         "@bazel_tools//platforms:windows",
@@ -64,6 +80,7 @@ filegroup(
     name = "devserver",
     srcs = select({
         ":darwin_x64": [":devserver_darwin_amd64"],
+        ":linux_arm64": [":devserver_linux_arm64"],
         ":linux_x64": [":devserver_linux_amd64"],
         ":windows_x64": [":devserver_windows_amd64"],
     }),

--- a/toolchains/node/BUILD.bazel
+++ b/toolchains/node/BUILD.bazel
@@ -34,6 +34,14 @@ platform(
 )
 
 platform(
+    name = "linux_arm64",
+    constraint_values = [
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//platforms:aarch64",
+    ],
+)
+
+platform(
     name = "windows_amd64",
     constraint_values = [
         "@bazel_tools//platforms:windows",
@@ -63,6 +71,7 @@ alias(
     actual = select({
         "@bazel_tools//src/conditions:darwin": "@nodejs_darwin_amd64_config//:toolchain",
         "@bazel_tools//src/conditions:darwin_x86_64": "@nodejs_darwin_amd64_config//:toolchain",
+        "@bazel_tools//src/conditions:linux_aarch64": "@nodejs_linux_arm64_config//:toolchain",
         "@bazel_tools//src/conditions:linux_x86_64": "@nodejs_linux_amd64_config//:toolchain",
         "@bazel_tools//src/conditions:windows": "@nodejs_windows_amd64_config//:toolchain",
         "//conditions:default": "@nodejs_linux_amd64_config//:toolchain",
@@ -76,6 +85,7 @@ alias(
     actual = select({
         "@bazel_tools//src/conditions:darwin": "@nodejs_darwin_amd64//:node_bin",
         "@bazel_tools//src/conditions:darwin_x86_64": "@nodejs_darwin_amd64//:node_bin",
+        "@bazel_tools//src/conditions:linux_aarch64": "@nodejs_linux_arm64//:node_bin",
         "@bazel_tools//src/conditions:linux_x86_64": "@nodejs_linux_amd64//:node_bin",
         "@bazel_tools//src/conditions:windows": "@nodejs_windows_amd64//:node_bin",
         "//conditions:default": "@nodejs_linux_amd64//:node_bin",
@@ -84,7 +94,7 @@ alias(
 )
 
 toolchain(
-    name = "node_linux_toolchain",
+    name = "node_linux_amd64_toolchain",
     target_compatible_with = [
         "@bazel_tools//platforms:linux",
         "@bazel_tools//platforms:x86_64",
@@ -94,7 +104,17 @@ toolchain(
 )
 
 toolchain(
-    name = "node_darwin_toolchain",
+    name = "node_linux_arm64_toolchain",
+    target_compatible_with = [
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//platforms:aarch64",
+    ],
+    toolchain = "@nodejs_linux_arm64_config//:toolchain",
+    toolchain_type = ":toolchain_type",
+)
+
+toolchain(
+    name = "node_darwin_amd64_toolchain",
     target_compatible_with = [
         "@bazel_tools//platforms:osx",
         "@bazel_tools//platforms:x86_64",
@@ -104,7 +124,7 @@ toolchain(
 )
 
 toolchain(
-    name = "node_windows_toolchain",
+    name = "node_windows_amd64_toolchain",
     target_compatible_with = [
         "@bazel_tools//platforms:windows",
         "@bazel_tools//platforms:x86_64",


### PR DESCRIPTION
Connects to #231 

A start at adding support for linux/arm64. This unblocks me for my current use-case, but there is still work to do.

When I run `bazel test //...` on an aarch64 device, currently it fails with the following output:

```
ERROR: /root/.cache/bazel/_bazel_root/c6d1af4279bc20274c5613de1579a2dc/external/io_bazel_rules_webtesting/go/metadata/main/BUILD.bazel:19:1: Configurable attribute "actual" doesn't match this configuration (would a default condition help?).
Conditions checked:
 @io_bazel_rules_webtesting//common/conditions:linux
 @io_bazel_rules_webtesting//common/conditions:mac
 @io_bazel_rules_webtesting//common/conditions:windows
```

I think rules_webtesting needs to be updated in a similar way to add aarch64 support.

That being said, this PR shouldn't break any existing build, so it won't harm anything to merge.

I left a TODO to add arm64 to all the repositories until this PR is given high-level approval, but I am happy to fill those in in this PR.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
