### PR TITLE
fix(cypress): allow for async cypress plugins

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -120,6 +120,8 @@ load("//packages/cypress:index.bzl", "cypress_repository")
 cypress_repository(
     name = "cypress",
     cypress_bin = "@cypress_deps//:node_modules/cypress/bin/cypress",
+    # Currently cypress cannot be installed on our Linux/Windows CI machines
+    fail_on_error = False,
 )
 
 #

--- a/packages/cypress/BUILD.bazel
+++ b/packages/cypress/BUILD.bazel
@@ -76,8 +76,8 @@ pkg_npm(
     srcs = [
         "index.bzl",
         "package.json",
-        "//packages/cypress:internal/cypress-install.js",
         "//packages/cypress:internal/cypress_repository.bzl",
+        "//packages/cypress:internal/install-cypress.js",
         "//packages/cypress:internal/plugins/base.js",
         "//packages/cypress:internal/plugins/index.template.js",
         "//packages/cypress:internal/run-cypress.js",
@@ -90,8 +90,8 @@ pkg_npm(
     "plugins/base.js",
 ])""",
     substitutions = {
-        "@build_bazel_rules_nodejs//packages/cypress:internal/cypress-install.js": "TEMPLATED_node_modules_workspace_name//@bazel/cypress:internal/cypress-install.js",
         "@build_bazel_rules_nodejs//packages/cypress:internal/cypress_repository.bzl": "//packages/cypress:internal/cypress_repository.bzl",
+        "@build_bazel_rules_nodejs//packages/cypress:internal/install-cypress.js": "TEMPLATED_node_modules_workspace_name//@bazel/cypress:internal/install-cypress.js",
         "@build_bazel_rules_nodejs//packages/cypress:internal/plugins/base.js": "TEMPLATED_node_modules_workspace_name//@bazel/cypress:internal/plugins/base.js",
         "@build_bazel_rules_nodejs//packages/cypress:internal/plugins/index.template.js": "TEMPLATED_node_modules_workspace_name//@bazel/cypress:internal/plugins/index.template.js",
         "@build_bazel_rules_nodejs//packages/cypress:internal/run-cypress.js": "TEMPLATED_node_modules_workspace_name//@bazel/cypress:internal/run-cypress.js",

--- a/packages/cypress/internal/cypress_repository.bzl
+++ b/packages/cypress/internal/cypress_repository.bzl
@@ -20,10 +20,10 @@ load("@build_bazel_rules_nodejs//internal/node:node_labels.bzl", "get_node_label
 def _cypress_repository_impl(repository_ctx):
     node = repository_ctx.path(get_node_label(repository_ctx))
 
-    cypress_install = "packages/cypress/internal/cypress-install.js"
+    install_cypress = "packages/cypress/internal/install-cypress.js"
     repository_ctx.template(
-        cypress_install,
-        repository_ctx.path(repository_ctx.attr._cypress_install),
+        install_cypress,
+        repository_ctx.path(repository_ctx.attr._install_cypress),
         {},
     )
 
@@ -36,9 +36,12 @@ def _cypress_repository_impl(repository_ctx):
     )
 
     exec_result = repository_ctx.execute(
-        [node, cypress_install, repository_ctx.path(repository_ctx.attr.cypress_bin)],
+        [node, install_cypress, repository_ctx.path(repository_ctx.attr.cypress_bin)],
         quiet = repository_ctx.attr.quiet,
     )
+
+    if exec_result.return_code != 0 and repository_ctx.attr.fail_on_error:
+        fail("\ncypress_repository exited with code: {}\n\nstdout:\n{}\n\nstderr:\n{}\n\n".format(exec_result.return_code, exec_result.stdout, exec_result.stderr))
 
 cypress_repository = repository_rule(
     implementation = _cypress_repository_impl,
@@ -48,17 +51,21 @@ cypress_repository = repository_rule(
             allow_single_file = True,
             default = "@npm//:node_modules/cypress/bin/cypress",
         ),
+        "fail_on_error": attr.bool(
+            default = True,
+            doc = "If the repository rule should allow errors",
+        ),
         "quiet": attr.bool(
             default = True,
             doc = "If stdout and stderr should be printed to the terminal",
         ),
-        "_cypress_install": attr.label(
-            allow_single_file = True,
-            default = "//packages/cypress:internal/cypress-install.js",
-        ),
         "_cypress_web_test": attr.label(
             allow_single_file = True,
             default = "//packages/cypress:internal/template.cypress_web_test.bzl",
+        ),
+        "_install_cypress": attr.label(
+            allow_single_file = True,
+            default = "//packages/cypress:internal/install-cypress.js",
         ),
     },
 )

--- a/packages/cypress/internal/run-cypress.js
+++ b/packages/cypress/internal/run-cypress.js
@@ -7,10 +7,10 @@ const [node, entry, configFilePath, pluginsFilePath, cypressExecutable, ...args]
 if (cypressExecutable) {
   process.env.CYPRESS_RUN_BINARY =
       join(process.cwd(), cypressExecutable.replace('external/', '../'));
+  process.env.CYPRESS_CACHE_FOLDER =
+      join(process.env.CYPRESS_RUN_BINARY.split('/cypress-cache/')[0], '/cypress-cache');
+  process.env.HOME = process.env['TEST_TMPDIR'];
 }
-
-console.log(process.argv);
-
 
 const pluginsFile = runfiles.resolveWorkspaceRelative(pluginsFilePath).replace(process.cwd(), '.');
 const configFile = runfiles.resolveWorkspaceRelative(configFilePath).replace(process.cwd(), '.');


### PR DESCRIPTION
cypress_repository now fails if cypress verify fails
set the HOME env variable since cypress writes files to it
remove unused includeScreenshots / includeVideos variables
browserify files are no longer included in test output files
screenshots/videos are stored directory in TEST_UNDECLARED_OUTPUTS_DIR

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No