### PR TITLE
fix(builtin): fixes nodejs_binary to collect JSNamedModuleInfo

### DIFF
--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -20,7 +20,7 @@ They support module mapping: any targets in the transitive dependencies with
 a `module_name` attribute can be `require`d by that name.
 """
 
-load("//:providers.bzl", "JSModuleInfo", "NodeRuntimeDepsInfo", "NpmPackageInfo", "node_modules_aspect")
+load("//:providers.bzl", "JSModuleInfo", "JSNamedModuleInfo", "NodeRuntimeDepsInfo", "NpmPackageInfo", "node_modules_aspect")
 load("//internal/common:expand_into_runfiles.bzl", "expand_location_into_runfiles")
 load("//internal/common:module_mappings.bzl", "module_mappings_runtime_aspect")
 load("//internal/common:path_utils.bzl", "strip_external")
@@ -167,6 +167,11 @@ def _nodejs_binary_impl(ctx):
     for d in ctx.attr.data:
         if JSModuleInfo in d:
             sources_depsets.append(d[JSModuleInfo].sources)
+
+        # Deprecated should be removed with version 3.x.x at least have a transition phase
+        # for dependencies to provide the output under the JSModuleInfo instead.
+        if JSNamedModuleInfo in d:
+            sources_depsets.append(d[JSNamedModuleInfo].sources)
         if hasattr(d, "files"):
             sources_depsets.append(d.files)
     sources = depset(transitive = sources_depsets)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently it breaks rules that do not provide the new `JSModuleInfo` instead of the `JSNamedModuleInfo`,

Issue Number: Fixes #1998


## What is the new behavior?

To be backwards compatible with earlier versions still support the `JSNamedModuleInfo` provider for nodejs_binary dependencies along with the new `JSModuleInfo`.

This should help dependencies to transition to the new provider without having to patch it.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
