### PR TITLE
chore: treat Bazel dev builds as 2.1+ for hiding BUILD files

### DIFF
--- a/internal/npm_install/index.js
+++ b/internal/npm_install/index.js
@@ -285,11 +285,13 @@ function findPackages(p = 'node_modules') {
         .filter(f => !f.startsWith('.'))
         .map(f => path.posix.join(p, f))
         .filter(f => isDirectory(f));
+    let defaultHide = !(Number(BAZEL_VERSION.split('.')[0]) >= 2 && !BAZEL_VERSION.startsWith('2.0'));
+    if (BAZEL_VERSION == "") {
+        console.warn("Using a development build of bazel. Please make sure it's running 2.1+");
+        defaultHide = false;
+    }
     packages.forEach(f => {
-        let hide = true;
-        if (Number(BAZEL_VERSION.split('.')[0]) >= 2 && !BAZEL_VERSION.startsWith('2.0')) {
-            hide = false;
-        }
+        let hide = defaultHide;
         if (fs.lstatSync(f).isSymbolicLink()) {
             hide = false;
         }


### PR DESCRIPTION
I don't think anyone should be using a dev build for a really old bezel version

This makes the behavior consistent for new local dev builds and official releases.