### PR TITLE
feat: add depset support to run_node inputs, matching ctx.action.run

### DIFF
--- a/internal/providers/test/BUILD.bazel
+++ b/internal/providers/test/BUILD.bazel
@@ -17,6 +17,11 @@ nodejs_binary(
     entry_point = "js-write-file.js",
 )
 
+nodejs_binary(
+    name = "cloner_bin",
+    entry_point = "js-clone-file.js",
+)
+
 js_write_file(
     name = "write_file",
     content = "test file content",
@@ -32,5 +37,7 @@ js_write_file(
     for file in [
         "out",
         "out2",
+        "out3",
+        "out4",
     ]
 ]

--- a/internal/providers/test/js-clone-file.js
+++ b/internal/providers/test/js-clone-file.js
@@ -1,0 +1,9 @@
+const readFileSync = require('fs').readFileSync;
+const writeFileSync = require('fs').writeFileSync;
+
+const inputPath = process.argv[2];
+const outputPath = process.argv[3];
+
+const content = readFileSync(inputPath, 'utf8');
+
+writeFileSync(outputPath, content, {encoding: 'utf8'});

--- a/internal/providers/test/run_node_test.bzl
+++ b/internal/providers/test/run_node_test.bzl
@@ -31,14 +31,53 @@ def _js_write_file_impl(ctx):
         outputs = [ctx.outputs.out2],
     )
 
+    content_txt = ctx.actions.declare_file("content.txt")
+    ctx.actions.write(
+        output = content_txt,
+        content = ctx.attr.content,
+    )
+
+    run_node(
+        ctx = ctx,
+        executable = "_clone",
+        mnemonic = "cloner",
+        # Pass inputs as a list.
+        inputs = [content_txt],
+        arguments = [
+            content_txt.path,
+            ctx.outputs.out3.path,
+        ],
+        outputs = [ctx.outputs.out3],
+    )
+
+    run_node(
+        ctx = ctx,
+        executable = "_clone",
+        mnemonic = "cloner",
+        # Pass inputs as a depset.
+        inputs = depset(direct = [content_txt]),
+        arguments = [
+            content_txt.path,
+            ctx.outputs.out4.path,
+        ],
+        outputs = [ctx.outputs.out4],
+    )
+
 js_write_file = rule(
     implementation = _js_write_file_impl,
     outputs = {
         "out": "out.txt",
         "out2": "out2.txt",
+        "out3": "out3.txt",
+        "out4": "out4.txt",
     },
     attrs = {
         "content": attr.string(),
+        "_clone": attr.label(
+            default = Label("//internal/providers/test:cloner_bin"),
+            cfg = "host",
+            executable = True,
+        ),
         "_writer": attr.label(
             default = Label("//internal/providers/test:writer_bin"),
             cfg = "host",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

`run_node`'s `inputs` param doesn't serve as a drop-in for `ctx.action.run`'s corresponding `inputs` param. The former only accepts lists, whereas `ctx.action.run` [also accepts depsets](https://docs.bazel.build/versions/master/skylark/lib/actions.html#run).

## What is the new behavior?

Allow `run_node` to accept depsets in the `inputs` param, as well as refactoring the creation of `inputs` for the internal `ctx.actions.run` call to build a depset, rather than a list.

This allows callers of `run_node` to avoid flattening depsets, which is usually [O(n^2) cost](https://docs.bazel.build/versions/master/skylark/performance.html#avoid-calling-depsetto_list).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

