### PR TITLE
feat(typescript): worker mode for ts_project

### DIFF
--- a/examples/react_webpack/BUILD.bazel
+++ b/examples/react_webpack/BUILD.bazel
@@ -14,7 +14,7 @@ sass(
 )
 
 ts_project(
-    # Start a tsc daemon to watch for changes to make recompiles faster.
+    # Experimental: Start a tsc daemon to watch for changes to make recompiles faster.
     supports_workers = True,
     deps = [
         "@npm//@types",

--- a/examples/react_webpack/BUILD.bazel
+++ b/examples/react_webpack/BUILD.bazel
@@ -14,6 +14,8 @@ sass(
 )
 
 ts_project(
+    # Start a tsc daemon to watch for changes to make recompiles faster.
+    supports_workers = True,
     deps = [
         "@npm//@types",
         "@npm//csstype",

--- a/examples/react_webpack/tsconfig.json
+++ b/examples/react_webpack/tsconfig.json
@@ -1,6 +1,14 @@
 {
     "compilerOptions": {
         "jsx": "react",
-        "lib": ["ES2015", "DOM"]
-    }
+        "lib": [
+            "ES2015",
+            "DOM"
+        ]
+    },
+    // When using ts_project in worker mode, make sure to whitelist the files that should be part of this particular compilation. In worker mode, the CWD is different than by default so typescript will pickup extraneous files without the whitelist.
+    "include": [
+        "*.tsx",
+        "*.ts"
+    ]
 }

--- a/examples/react_webpack/tsconfig.json
+++ b/examples/react_webpack/tsconfig.json
@@ -6,7 +6,8 @@
             "DOM"
         ]
     },
-    // When using ts_project in worker mode, make sure to whitelist the files that should be part of this particular compilation. In worker mode, the CWD is different than by default so typescript will pickup extraneous files without the whitelist.
+    // When using ts_project in worker mode, we run outside the Bazel sandbox (unless using --worker_sandboxing).
+    // We list the files that should be part of this particular compilation to avoid TypeScript discovering others.
     "include": [
         "*.tsx",
         "*.ts"

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -150,6 +150,9 @@ def _to_execroot_path(ctx, file):
 
     return file.path
 
+def _join(*elements):
+    return "/".join([f for f in elements if f])
+
 def _nodejs_binary_impl(ctx):
     node_modules_manifest = write_node_modules_manifest(ctx, link_workspace_root = ctx.attr.link_workspace_root)
     node_modules_depsets = []
@@ -250,14 +253,11 @@ fi
     expanded_args = [expand_location_into_runfiles(ctx, a, ctx.attr.data) for a in expanded_args]
 
     # Next expand predefined variables & custom variables
-    rule_dir = [f for f in [
-        ctx.bin_dir.path,
-        ctx.label.workspace_root,
-        ctx.label.package,
-    ] if f]
-    additional_substitutions = {}
-    additional_substitutions["@D"] = "/".join([o for o in rule_dir if o])
-    additional_substitutions["RULEDIR"] = "/".join([o for o in rule_dir if o])
+    rule_dir = _join(ctx.bin_dir.path, ctx.label.workspace_root, ctx.label.package)
+    additional_substitutions = {
+        "@D": rule_dir,
+        "RULEDIR": rule_dir,
+    }
     expanded_args = [ctx.expand_make_variables("templated_args", e, additional_substitutions) for e in expanded_args]
 
     substitutions = {

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -37,7 +37,7 @@ def _trim_package_node_modules(package_name):
     for n in package_name.split("/"):
         if n == "node_modules":
             break
-        segments += [n]
+        segments.append(n)
     return "/".join(segments)
 
 def _compute_node_modules_root(ctx):
@@ -250,7 +250,15 @@ fi
     expanded_args = [expand_location_into_runfiles(ctx, a, ctx.attr.data) for a in expanded_args]
 
     # Next expand predefined variables & custom variables
-    expanded_args = [ctx.expand_make_variables("templated_args", e, {}) for e in expanded_args]
+    rule_dir = [f for f in [
+        ctx.bin_dir.path,
+        ctx.label.workspace_root,
+        ctx.label.package,
+    ] if f]
+    additional_substitutions = {}
+    additional_substitutions["@D"] = "/".join([o for o in rule_dir if o])
+    additional_substitutions["RULEDIR"] = "/".join([o for o in rule_dir if o])
+    expanded_args = [ctx.expand_make_variables("templated_args", e, additional_substitutions) for e in expanded_args]
 
     substitutions = {
         # TODO: Split up results of multifile expansions into separate args and qoute them with

--- a/packages/typescript/BUILD.bazel
+++ b/packages/typescript/BUILD.bazel
@@ -100,6 +100,7 @@ pkg_npm(
         ":npm_version_check",
         "//packages/typescript/internal:BUILD",
         "//packages/typescript/internal:ts_project_options_validator.js",
+        "//packages/typescript/internal/worker",
     ] + select({
         # FIXME: fix stardoc on Windows; //packages/typescript:index.md generation fails with:
         #   ERROR: D:/b/62unjjin/external/npm_bazel_typescript/BUILD.bazel:36:1: Couldn't build file

--- a/packages/typescript/internal/BUILD.bazel
+++ b/packages/typescript/internal/BUILD.bazel
@@ -64,6 +64,7 @@ filegroup(
         "ts_config.bzl",
         "ts_project.bzl",
         "//packages/typescript/internal/devserver:package_contents",
+        "//packages/typescript/internal/worker:package_contents",
     ],
     visibility = ["//packages/typescript:__subpackages__"],
 )

--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -594,11 +594,18 @@ def ts_project_macro(
 
     if supports_workers:
         tsc_worker = "%s_worker" % name
+        protobufjs = (
+            # BEGIN-INTERNAL
+            "@npm" +
+            # END-INTERNAL
+            "//protobufjs"
+        )
         nodejs_binary(
             name = tsc_worker,
             data = [
                 Label("//packages/typescript/internal/worker:worker"),
                 Label(_DEFAULT_TSC_BIN),
+                Label(protobufjs),
                 tsconfig,
             ],
             entry_point = Label("//packages/typescript/internal/worker:worker_adapter"),

--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -21,7 +21,7 @@ _DEFAULT_TSC_BIN = (
     "//:node_modules/typescript/bin/tsc"
 )
 
-_DEFAULT_TYPESCRIP_MODULE = (
+_DEFAULT_TYPESCRIPT_MODULE = (
     # BEGIN-INTERNAL
     "@npm" +
     # END-INTERNAL
@@ -322,7 +322,7 @@ def ts_project_macro(
         ts_build_info_file = None,
         tsc = None,
         worker_tsc_bin = _DEFAULT_TSC_BIN,
-        worker_typescript_module = _DEFAULT_TYPESCRIP_MODULE,
+        worker_typescript_module = _DEFAULT_TYPESCRIPT_MODULE,
         validate = True,
         supports_workers = False,
         declaration_dir = None,
@@ -503,8 +503,14 @@ def ts_project_macro(
 
         supports_workers: Experimental! Use only with caution.
 
-            Allows you to enable the Bazel Worker strategy for this project.
-            This requires that the tsc binary support it.
+            Allows you to enable the Bazel Persistent Workers strategy for this project.
+            See https://docs.bazel.build/versions/master/persistent-workers.html
+
+            This requires that the tsc binary support a `--watch` option.
+
+            NOTE: this does not work on Windows yet.
+            We will silently fallback to non-worker mode on Windows regardless of the value of this attribute.
+            Follow https://github.com/bazelbuild/rules_nodejs/issues/2277 for progress on this feature.
 
         root_dir: a string specifying a subdirectory under the input package which should be consider the
             root directory of all the input files.

--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -79,7 +79,7 @@ def _ts_project_impl(ctx):
         arguments.use_param_file("@%s", use_always = True)
         arguments.set_param_file_format("multiline")
         execution_requirements["supports-workers"] = "1"
-        execution_requirements["worker-key-mnemonic"] = "TsProjectMnemonic"
+        execution_requirements["worker-key-mnemonic"] = "TsProject"
         progress_prefix = "Compiling TypeScript project (worker mode)"
 
     generated_srcs = False
@@ -618,7 +618,6 @@ def ts_project_macro(
                 "--outDir",
                 "$(RULEDIR)",
                 # FIXME: what about other settings like declaration_dir, root_dir, etc
-                "--watch",
             ],
         )
 

--- a/packages/typescript/internal/worker/BUILD.bazel
+++ b/packages/typescript/internal/worker/BUILD.bazel
@@ -1,0 +1,55 @@
+# BEGIN-INTERNAL
+
+load("//internal/common:copy_to_bin.bzl", "copy_to_bin")
+load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "copy_file")
+
+# Copy the proto file to a matching third_party/... nested directory
+# so the runtime require() statements still work
+_worker_proto_dir = "third_party/github.com/bazelbuild/bazel/src/main/protobuf"
+
+genrule(
+    name = "copy_worker_js",
+    srcs = ["//packages/worker:npm_package"],
+    outs = ["worker.js"],
+    cmd = "cp $(execpath //packages/worker:npm_package)/index.js $@",
+    visibility = ["//visibility:public"],
+)
+
+copy_file(
+    name = "copy_worker_proto",
+    src = "@build_bazel_rules_typescript//%s:worker_protocol.proto" % _worker_proto_dir,
+    out = "%s/worker_protocol.proto" % _worker_proto_dir,
+    visibility = ["//visibility:public"],
+)
+
+copy_to_bin(
+    name = "worker_adapter",
+    srcs = [
+        "worker_adapter.js",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package_contents",
+    srcs = [
+        "BUILD.bazel",
+    ],
+    visibility = ["//packages/typescript:__subpackages__"],
+)
+
+# END-INTERNAL
+
+exports_files([
+    "worker_adapter.js",
+])
+
+filegroup(
+    name = "worker",
+    srcs = [
+        "third_party/github.com/bazelbuild/bazel/src/main/protobuf/worker_protocol.proto",
+        "worker.js",
+        "worker_adapter.js",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/packages/typescript/internal/worker/worker_adapter.js
+++ b/packages/typescript/internal/worker/worker_adapter.js
@@ -61,7 +61,25 @@ async function main() {
         `Started a new process to perform this action. Your build might be misconfigured, try
       --strategy=${MNEMONIC}=worker`);
 
-    child.on('exit', code => process.exit(code));
+    const stdoutbuffer = [];
+    child.stdout.on('data', data => stdoutbuffer.push(data));
+
+    const stderrbuffer = [];
+    child.stderr.on('data', data => stderrbuffer.push(data));
+
+    child.on('exit', code => {
+      if (code !== 0) {
+        console.error(
+            `\nstdout from tsc:\n\n  ${
+                stdoutbuffer.map(s => s.toString()).join('').replace(/\n/g, '\n  ')}`,
+        )
+        console.error(
+            `\nstderr from tsc:\n\n  ${
+                stderrbuffer.map(s => s.toString()).join('').replace(/\n/g, '\n  ')}`,
+        )
+      }
+      process.exit(code)
+    });
   }
 }
 

--- a/packages/typescript/internal/worker/worker_adapter.js
+++ b/packages/typescript/internal/worker/worker_adapter.js
@@ -1,3 +1,13 @@
+/**
+ * @fileoverview wrapper program around the TypeScript compiler, tsc
+ *
+ * It intercepts the Bazel Persistent Worker protocol, using it to remote-control tsc running as a
+ * child process. In between builds, the tsc process is stopped (akin to ctrl-z in a shell) and then
+ * resumed (akin to `fg`) when the inputs have changed.
+ *
+ * See https://medium.com/@mmorearty/how-to-create-a-persistent-worker-for-bazel-7738bba2cabb
+ * for more background (note, that is documenting a different implementation)
+ */
 const child_process = require('child_process');
 const MNEMONIC = 'TsProject';
 const worker = require('./worker');
@@ -7,7 +17,8 @@ if (workerArg > 0) {
   process.argv.splice(workerArg, 1, '--watch')
 
   if (process.platform !== 'linux' && process.platform !== 'darwin') {
-    throw new Error('Worker mode is only supported on unix type systems.');
+    throw new Error(`Worker mode is only supported on linux and darwin, not ${process.platform}.
+        See https://github.com/bazelbuild/rules_nodejs/issues/2277`);
   }
 }
 

--- a/packages/typescript/internal/worker/worker_adapter.js
+++ b/packages/typescript/internal/worker/worker_adapter.js
@@ -1,0 +1,52 @@
+const child_process = require('child_process');
+
+const worker = require('./worker');
+
+const workerArg = process.argv.indexOf('--persistent_worker')
+if (workerArg > 0) {
+  process.argv.splice(workerArg, 1)
+
+  if (process.platform !== 'linux' && process.platform !== 'darwin') {
+    throw new Error('Worker mode is only supported on unix type systems.');
+  }
+
+  worker.runWorkerLoop(awaitOneBuild);
+}
+
+const [tscBin, ...tscArgs] = process.argv.slice(2);
+
+const child = child_process.spawn(
+    tscBin,
+    tscArgs,
+    {stdio: 'pipe'},
+);
+
+function awaitOneBuild() {
+  child.kill('SIGCONT')
+
+  let buffer = [];
+  return new Promise((res) => {
+    function awaitBuild(s) {
+      buffer.push(s);
+
+      if (s.includes('Watching for file changes.')) {
+        child.kill('SIGSTOP')
+
+        const success = s.includes('Found 0 errors.');
+        res(success);
+
+        child.stdout.removeListener('data', awaitBuild);
+
+        if (!success) {
+          console.error(
+              `\nError output from tsc worker:\n\n  ${
+                  buffer.slice(1).map(s => s.toString()).join('').replace(/\n/g, '\n  ')}`,
+          )
+        }
+
+        buffer = [];
+      }
+    };
+    child.stdout.on('data', awaitBuild);
+  });
+}

--- a/packages/typescript/replacements.bzl
+++ b/packages/typescript/replacements.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Replacements for @npm/typescript package
+"""Replacements for @bazel/typescript package
 """
 
 load("@build_bazel_rules_nodejs//:index.bzl", "COMMON_REPLACEMENTS")
@@ -24,6 +24,7 @@ TYPESCRIPT_REPLACEMENTS = dict(
         # @build_bazel_rules_typescript//:npm_bazel_typescript_package
         # use this alternate fencing
         "(#|\\/\\/)\\s+BEGIN-DEV-ONLY[\\w\\W]+?(#|\\/\\/)\\s+END-DEV-ONLY": "",
+        "//packages/typescript/internal/worker:worker_adapter": "//@bazel/typescript/internal/worker:worker_adapter.js",
         # This file gets vendored into our repo
         "@build_bazel_rules_typescript//internal:common": "//@bazel/typescript/internal:common",
         # Replace the local compiler label with one that comes from npm

--- a/packages/typescript/test/ts_project/worker/BUILD.bazel
+++ b/packages/typescript/test/ts_project/worker/BUILD.bazel
@@ -1,0 +1,11 @@
+load("//packages/typescript:index.bzl", "ts_project")
+
+ts_project(
+    supports_workers = True,
+    tsconfig = {
+        "compilerOptions": {
+            "declaration": True,
+            "types": [],
+        },
+    },
+)

--- a/packages/typescript/test/ts_project/worker/BUILD.bazel
+++ b/packages/typescript/test/ts_project/worker/BUILD.bazel
@@ -2,6 +2,7 @@ load("//packages/typescript:index.bzl", "ts_project")
 
 ts_project(
     supports_workers = True,
+    tags = ["fix-windows"],
     tsconfig = {
         "compilerOptions": {
             "declaration": True,

--- a/packages/typescript/test/ts_project/worker/big.ts
+++ b/packages/typescript/test/ts_project/worker/big.ts
@@ -1,0 +1,3 @@
+// TODO: make it big enough to slow down tsc
+
+export const a: number = 2;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: https://github.com/bazelbuild/rules_nodejs/issues/1726


## What is the new behavior?
Introduce experimental `supports_workers` property on ts_project to persist worker tsc --watch processes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Unsupported on windows with current implementation which relies on suspending/resuming tsc --watch process
