### PR TITLE
docs: update generated builtin docs to include aspects and providers

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -25,6 +25,16 @@ stardoc(
     ],
 )
 
+stardoc(
+    name = "providers",
+    out = "providers.api",
+    input = "//:providers.bzl",
+    tags = ["fix-windows"],
+    deps = [
+        "//:bzl",
+    ],
+)
+
 _BUILTINS_README = "# Built-in rules\n\nThese rules are available without any npm installation, via the `WORKSPACE` install of the `build_bazel_rules_nodejs` workspace. This is necessary to bootstrap Bazel to run the package manager to download other rules from NPM.\n\n"
 
 # Ugly genrule depending on local linux environment to build the README out of skylark doc generation.
@@ -32,10 +42,14 @@ _BUILTINS_README = "# Built-in rules\n\nThese rules are available without any np
 # TODO: This ought to be possible with stardoc alone. Need to coordinate with Chris Parsons.
 genrule(
     name = "builtins_md",
-    srcs = [":builtins.api"],
+    srcs = [
+        ":builtins.api",
+        ":providers.api",
+    ],
     outs = ["builtins.doc"],
     cmd = "echo '%s' > $@;" % _BUILTINS_README +
-          "cat $< | sed 's/^##/\\\n##/' >> $@",
+          "cat $(location :builtins.api) | sed 's/^##/\\\n##/' >> $@ &&" +
+          "cat $(location :providers.api) | sed 's/^##/\\\n##/' >> $@",
     tags = ["fix-windows"],
 )
 

--- a/internal/providers/declaration_info.bzl
+++ b/internal/providers/declaration_info.bzl
@@ -15,15 +15,13 @@
 """This module contains a provider for TypeScript typings files (.d.ts)"""
 
 DeclarationInfo = provider(
-    doc = """The DeclarationInfo provider allows JS rules to communicate typing information.
-TypeScript's .d.ts files are used as the interop format for describing types.
+    doc = """The DeclarationInfo provider allows JS rules to communicate typing information. TypeScript's .d.ts files are used as the interop format for describing types.
 
 Do not create DeclarationInfo instances directly, instead use the declaration_info factory function.
 
-TODO(alexeagle): The ts_library#deps attribute should require that this provider is attached.
-
 Note: historically this was a subset of the string-typed "typescript" provider.
 """,
+    # TODO(alexeagle): The ts_library#deps attribute should require that this provider is attached.
     # TODO: if we ever enable --declarationMap we will have .d.ts.map files too
     fields = {
         "declarations": "A depset of .d.ts files produced by this rule",
@@ -36,14 +34,15 @@ This prevents needing an aspect in rules that consume the typings, which improve
 def declaration_info(declarations, deps = []):
     """Constructs a DeclarationInfo including all transitive declarations from DeclarationInfo providers in a list of deps.
 
-    # TODO: add some checking actions to ensure the declarations are well-formed and don't have semantic diagnostics
-
     Args:
         declarations: list of .d.ts files
         deps: list of labels of dependencies where we should collect their DeclarationInfo to pass transitively
+
     Returns:
         a single DeclarationInfo provider
     """
+
+    # TODO: add some checking actions to ensure the declarations are well-formed and don't have semantic diagnostics
     transitive_depsets = [declarations]
     for dep in deps:
         if DeclarationInfo in dep:

--- a/internal/providers/js_providers.bzl
+++ b/internal/providers/js_providers.bzl
@@ -47,8 +47,8 @@ JSModuleInfo = provider(
 def js_module_info(sources, deps = []):
     """Constructs a JSModuleInfo including all transitive sources from JSModuleInfo providers in a list of deps.
 
-Returns a single JSModuleInfo.
-"""
+    Returns a single JSModuleInfo.
+    """
     transitive_depsets = [sources]
     for dep in deps:
         if JSModuleInfo in dep:
@@ -78,8 +78,8 @@ Historical note: this was the typescript.es5_sources output.
 def js_named_module_info(sources, deps = []):
     """Constructs a JSNamedModuleInfo including all transitive sources from JSNamedModuleInfo providers in a list of deps.
 
-Returns a single JSNamedModuleInfo.
-"""
+    Returns a single JSNamedModuleInfo.
+    """
     transitive_depsets = [sources]
     for dep in deps:
         if JSNamedModuleInfo in dep:
@@ -95,9 +95,9 @@ JSEcmaScriptModuleInfo = provider(
 
 They should use modern syntax and ESModules.
 These files should typically be named "foo.mjs"
-TODO: should we require that?
 
 Historical note: this was the typescript.es6_sources output""",
+    # TODO: should we require that these are ESModules with the mjs extension?
     fields = {
         "direct_sources": "Depset of direct JavaScript files and sourcemaps",
         "sources": "Depset of direct and transitive JavaScript files and sourcemaps",
@@ -107,8 +107,8 @@ Historical note: this was the typescript.es6_sources output""",
 def js_ecma_script_module_info(sources, deps = []):
     """Constructs a JSEcmaScriptModuleInfo including all transitive sources from JSEcmaScriptModuleInfo providers in a list of deps.
 
-Returns a single JSEcmaScriptModuleInfo.
-"""
+    Returns a single JSEcmaScriptModuleInfo.
+    """
     transitive_depsets = [sources]
     for dep in deps:
         if JSEcmaScriptModuleInfo in dep:

--- a/internal/providers/linkable_package_info.bzl
+++ b/internal/providers/linkable_package_info.bzl
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A docstring
+"""LinkablePackageInfo module
 """
 
 LinkablePackageInfo = provider(
-    doc = "A doc string",
+    doc = "The LinkablePackageInfo provider provides information to the linker for linking pkg_npm built packages",
     fields = {
         "files": "Depset of files in this package (must all be contained within path)",
         "package_name": """The package name.

--- a/internal/providers/node_runtime_deps_info.bzl
+++ b/internal/providers/node_runtime_deps_info.bzl
@@ -58,7 +58,16 @@ def _compute_node_modules_root(ctx):
 
 def run_node(ctx, inputs, arguments, executable, **kwargs):
     """Helper to replace ctx.actions.run
-    This calls node programs with a node_modules directory in place"""
+
+    This calls node programs with a node_modules directory in place
+
+    Args:
+        ctx: rule context from the calling rule implementation function
+        inputs: list or depset of inputs to the action
+        arguments: list or ctx.actions.Args object containing arguments to pass to the executable
+        executable: stringy representation of the executable this action will run, eg eg. "my_executable" rather than ctx.executable.my_executable
+        kwargs: all other args accepted by ctx.actions.run
+    """
     if (type(executable) != "string"):
         fail("""run_node requires that executable be provided as a string,
             eg. my_executable rather than ctx.executable.my_executable

--- a/providers.bzl
+++ b/providers.bzl
@@ -61,7 +61,9 @@ LinkablePackageInfo = _LinkablePackageInfo
 #Modelled after _GoContextData in rules_go/go/private/context.bzl
 NodeContextInfo = provider(
     doc = "Provides data about the build context, like config_setting's",
-    fields = ["stamp"],
+    fields = {
+        "stamp": "If stamping is enabled",
+    },
 )
 
 NodeRuntimeDepsInfo = _NodeRuntimeDepsInfo

--- a/tools/stardoc/templates/aspect.vm
+++ b/tools/stardoc/templates/aspect.vm
@@ -1,1 +1,19 @@
-ASPECT TODO
+#[[##]]# ${aspectName}
+
+#[[###]]# Usage
+
+```
+$aspectName(#foreach( $attr in $aspectInfo.getAttributeList() )$attr.name#if( $foreach.hasNext ), #end#end)
+```
+
+#if (!$aspectInfo.getAttributeList().isEmpty())
+#foreach ($attribute in $aspectInfo.getAttributeList())
+
+#[[####]]# `${attribute.name}`
+(*#if ($attribute.type == "NAME")[name]#elseif( $attribute.type == "LABEL" )[label]#elseif( $attribute.type == "LABEL_LIST" )[labels]#else${util.attributeTypeString($attribute)}#end#if( $attribute.mandatory ), mandatory#end*)#if (!$attribute.docString.isEmpty()): ${attribute.docString.trim()}#end
+#if( !$attribute.defaultValue.isEmpty() )
+
+
+Defaults to `$attribute.defaultValue`#end
+#end
+#end

--- a/tools/stardoc/templates/provider.vm
+++ b/tools/stardoc/templates/provider.vm
@@ -1,1 +1,13 @@
-PROVIDER TODO
+#[[##]]# ${providerName}
+
+${providerInfo.docString}
+
+#if (!$providerInfo.fieldInfoList.isEmpty())
+#foreach ($field in $providerInfo.fieldInfoList)
+
+#[[####]]# `${field.name}`
+${field.docString}
+
+#end
+
+#end


### PR DESCRIPTION
Include the docstrings for providers and aspects that were missed from the builtins documentation page

closes #2009 