### PR TITLE
feat: add stdout capture to npm_package_bin

### DIFF
--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -283,10 +283,20 @@ nodejs_binary(
     entry_point = "terser_diagnostics_stats.js",
 )
 
+# When we build with --define=VERBOSE_LOGS=1 there is some extra stuff printed to stderr
+# We don't care to assert about that, and it has machine-local paths so we can't assert
+# on the exact content either.
+genrule(
+    name = "scrub_verbose_logs_stderr",
+    srcs = [":diagnostics.out"],
+    outs = [":diagnostics.scrubbed.out"],
+    cmd = "grep -v 'bazel node patches enabled' $< > $@",
+)
+
 generated_file_test(
     name = "stderr_output_test",
     src = "stderr_output_test.golden",
-    generated = ":diagnostics.out",
+    generated = ":diagnostics.scrubbed.out",
 )
 
 nodejs_binary(

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -241,6 +241,54 @@ npm_package_bin(
     package = "terser",
 )
 
+# captures stdout of terser_input.js to minified.stdout.js (note args do not include --output flag)
+npm_package_bin(
+    name = "run_terser_stdout",
+    args = [
+        "$(execpath terser_input.js)",
+    ],
+    data = ["terser_input.js"],
+    package = "terser",
+    stdout = "minified.stdout.js",
+)
+
+generated_file_test(
+    name = "stdout_output_test",
+    src = "stdout_output_test.golden",
+    generated = ":minified.stdout.js",
+)
+
+# capture stderr to diagnostics.out, then analyze it in terser_diagnostics_stats printing some stats
+# stdout is captured into greeter.min.js (again, without the --output $@ flags)
+npm_package_bin(
+    name = "diagnostics_producing_bin",
+    args = [
+        "$(execpath terser_input_with_diagnostics.js)",
+        "--compress",
+        "--verbose",
+        "--warn",
+    ],
+    data = ["terser_input_with_diagnostics.js"],
+    package = "terser",
+    stderr = "diagnostics.out",
+    stdout = "greeter.min.js",
+)
+
+nodejs_binary(
+    name = "terser_diagnostics_stats",
+    data = [
+        "diagnostics_producing_bin",
+        "terser_diagnostics_stats.js",
+    ],
+    entry_point = "terser_diagnostics_stats.js",
+)
+
+generated_file_test(
+    name = "stderr_output_test",
+    src = "stderr_output_test.golden",
+    generated = ":diagnostics.out",
+)
+
 nodejs_binary(
     name = "copy_to_directory",
     entry_point = "copy_to_directory.js",

--- a/internal/node/test/stderr_output_test.golden
+++ b/internal/node/test/stderr_output_test.golden
@@ -1,0 +1,1 @@
+WARN: Dropping unreachable code [internal/node/test/terser_input_with_diagnostics.js:6,4]

--- a/internal/node/test/stdout_output_test.golden
+++ b/internal/node/test/stdout_output_test.golden
@@ -1,0 +1,1 @@
+class A{doThing(){console.error("thing")}}

--- a/internal/node/test/terser_diagnostics_stats.js
+++ b/internal/node/test/terser_diagnostics_stats.js
@@ -1,0 +1,6 @@
+const fs = require('fs');
+
+const diagnostics = fs.readFileSync('internal/node/test/diagnostics.out', {encoding: 'utf8'});
+const count = diagnostics.trim().split('\n').length;
+
+console.log(`Terser produced ${count} diagnostic${count > 1 ? 's' : ''}`);

--- a/internal/node/test/terser_input_with_diagnostics.js
+++ b/internal/node/test/terser_input_with_diagnostics.js
@@ -1,0 +1,8 @@
+class Greeter {
+  greet(name) {
+    return name;
+    // return statement above is intentional to force terser to produce a diagnostic
+    // about dropping now unreachable code below
+    console.log(`Hello ${name}`);
+  }
+}


### PR DESCRIPTION
adds `stdout` and `stderr` attributes to `npm_package_bin` and `run_node` to capture stdout into the specified file

closes #1466 