### PR TITLE
fix(rollup): allow config files to override default onwarn method

### DIFF
--- a/packages/rollup/index.js
+++ b/packages/rollup/index.js
@@ -103,11 +103,15 @@ function extractEnvironmentVariables(vars) {
 //  input:  https://rollupjs.org/guide/en/#inputoptions-object
 //  output: https://rollupjs.org/guide/en/#outputoptions-object
 async function parseCLIArgs(args) {
-  let inputOptions = {
+  // Options which the CLI args or config file can override
+  const defaultInputOptions = {
     onwarn(...warnArgs) {
       worker.log(...warnArgs);
     },
   };
+
+  // Options which can override the config file
+  let inputOptions = {};
 
   let outputOptions = {};
 
@@ -193,6 +197,9 @@ async function parseCLIArgs(args) {
     // may be external and persisted across runs
     delete inputOptions.output;
   }
+
+  // Provide default inputOptions which can be overwritten
+  inputOptions = {...defaultInputOptions, ...inputOptions};
 
   // The inputs are the rule entry_point[s]
   inputOptions.input = inputs;

--- a/packages/rollup/test/integration/foo/BUILD.bazel
+++ b/packages/rollup/test/integration/foo/BUILD.bazel
@@ -11,10 +11,12 @@ copy_file(
 )
 
 ts_project(
+    name = "foo_tslib",
     srcs = [
         "index.ts",
         "user.d.ts",
     ],
+    tsconfig = ":tsconfig.json",
     deps = ["@npm//date-fns"],
 )
 
@@ -22,8 +24,9 @@ js_library(
     name = "foo_lib",
     package_name = "@foo/lib",
     srcs = [
-        "user.d.ts",
-        ":index.js",
         ":user.js",
+    ],
+    deps = [
+        ":foo_tslib",
     ],
 )


### PR DESCRIPTION
Fixes #2084

... will try adding a test still.