### PR TITLE
test: add repro case for run_node with ts_library built executable

### DIFF
--- a/packages/typescript/test/some_module/BUILD.bazel
+++ b/packages/typescript/test/some_module/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("//packages/typescript:index.bzl", "ts_library")
+load("//packages/typescript/test/some_module:run_node_test.bzl", "ts_write_file")
 
 # We compile this library with the module name "sm" to make it possible to
 # use `import {} from 'sm';` both at type-check time (we include the mapping in
@@ -33,4 +34,31 @@ sh_test(
         ":bin",
         "@build_bazel_rules_nodejs//third_party/github.com/bazelbuild/bazel/tools/bash/runfiles",
     ],
+)
+
+# ts_library for compiling the tool
+ts_library(
+    name = "writer",
+    srcs = ["writer.ts"],
+    deps = ["@npm//@types/node"],
+)
+
+# nodejs_binary for generating an executable for the tool :writer
+nodejs_binary(
+    name = "writer_bin",
+    data = [
+        ":writer",
+    ],
+    entry_point = ":writer.ts",
+)
+
+# custom rule using the executable above via run_node
+# invoked via bazel build //packages/typescript/test/some_module:test
+# as --nobazel_patch_module_resolver is added by default by run_node, the entry_point on the executable is resolved
+# to the ts file - writer.ts
+# this works for bazel run //packages/typescript/test/some_module:writer_bin as this will patch require and resolve the
+# ts to js
+ts_write_file(
+    name = "test",
+    content = "hello world",
 )

--- a/packages/typescript/test/some_module/run_node_test.bzl
+++ b/packages/typescript/test/some_module/run_node_test.bzl
@@ -1,0 +1,30 @@
+"""Contrived custom rule for writing some content to a file using run_node"""
+
+load("//:providers.bzl", "run_node")
+
+def _ts_write_file_impl(ctx):
+    run_node(
+        ctx = ctx,
+        executable = "_writer",
+        inputs = [],
+        arguments = [
+            ctx.attr.content,
+            ctx.outputs.out.path,
+        ],
+        outputs = [ctx.outputs.out],
+    )
+
+ts_write_file = rule(
+    implementation = _ts_write_file_impl,
+    outputs = {
+        "out": "out.txt",
+    },
+    attrs = {
+        "content": attr.string(),
+        "_writer": attr.label(
+            default = Label("//packages/typescript/test/some_module:writer_bin"),
+            cfg = "host",
+            executable = True,
+        ),
+    },
+)

--- a/packages/typescript/test/some_module/writer.ts
+++ b/packages/typescript/test/some_module/writer.ts
@@ -1,0 +1,6 @@
+import {writeFileSync} from 'fs';
+
+const content = process.argv[2];
+const outputPath = process.argv[3];
+
+writeFileSync(outputPath, content, {encoding: 'utf8'});


### PR DESCRIPTION
Repro of issue with `run_node` replacement for `ctx.actions.run` 
(contrived) custom rule using an executable via run_node
invoked via bazel `build //packages/typescript/test/some_module:test` as `--nobazel_patch_module_resolver` is added by default by run_node, the entry_point on the executable is resolved to the ts file.
This works for `bazel run //packages/typescript/test/some_module:writer_bin` as this will patch require and resolve the
ts to js