### PR TITLE
build: set --incompatible_restrict_string_escapes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -51,3 +51,4 @@ build:docker-sandbox --experimental_docker_image=gcr.io/cloud-marketplace/google
 
 # Incompatible flags to run with
 build --incompatible_no_implicit_file_export
+build --incompatible_restrict_string_escapes

--- a/.bazelrc
+++ b/.bazelrc
@@ -48,3 +48,6 @@ build:docker-sandbox --experimental_docker_verbose
 build:docker-sandbox --experimental_enable_docker_sandbox
 # This is the same image used on BazelCI rbe_ubuntu1604 job
 build:docker-sandbox --experimental_docker_image=gcr.io/cloud-marketplace/google/rbe-ubuntu16-04
+
+# Incompatible flags to run with
+build --incompatible_no_implicit_file_export

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,7 +25,16 @@ exports_files([
     "tsconfig.json",
     "package.json",
     "bootstrap.js",
+    "LICENSE",
 ])
+
+exports_files(
+    [
+        "providers.bzl",
+        "index.for_docs.bzl",
+    ],
+    visibility = ["//docs:__subpackages__"],
+)
 
 bzl_library(
     name = "bzl",

--- a/internal/node/BUILD.bazel
+++ b/internal/node/BUILD.bazel
@@ -17,6 +17,12 @@ load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files([
+    "node_patches.js",
+    "require_patch.js",
+    "loader.js",
+])
+
 bzl_library(
     name = "bzl",
     srcs = glob(["*.bzl"]),

--- a/packages/cypress/BUILD.bazel
+++ b/packages/cypress/BUILD.bazel
@@ -19,6 +19,14 @@ load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "co
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(
+    [
+        "internal/plugins/index.template.js",
+        "internal/run-cypress.js",
+    ],
+    visibility = ["//packages/cypress/test:__subpackages__"],
+)
+
 codeowners(
     teams = ["@mrmeku"],
 )

--- a/packages/jasmine/BUILD.bazel
+++ b/packages/jasmine/BUILD.bazel
@@ -21,6 +21,8 @@ load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "co
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["jasmine_runner.js"])
+
 bzl_library(
     name = "bzl",
     srcs = glob(["*.bzl"]),

--- a/packages/karma/BUILD.bazel
+++ b/packages/karma/BUILD.bazel
@@ -21,6 +21,8 @@ load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "co
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["karma.conf.js"])
+
 ts_library(
     name = "bazel_karma_lib",
     srcs = glob(["*.ts"]),

--- a/packages/protractor/BUILD.bazel
+++ b/packages/protractor/BUILD.bazel
@@ -21,6 +21,11 @@ load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "co
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(
+    ["protractor.conf.js"],
+    visibility = ["//packages/protractor/test:__subpackages__"],
+)
+
 bzl_library(
     name = "bzl",
     testonly = True,

--- a/packages/rollup/BUILD.bazel
+++ b/packages/rollup/BUILD.bazel
@@ -23,7 +23,10 @@ codeowners(
     teams = ["@jbedard"],
 )
 
-exports_files(["rollup.config.js"])
+exports_files([
+    "rollup.config.js",
+    "index.js",
+])
 
 bzl_library(
     name = "bzl",

--- a/packages/terser/BUILD.bazel
+++ b/packages/terser/BUILD.bazel
@@ -21,6 +21,11 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(["terser_config.default.json"])
 
+exports_files(
+    ["index.js"],
+    visibility = ["//packages/terser:__subpackages__"],
+)
+
 bzl_library(
     name = "bzl",
     srcs = glob(["*.bzl"]),


### PR DESCRIPTION
Sets --incompatible_restrict_string_escapes to ensure no regression is introduced, branched from https://github.com/bazelbuild/rules_nodejs/pull/2067

closes https://github.com/bazelbuild/rules_nodejs/issues/1301