### PR TITLE
fix(builtin): linker silently not generating expected links in windows

### DIFF
--- a/internal/linker/index.js
+++ b/internal/linker/index.js
@@ -16,8 +16,8 @@ function log_verbose(...m) {
     if (VERBOSE_LOGS)
         console.error('[link_node_modules.js]', ...m);
 }
-function log_error(...m) {
-    console.error('[link_node_modules.js]', ...m);
+function log_error(error) {
+    console.error('[link_node_modules.js] An error has been reported:', error, error.stack);
 }
 function panic(m) {
     throw new Error(`Internal error! Please run again with

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -47,6 +47,60 @@ async function mkdirp(p: string) {
   }
 }
 
+/**
+ * Gets the `lstat` results for a given path. Returns `null` if the path
+ * does not exist on disk.
+ */
+async function gracefulLstat(path: string): Promise<fs.Stats|null> {
+  try {
+    return await fs.promises.lstat(path);
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return null;
+    }
+    throw e;
+  }
+}
+
+/**
+ * Deletes the given module name from the current working directory (i.e. symlink root).
+ * If the module name resolves to a directory, the directory is deleted. Otherwise the
+ * existing file or junction is unlinked.
+ */
+async function unlink(moduleName: string) {
+  const stat = await gracefulLstat(moduleName);
+  if (stat === null) {
+    return;
+  }
+  log_verbose(`unlink( ${moduleName} )`);
+  if (stat.isDirectory()) {
+    await deleteDirectory(moduleName);
+  } else {
+    log_verbose("Deleting file: ", moduleName);
+    await fs.promises.unlink(moduleName);
+  }
+}
+
+/** Asynchronously deletes a given directory (with contents). */
+async function deleteDirectory(p: string) {
+  log_verbose("Deleting children of", p);
+  for (let entry of await fs.promises.readdir(p)) {
+    const childPath = path.join(p, entry);
+    const stat = await gracefulLstat(childPath);
+    if (stat === null) {
+      throw Error(`File does not exist, but is listed as directory entry: ${childPath}`);
+    }
+    if (stat.isDirectory()) {
+      await deleteDirectory(childPath);
+    } else {
+      log_verbose("Deleting file", childPath);
+      await fs.promises.unlink(childPath);
+    }
+  }
+  log_verbose("Cleaning up dir", p);
+  await fs.promises.rmdir(p);
+}
+
 async function symlink(target: string, p: string): Promise<boolean> {
   log_verbose(`symlink( ${p} -> ${target} )`);
 
@@ -55,7 +109,7 @@ async function symlink(target: string, p: string): Promise<boolean> {
   // it is necessary for the time being.
   if (!await exists(target)) {
     // This can happen if a module mapping is propogated from a dependency
-    // but the targat that generated the mapping in not in the deps. We don't
+    // but the target that generated the mapping in not in the deps. We don't
     // want to create symlinks to non-existant targets as this will
     // break any nested symlinks that may be created under the module name
     // after this.
@@ -334,20 +388,12 @@ declare global {
 // There is no fs.promises.exists function because
 // node core is of the opinion that exists is always too racey to rely on.
 async function exists(p: string) {
-  try {
-    await fs.promises.stat(p)
-    return true;
-  } catch (e) {
-    if (e.code === 'ENOENT') {
-      return false;
-    }
-    throw e;
-  }
+  return (await gracefulLstat(p) !== null);
 }
 
 function existsSync(p: string) {
   try {
-    fs.statSync(p)
+    fs.lstatSync(p);
     return true;
   } catch (e) {
     if (e.code === 'ENOENT') {
@@ -508,6 +554,22 @@ function isNameLinkPathTopAligned(namePath: string, [, linkPath]: Link) {
   return path.basename(namePath) === path.basename(linkPath);
 }
 
+async function visitDirectoryPreserveLinks(
+    dirPath: string, visit: (filePath: string, stat: fs.Stats) => Promise<void>) {
+  for (const entry of await fs.promises.readdir(dirPath)) {
+    const childPath = path.join(dirPath, entry);
+    const stat = await gracefulLstat(childPath);
+    if (stat === null) {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      await visitDirectoryPreserveLinks(childPath, visit);
+    } else {
+      await visit(childPath, stat);
+    }
+  }
+}
+
 // See link_node_modules.bzl where these link roots types
 // are used to indicate which root the linker should target
 // for each package:
@@ -567,6 +629,64 @@ export async function main(args: string[], runfiles: Runfiles) {
   // symlinks will be created under node_modules
   process.chdir(rootDir);
 
+  /**
+   * Whether the given module resolves to a directory that has been created by a previous linker
+   * run purely to make space for deep module links. e.g. consider a mapping for `my-pkg/a11y`.
+   * The linker will create folders like `node_modules/my-pkg/` so that the `a11y` symbolic
+   * junction can be created. The `my-pkg` folder is then considered a leftover from a previous
+   * linker run as it only contains symbolic links and no actual source files.
+   */
+  async function isLeftoverDirectoryFromLinker(stats: fs.Stats, modulePath: string) {
+    // If we are running without a runfiles manifest (i.e. in sandbox or with symlinked runfiles),
+    // then this is guaranteed to be not an artifact from a previous linker run.
+    if (runfiles.manifest === undefined) {
+      return false;
+    }
+    if (!stats.isDirectory()) {
+      return false;
+    }
+    let isLeftoverFromPreviousLink = true;
+    // If the directory contains actual files, this cannot be a leftover from a previous
+    // linker run. The linker only creates directories in the node modules that hold
+    // symbolic links for configured module mappings.
+    await visitDirectoryPreserveLinks(modulePath, async (childPath, childStats) => {
+      if (!childStats.isSymbolicLink()) {
+        isLeftoverFromPreviousLink = false;
+      }
+    });
+    return isLeftoverFromPreviousLink;
+  }
+
+  /**
+   * Creates a symlink for the given module. Existing child symlinks which are part of
+   * the module are preserved in order to not cause race conditions in non-sandbox
+   * environments where multiple actions rely on the same node modules root.
+   *
+   * To avoid unexpected resource removal, a new temporary link for the target is created.
+   * Then all symlinks from the existing module are cloned. Once done, the existing module
+   * is unlinked while the temporary link takes place for the given module. This ensures
+   * that the module link is never removed at any time (causing race condition failures).
+   */
+  async function createSymlinkAndPreserveContents(stats: fs.Stats, modulePath: string,
+                                                  target: string) {
+    const tmpPath = `${modulePath}__linker_tmp`;
+    log_verbose(`createSymlinkAndPreserveContents( ${modulePath} )`);
+
+    await symlink(target, tmpPath);
+    await visitDirectoryPreserveLinks(modulePath, async (childPath, stat) => {
+      if (stat.isSymbolicLink()) {
+        const targetPath = path.join(tmpPath, path.relative(modulePath, childPath));
+        log_verbose(`Cloning symlink into temporary created link ( ${childPath} )`);
+        await mkdirp(path.dirname(targetPath));
+        await symlink(targetPath, await fs.promises.realpath(childPath));
+      }
+    });
+
+    log_verbose(`Removing existing module so that new link can take place ( ${modulePath} )`);
+    await unlink(modulePath);
+    await fs.promises.rename(tmpPath, modulePath);
+  }
+
   async function linkModules(m: LinkerTreeElement) {
     // ensure the parent directory exist
     await mkdirp(path.dirname(m.name));
@@ -605,7 +725,20 @@ export async function main(args: string[], runfiles: Runfiles) {
           break;
       }
 
-      await symlink(target, m.name);
+      const stats = await gracefulLstat(m.name);
+      // In environments where runfiles are not symlinked (e.g. Windows), existing linked
+      // modules are preserved. This could cause issues when a link is created at higher level
+      // as a conflicting directory is already on disk. e.g. consider in a previous run, we
+      // linked the modules `my-pkg/overlay`. Later on, in another run, we have a module mapping
+      // for `my-pkg` itself. The linker cannot create `my-pkg` because the directory `my-pkg`
+      // already exists. To ensure that the desired link is generated, we create the new desired
+      // link and move all previous nested links from the old module into the new link. Read more
+      // about this in the description of `createSymlinkAndPreserveContents`.
+      if (stats !== null && await isLeftoverDirectoryFromLinker(stats, m.name)) {
+        await createSymlinkAndPreserveContents(stats, m.name, target);
+      } else {
+        await symlink(target, m.name);
+      }
     }
 
     // Process each child branch concurrently
@@ -614,11 +747,11 @@ export async function main(args: string[], runfiles: Runfiles) {
     }
   }
 
-  const moduleHeirarchy = reduceModules(modules);
-  log_verbose(`mapping hierarchy ${JSON.stringify(moduleHeirarchy)}`);
+  const moduleHierarchy = reduceModules(modules);
+  log_verbose(`mapping hierarchy ${JSON.stringify(moduleHierarchy)}`);
 
   // Process each root branch concurrently
-  const links = moduleHeirarchy.map(linkModules);
+  const links = moduleHierarchy.map(linkModules);
 
   let code = 0;
   await Promise.all(links).catch(e => {

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -13,8 +13,8 @@ function log_verbose(...m: string[]) {
   if (VERBOSE_LOGS) console.error('[link_node_modules.js]', ...m);
 }
 
-function log_error(...m: string[]) {
-  console.error('[link_node_modules.js]', ...m);
+function log_error(error: Error) {
+  console.error('[link_node_modules.js] An error has been reported:', error, error.stack);
 }
 
 function panic(m: string) {

--- a/internal/linker/test/link_node_modules.spec.ts
+++ b/internal/linker/test/link_node_modules.spec.ts
@@ -35,9 +35,16 @@ describe('link_node_modules', () => {
     mkdirp(runfilesWorkspace);
   });
 
-  function readWorkspaceNodeModules(...parts: string[]) {
-    const filePath = path.join(process.env['TEST_TMPDIR']!, workspace, 'node_modules', ...parts);
-    return fs.readFileSync(filePath, 'utf-8')
+  function getWorkspaceModulePath(...parts: string[]): string {
+    return path.join(process.env['TEST_TMPDIR']!, workspace, 'node_modules', ...parts);
+  }
+
+  function readWorkspaceNodeModules(...parts: string[]): string {
+    return fs.readFileSync(getWorkspaceModulePath(...parts), 'utf-8')
+  }
+
+  function hasWorkspaceNodeModule(...parts: string[]): boolean {
+    return fs.existsSync(getWorkspaceModulePath(...parts))
   }
 
   describe('reduceModules', () => {
@@ -435,6 +442,70 @@ describe('link_node_modules', () => {
         .toEqual('/*@foo/d/bar*/exports = {}');
     expect(readWorkspaceNodeModules('@foo', 'd', 'bar', 'fum', 'far', 'index.js'))
         .toEqual('/*@foo/d/bar/fum/far*/exports = {}');
+  });
+
+  it('should create link at higher level if directory already exists from past run', async () => {
+    const workspacePath = path.join(process.env['TEST_TMPDIR']!, workspace);
+    // Set the cwd() like Bazel would in the execroot
+    process.chdir(workspacePath);
+
+    // Create a package in the user workspace
+    mkdirp(`${BIN_DIR}/src/cdk/bidi`);
+    mkdirp(`${BIN_DIR}/src/other-core-folder`);
+    fs.writeFileSync(`${BIN_DIR}/src/cdk/index.js`, '/*cdk/index*/exports = {}', 'utf-8');
+    fs.writeFileSync(`${BIN_DIR}/src/cdk/bidi/index.js`, '/*cdk/bidi/index*/exports = {}', 'utf-8');
+    fs.writeFileSync(`${BIN_DIR}/src/other-core-folder/index.js`, `/*other-core*/`, 'utf-8');
+
+    writeRunfiles([]);
+    writeManifest({
+      bin: BIN_DIR,
+      workspace: workspace,
+      modules: {
+        '@angular/cdk/bidi': ['execroot', `${BIN_DIR}/src/cdk/bidi`],
+        '@angular/cdk/core': ['execroot', `${BIN_DIR}/src/other-core-folder`],
+      },
+    });
+
+    await linker.main(['manifest.json'], new linker.Runfiles({
+      // This test assumes an environment where runfiles are not symlinked. Hence
+      // we pass a runfile manifest file.
+      'RUNFILES_MANIFEST_FILE': 'runfiles.mf',
+    }));
+
+    expect(readWorkspaceNodeModules('@angular', 'cdk', 'bidi', 'index.js'))
+      .toEqual('/*cdk/bidi/index*/exports = {}');
+    expect(readWorkspaceNodeModules('@angular', 'cdk', 'core', 'index.js'))
+      .toEqual('/*other-core*/');
+    expect(hasWorkspaceNodeModule('@angular', 'cdk', 'index.js')).toBe(false);
+
+    // Set the cwd() like Bazel would in the execroot
+    process.chdir(workspacePath);
+
+    writeManifest({
+      bin: BIN_DIR,
+      workspace: workspace,
+      modules: {
+        '@angular/cdk': ['execroot', `${BIN_DIR}/src/cdk`],
+        '@angular/cdk/bidi': ['execroot', `${BIN_DIR}/src/cdk/bidi`],
+        '@angular/cdk/core': ['execroot', `${BIN_DIR}/src/other-core-folder`],
+      },
+    });
+
+    // In the second run, we added a mapping for `@angular/cdk`. This means
+    // that the linker would need to clean up the previous `cdk/bidi` link
+    // in order to be able to create a link for `@angular/cdk`.
+    await linker.main(['manifest.json'], new linker.Runfiles({
+      // This test assumes an environment where runfiles are not symlinked. Hence
+      // we pass a runfile manifest file.
+      'RUNFILES_MANIFEST_FILE': 'runfiles.mf',
+    }));
+
+    expect(readWorkspaceNodeModules('@angular', 'cdk', 'bidi', 'index.js'))
+      .toEqual('/*cdk/bidi/index*/exports = {}');
+    expect(readWorkspaceNodeModules('@angular', 'cdk', 'core', 'index.js'))
+      .toEqual('/*other-core*/');
+    expect(readWorkspaceNodeModules('@angular', 'cdk', 'index.js'))
+      .toEqual('/*cdk/index*/exports = {}');
   });
 
   it('should handle first-party packages with single parent link', async () => {


### PR DESCRIPTION
Currently the builtin linker sometimes does not generate links as
defined in the module mappings on Windows. This results in unexpected
and confusing runtime issues, and differences with other platforms.

The linker fails to generate links if module mappings result in
a different symlink/module hierarchy (as computed by `reduceModules`).

For example, consider in a previous linker run, we linked the module
`@angular/cdk/overlay` into `node_modules/@angular/cdk/overlay`. In
a second run then, we actually link `@angular/cdk`. The linker will
fail to do that as the `node_modules/@angular/cdk` folder already
exists (due to missing sandbox/runfile symlinking in windows)

We fix this by clearing such leftover linker directories so that
the newly configured module mapping can be created. In order to
avoid race conditions in non-sandboxed environments, we need to
pay special attention to potential concurrent resource accesses,
and also need to preserve possible child links from previous or
concurrent linker runs.