### PR TITLE
fix(typescript): add the tsBuildInfoFile option to ts_project

### DIFF
--- a/packages/typescript/internal/ts_project_options_validator.ts
+++ b/packages/typescript/internal/ts_project_options_validator.ts
@@ -1,3 +1,4 @@
+import {relative} from 'path';
 import * as ts from 'typescript';
 
 const diagnosticsHost: ts.FormatDiagnosticsHost = {
@@ -29,14 +30,37 @@ function main([tsconfigPath, output, target, attrsStr]: string[]): 0|1 {
 
   const failures: string[] = [];
   const buildozerCmds: string[] = [];
+
+  function getTsOption(option) {
+    if (typeof (options[option]) === 'string') {
+      // Currently the only string-typed options are filepaths.
+      // TypeScript will resolve these to a project path
+      // so when echoing that back to the user, we need to reverse that resolution.
+      // First turn //path/to/pkg:tsconfig into path/to/pkg
+      const packageDir = target.substr(2, target.indexOf(':') - 2);
+      return relative(packageDir, options[option] as string);
+    }
+    return options[option];
+  }
+
   function check(option: string, attr?: string) {
     attr = attr || option;
     // treat compilerOptions undefined as false
-    const optionVal = options[option] === undefined ? false : options[option];
-    if (optionVal !== attrs[attr]) {
+    const optionVal = getTsOption(option);
+    const match = optionVal === attrs[attr] ||
+        (optionVal === undefined && (attrs[attr] === false || attrs[attr] === ''));
+    if (!match) {
       failures.push(
           `attribute ${attr}=${attrs[attr]} does not match compilerOptions.${option}=${optionVal}`);
-      buildozerCmds.push(`set ${attr} ${optionVal ? 'True' : 'False'}`);
+      if (typeof (optionVal) === 'boolean') {
+        buildozerCmds.push(`set ${attr} ${optionVal ? 'True' : 'False'}`);
+      } else if (typeof (optionVal) === 'string') {
+        buildozerCmds.push(`set ${attr} \"${optionVal}\"`);
+      } else if (optionVal === undefined) {
+        // nothing to sync
+      } else {
+        throw new Error(`cannot check option ${option} of type ${typeof (option)}`);
+      }
     }
   }
 
@@ -46,6 +70,7 @@ function main([tsconfigPath, output, target, attrsStr]: string[]): 0|1 {
   check('composite');
   check('declaration');
   check('incremental');
+  check('tsBuildInfoFile', 'ts_build_info_file');
 
   if (failures.length > 0) {
     console.error(`ERROR: ts_project rule ${
@@ -70,6 +95,7 @@ function main([tsconfigPath, output, target, attrsStr]: string[]): 0|1 {
 // incremental:           ${attrs.incremental}
 // source_map:            ${attrs.source_map}
 // emit_declaration_only: ${attrs.emit_declaration_only}
+// ts_build_info_file:    ${attrs.ts_build_info_file}
 `,
       'utf-8');
   return 0;

--- a/packages/typescript/test/ts_project/tsbuildinfofile/BUILD.bazel
+++ b/packages/typescript/test/ts_project/tsbuildinfofile/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//packages/typescript:index.bzl", "ts_project")
+
+ts_project(
+    name = "tsconfig",
+    composite = True,
+    ts_build_info_file = "my.tsbuildinfo",
+)

--- a/packages/typescript/test/ts_project/tsbuildinfofile/a.ts
+++ b/packages/typescript/test/ts_project/tsbuildinfofile/a.ts
@@ -1,0 +1,1 @@
+export const a: string = '';

--- a/packages/typescript/test/ts_project/tsbuildinfofile/tsconfig.json
+++ b/packages/typescript/test/ts_project/tsbuildinfofile/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+        "composite": true,
+        "tsBuildInfoFile": "my.tsbuildinfo",
+        "types": []
+    }
+}


### PR DESCRIPTION
Like other options that affect tsc outputs, Bazel needs to know the value from the tsconfig if its set.
Add it to our validator so there's a buildozer command to sync the option value into the BUILD file.

Fixes #2137
