### PR TITLE
docs: use @npm//@bazel for example load sites

### DIFF
--- a/packages/labs/protobufjs/ts_proto_library.bzl
+++ b/packages/labs/protobufjs/ts_proto_library.bzl
@@ -175,7 +175,7 @@ a `ts_library` can appear, such as in the `deps[]` of another `ts_library`.
 Example:
 
 ```python
-load("//packages/typescript:index.bzl", "ts_library", "ts_proto_library")
+load("@npm//@bazel/typescript:index.bzl", "ts_library", "ts_proto_library")
 
 proto_library(
     name = "car_proto",
@@ -203,18 +203,18 @@ name the rule differently from the output file.
 The JavaScript produced by protobuf.js has a runtime dependency on a support library.
 Under devmode (e.g. `ts_devserver`, `karma_web_test_suite`) you'll need to include these scripts
 in the `bootstrap` phase (before Require.js loads). You can use the label
-`//packages/labs/protobufjs:bootstrap_scripts` to reference these scripts
+`@npm//@bazel/labs/protobufjs:bootstrap_scripts` to reference these scripts
 in the `bootstrap` attribute of `karma_web_test_suite` or `ts_devserver`.
 
 To complete the example above, you could write a `karma_web_test_suite`:
 
 ```python
-load("//packages/karma:index.bzl", "karma_web_test_suite")
+load("@npm//@bazel/karma:index.bzl", "karma_web_test_suite")
 
 karma_web_test_suite(
     name = "test",
     deps = ["test_lib"],
-    bootstrap = ["//packages/labs/protobufjs:bootstrap_scripts"],
+    bootstrap = ["@npm//@bazel/labs/protobufjs:bootstrap_scripts"],
     browsers = [
         "@io_bazel_rules_webtesting//browsers:chromium-local",
         "@io_bazel_rules_webtesting//browsers:firefox-local",

--- a/packages/rollup/rollup_bundle.bzl
+++ b/packages/rollup/rollup_bundle.bzl
@@ -9,7 +9,7 @@ See https://rollupjs.org/guide/en/#command-line-reference
 
 Typical example:
 ```python
-load("//packages/rollup:index.bzl", "rollup_bundle")
+load("@npm//@bazel/rollup:index.bzl", "rollup_bundle")
 
 rollup_bundle(
     name = "bundle",

--- a/packages/terser/terser_minified.bzl
+++ b/packages/terser/terser_minified.bzl
@@ -20,7 +20,7 @@ _DOC = """Run the terser minifier.
 
 Typical example:
 ```python
-load("//packages/terser:index.bzl", "terser_minified")
+load("@npm//@bazel/terser:index.bzl", "terser_minified")
 
 terser_minified(
     name = "out.min",


### PR DESCRIPTION
Have the docs for rules_nodejs use the `@npm//@bazel/foo` in the examples for the load sites for different packages.
The current docs show loading them from `//packages/foo`, which causes confusion. The common case seems to be to have a external workspace called `@npm`

closes: #2092, #2087