### PR TITLE
fix(examples): use ./ prefix on babel config file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ babel(
     args = [
         "app.js",
         "--config-file",
-        "$(execpath es5.babelrc)",
+        "./$(execpath es5.babelrc)",
         "--out-file",
         "$(execpath app.es5.js)",
     ],

--- a/examples/webapp/differential_loading.bzl
+++ b/examples/webapp/differential_loading.bzl
@@ -36,7 +36,7 @@ def differential_loading(name, entry_point, srcs):
         args = [
             "$(execpath %s_chunks)" % name,
             "--config-file",
-            "$(execpath es5.babelrc)",
+            "./$(execpath es5.babelrc)",
             "--out-dir",
             "$(@D)",
         ],


### PR DESCRIPTION
Otherwise if it's in a subfolder, babel will think it's an npm package
