### PR TITLE
feat: augment TS2307 errors with missing dependency messages for ts_project

### DIFF
--- a/packages/typescript/bin/BUILD.bazel
+++ b/packages/typescript/bin/BUILD.bazel
@@ -12,3 +12,9 @@ nodejs_binary(
     entry_point = "//packages/typescript/internal:ts_project_options_validator.js",
     visibility = ["//:__subpackages__"],
 )
+
+nodejs_binary(
+    name = "diagnostics_processor",
+    entry_point = ":strict-deps-diagnostics-processor.js",
+    visibility = ["//:__subpackages__"],
+)

--- a/packages/typescript/bin/strict-deps-diagnostics-processor.js
+++ b/packages/typescript/bin/strict-deps-diagnostics-processor.js
@@ -1,0 +1,32 @@
+const {readFileSync, writeFileSync} = require('fs');
+const diagnosticsOutPath = process.argv[2];
+const exitcodeOutPath = process.argv[3];
+const processedDiagnosticsOutPath = process.argv[4];
+const label = process.argv[5];
+
+if (!diagnosticsOutPath && !exitcodeOutPath && !processedDiagnosticsOutPath) {
+  throw new Error(`Expected path to tsc diagnostics output and exitcode`);
+}
+
+let tsDiagnostics = readFileSync(diagnosticsOutPath, {encoding: 'utf8'});
+const exitcode = readFileSync(exitcodeOutPath, {encoding: 'utf8'});
+
+// find all the TS2307 diagnostics and pull out the module specifier from the message
+const matches =
+  tsDiagnostics.matchAll(new RegExp(`TS2307:.*?Cannot find module '(?<module>.*?)'\.`, 'gm'));
+
+if (matches) {
+  Array.from(matches).reverse().forEach(match => {
+    const moduleSpecifier = match.groups.module;
+    const diagOffset = match.index + match[0].length;
+    const depsMessage = ` Ensure that the dependency for '${
+      moduleSpecifier}' is added to ${label} deps attribute.`;
+    tsDiagnostics =
+      tsDiagnostics.slice(0, diagOffset) + depsMessage + tsDiagnostics.slice(diagOffset);
+  });
+}
+
+writeFileSync(processedDiagnosticsOutPath, tsDiagnostics, {encoding: 'utf8'});
+process.stderr.write(tsDiagnostics);
+
+process.exit(Number(exitcode));


### PR DESCRIPTION
Take 2, for `ts_project` as it presents an easier path to have tsc output files even when it fails, unlike ts_library which has a bunch of early exits depending on the diagnostics produced.

Last issue is the diagnostic processor must produce some output and something must request this, otherwise it will never be run, see comment on source