### PR TITLE
fix(typescript): produce .d.ts as default output rather than empty

### DIFF
--- a/packages/typescript/test/ts_project/declaration_only/BUILD.bazel
+++ b/packages/typescript/test/ts_project/declaration_only/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
+load("//packages/typescript:index.bzl", "ts_project")
+
+ts_project(
+    declaration = True,
+    emit_declaration_only = True,
+)
+
+generated_file_test(
+    name = "test",
+    src = "a.d.ts_",
+    generated = ":tsconfig",
+)

--- a/packages/typescript/test/ts_project/declaration_only/a.d.ts_
+++ b/packages/typescript/test/ts_project/declaration_only/a.d.ts_
@@ -1,0 +1,1 @@
+export declare const a: string;

--- a/packages/typescript/test/ts_project/declaration_only/a.ts
+++ b/packages/typescript/test/ts_project/declaration_only/a.ts
@@ -1,0 +1,1 @@
+export const a: string = '';

--- a/packages/typescript/test/ts_project/declaration_only/tsconfig.json
+++ b/packages/typescript/test/ts_project/declaration_only/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "types": []
+    }
+}


### PR DESCRIPTION
This lets you type-check a `ts_project(emit_declaration_only=True)` just by building it (its default outputs).