### PR TITLE
fix(typescript): add .proto files from npm deps to inputs of ts_library

### DIFF
--- a/packages/typescript/internal/build_defs.bzl
+++ b/packages/typescript/internal/build_defs.bzl
@@ -104,7 +104,7 @@ def _filter_ts_inputs(all_inputs):
     return [
         f
         for f in all_inputs
-        if f.extension in ["js", "jsx", "ts", "tsx", "json"]
+        if f.extension in ["js", "jsx", "ts", "tsx", "json", "proto"]
     ]
 
 def _compile_action(ctx, inputs, outputs, tsconfig_file, node_opts, description = "prodmode"):


### PR DESCRIPTION
If `@bazel/typescript` is a dep of ts_library such as 

```
ts_library(
    name = "lib",
    srcs = [
        "index.ts",
    ],
    deps = [
        "@npm//@bazel/typescript",
        "@npm//@microsoft/api-extractor",
        "@npm//@types/node",
    ],
)
```

as seen in `packages/bazel/src/api-extractor/BUILD.bazel` in angular/angular, then the linker needs to include `third_party/github.com/bazelbuild/bazel/src/main/protobuf/worker_protocol.proto` as an input as worker.js will run out of its linked location in node_modules & only files that are inputs to ts_library will be there.

The failure was only observed on Angular repo RBE since running ts_library has workers on by default it is not sandboxed.

Failure mode is:

```
ERROR: /home/circleci/ng/packages/bazel/src/api-extractor/BUILD.bazel:8:11: Compiling TypeScript (devmode) //packages/bazel/src/api-extractor:lib failed (Exit 1): tsc_wrapped.sh failed: error executing command 
 
  (cd /home/circleci/.cache/bazel/_bazel_circleci/9ce5c2144ecf75d11717c0aa41e45a8d/execroot/angular && \
 
  exec env - \
 
    PATH=/bin:/usr/bin:/usr/local/bin \
 
  bazel-out/host/bin/external/npm/@bazel/typescript/bin/tsc_wrapped.sh @@bazel-out/k8-fastbuild/bin/packages/bazel/src/api-extractor/lib_es5_tsconfig.json)
 
Execution platform: //tools:rbe_ubuntu1604-angular
 
/b/f/w/bazel-out/host/bin/external/npm/@bazel/typescript/bin/tsc_wrapped.sh.runfiles/build_bazel_rules_nodejs/internal/linker/index.js:158
 
        throw e;
 
        ^
 

 
Error: could not resolve modulePath build_bazel_rules_typescript/third_party/github.com/bazelbuild/bazel/src/main/protobuf/worker_protocol.proto
 
    at Runfiles.resolve (/b/f/w/bazel-out/host/bin/external/npm/@bazel/typescript/bin/tsc_wrapped.sh.runfiles/build_bazel_rules_nodejs/internal/linker/index.js:156:19)
 
    at loadWorkerPb (/b/f/w/node_modules/@bazel/typescript/internal/tsc_wrapped/worker.js:81:43)
 
    at Object.<anonymous> (/b/f/w/node_modules/@bazel/typescript/internal/tsc_wrapped/worker.js:101:18)
 
    at Module._compile (internal/modules/cjs/loader.js:955:30)
 
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:991:10)
 
    at Module.load (internal/modules/cjs/loader.js:811:32)
 
    at Function.Module._load (internal/modules/cjs/loader.js:723:14)
 
    at Module.require (internal/modules/cjs/loader.js:848:19)
 
    at require (internal/modules/cjs/helpers.js:74:18)
 
    at Object.<anonymous> (/b/f/w/node_modules/@bazel/typescript/internal/tsc_wrapped/compiler_host.js:7:18) {
 
  code: 'MODULE_NOT_FOUND'
 
}
 
ERROR: /home/circleci/ng/packages/bazel/BUILD.bazel:3:8 Compiling TypeScript (devmode) //packages/bazel/src/api-extractor:lib failed (Exit 1): tsc_wrapped.sh failed: error executing command 
 
  (cd /home/circleci/.cache/bazel/_bazel_circleci/9ce5c2144ecf75d11717c0aa41e45a8d/execroot/angular && \
 
  exec env - \
 
    PATH=/bin:/usr/bin:/usr/local/bin \
 
  bazel-out/host/bin/external/npm/@bazel/typescript/bin/tsc_wrapped.sh @@bazel-out/k8-fastbuild/bin/packages/bazel/src/api-extractor/lib_es5_tsconfig.json)
 
Execution platform: //tools:rbe_ubuntu1604-angular
```


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

