### PR TITLE
fix(builtin): fix linker bug when there are no third-party modules

### DIFF
--- a/internal/linker/index.js
+++ b/internal/linker/index.js
@@ -341,8 +341,8 @@ function main(args, runfiles) {
         log_verbose('resolved node_modules root', root, 'to', rootDir);
         log_verbose('cwd', process.cwd());
         if (!(yield exists(rootDir))) {
-            log_verbose('no third-party packages; mkdir node_modules at ', root);
-            yield fs.promises.mkdir(rootDir);
+            log_verbose('no third-party packages; mkdir node_modules at', root);
+            yield mkdirp(rootDir);
         }
         yield symlink(rootDir, 'node_modules');
         process.chdir(rootDir);

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -556,8 +556,8 @@ export async function main(args: string[], runfiles: Runfiles) {
   // Create rootDir if it does not exists. This will be the case if there are no third-party deps
   // for this target or if outside of the sandbox and there are no node_modules installed.
   if (!(await exists(rootDir))) {
-    log_verbose('no third-party packages; mkdir node_modules at ', root);
-    await fs.promises.mkdir(rootDir);
+    log_verbose('no third-party packages; mkdir node_modules at', root);
+    await mkdirp(rootDir);
   }
 
   // Create the node_modules symlink to the node_modules root that node will resolve from

--- a/internal/linker/test/no_npm_deps/BUILD.bazel
+++ b/internal/linker/test/no_npm_deps/BUILD.bazel
@@ -1,0 +1,11 @@
+load(":no_npm_deps.bzl", "no_npm_deps")
+
+# Tests the
+# ```
+# [link_node_modules.js] no third-party packages; mkdir node_modules at npm/node_modules
+# ```
+# path in the linker
+no_npm_deps(
+    name = "no_npm_deps_linker_test",
+    src = "input.js",
+)

--- a/internal/linker/test/no_npm_deps/input.js
+++ b/internal/linker/test/no_npm_deps/input.js
@@ -1,0 +1,1 @@
+console.log('here');

--- a/internal/linker/test/no_npm_deps/no_npm_deps.bzl
+++ b/internal/linker/test/no_npm_deps/no_npm_deps.bzl
@@ -1,0 +1,42 @@
+"""
+This rule runs terser executable directly via ctx.actions.run instead of using the run_node function.
+This ensures that there are no third-party npm deps in runfiles since run_node will add any
+NodeRuntimeDepsInfo deps from the executable terser.
+"""
+
+_ATTRS = {
+    "src": attr.label(
+        allow_single_file = True,
+        mandatory = True,
+    ),
+    "terser": attr.label(
+        executable = True,
+        cfg = "host",
+        default = Label("@npm//terser/bin:terser"),
+    ),
+}
+
+_OUTPUTS = {
+    "minified": "%{name}.js",
+}
+
+def _impl(ctx):
+    args = ctx.actions.args()
+    args.add(ctx.file.src.path)
+    args.add_all(["--output", ctx.outputs.minified.path])
+
+    ctx.actions.run(
+        progress_message = "Optimizing JavaScript %s [terser]" % ctx.outputs.minified.short_path,
+        executable = ctx.executable.terser,
+        inputs = [ctx.file.src],
+        outputs = [ctx.outputs.minified],
+        arguments = [args],
+    )
+
+    return [DefaultInfo()]
+
+no_npm_deps = rule(
+    implementation = _impl,
+    attrs = _ATTRS,
+    outputs = _OUTPUTS,
+)


### PR DESCRIPTION
Before fix:

```
ERROR: /Users/greg/google/rules_nodejs/internal/linker/test/no_third_party_deps/BUILD.bazel:3:1: Optimizing JavaScript internal/linker/test/no_third_party_deps/linker_test.js [terser] failed (Exit 1) terser.sh failed: error executing command bazel-out/host/bin/external/npm/terser/bin/terser.sh internal/linker/test/no_third_party_deps/input.js --output bazel-out/darwin-fastbuild/bin/internal/linker/test/no_third_party_deps/linker_test.js

Use --sandbox_debug to see verbose messages from the sandbox
[link_node_modules.js] manifest file bazel-out/host/bin/external/npm/terser/bin/terser.sh.runfiles/npm/terser/bin/_terser.module_mappings.json
[link_node_modules.js] manifest contents {
  "workspace": "build_bazel_rules_nodejs",
  "bin": "bazel-out/host/bin",
  "root": "npm/node_modules",
  "modules": {}
}
[link_node_modules.js] startCwd /private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/461/execroot/build_bazel_rules_nodejs
[link_node_modules.js] isExecroot true
[link_node_modules.js] resolved node_modules root npm/node_modules to /private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/461/execroot/build_bazel_rules_nodejs/external/npm/node_modules
[link_node_modules.js] cwd /private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/461/execroot/build_bazel_rules_nodejs
[link_node_modules.js] no third-party packages; mkdir node_modules at  npm/node_modules
[link_node_modules.js] [Error: ENOENT: no such file or directory, mkdir '/private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/461/execroot/build_bazel_rules_nodejs/external/npm/node_modules'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'mkdir',
  path: '/private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/461/execroot/build_bazel_rules_nodejs/external/npm/node_modules'
}
Target //internal/linker/test/no_third_party_deps:linker_test failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.428s, Critical Path: 0.11s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
```

after fix (which changes mkdir to mkdirp):

```
[link_node_modules.js] manifest file bazel-out/host/bin/external/npm/terser/bin/terser.sh.runfiles/npm/terser/bin/_terser.module_mappings.json
[link_node_modules.js] manifest contents {
  "workspace": "build_bazel_rules_nodejs",
  "bin": "bazel-out/host/bin",
  "root": "npm/node_modules",
  "modules": {}
}
[link_node_modules.js] startCwd /private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/462/execroot/build_bazel_rules_nodejs
[link_node_modules.js] isExecroot true
[link_node_modules.js] resolved node_modules root npm/node_modules to /private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/462/execroot/build_bazel_rules_nodejs/external/npm/node_modules
[link_node_modules.js] cwd /private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/462/execroot/build_bazel_rules_nodejs
[link_node_modules.js] no third-party packages; mkdir node_modules at  npm/node_modules
[link_node_modules.js] mkdir( /private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/462/execroot/build_bazel_rules_nodejs/external )
[link_node_modules.js] mkdir( /private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/462/execroot/build_bazel_rules_nodejs/external/npm )
[link_node_modules.js] mkdir( /private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/462/execroot/build_bazel_rules_nodejs/external/npm/node_modules )
[link_node_modules.js] symlink( node_modules -> /private/var/tmp/_bazel_greg/35306ad70b8da8f7bc31590523de35c0/sandbox/darwin-sandbox/462/execroot/build_bazel_rules_nodejs/external/npm/node_modules )
[link_node_modules.js] mapping hierarchy []
Target //internal/linker/test/no_third_party_deps:linker_test up-to-date:
  dist/bin/internal/linker/test/no_third_party_deps/linker_test.js
INFO: Elapsed time: 0.515s, Critical Path: 0.20s
INFO: 1 process: 1 darwin-sandbox.
INFO: Build completed successfully, 2 total actions
```


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

