### PR TITLE
docs: document the node_context_data attribute

### DIFF
--- a/internal/pkg_npm/pkg_npm.bzl
+++ b/internal/pkg_npm/pkg_npm.bzl
@@ -6,7 +6,7 @@ If all users of your library code use Bazel, they should just add your library
 to the `deps` of one of their targets.
 """
 
-load("//:providers.bzl", "DeclarationInfo", "JSModuleInfo", "LinkablePackageInfo", "NodeContextInfo")
+load("//:providers.bzl", "DeclarationInfo", "JSModuleInfo", "LinkablePackageInfo", "NODE_CONTEXT_ATTRS", "NodeContextInfo")
 
 _DOC = """The pkg_npm rule creates a directory containing a publishable npm artifact.
 
@@ -73,7 +73,7 @@ You can pass arguments to npm by escaping them from Bazel using a double-hyphen,
 """
 
 # Used in angular/angular /packages/bazel/src/ng_package/ng_package.bzl
-PKG_NPM_ATTRS = {
+PKG_NPM_ATTRS = dict(NODE_CONTEXT_ATTRS, **{
     "deps": attr.label_list(
         doc = """Other targets which produce files that should be included in the package, such as `rollup_bundle`""",
         allow_files = True,
@@ -81,11 +81,6 @@ PKG_NPM_ATTRS = {
     "nested_packages": attr.label_list(
         doc = """Other pkg_npm rules whose content is copied into this package.""",
         allow_files = True,
-    ),
-    "node_context_data": attr.label(
-        default = "@build_bazel_rules_nodejs//internal:node_context_data",
-        providers = [NodeContextInfo],
-        doc = "Internal use only",
     ),
     "package_name": attr.string(
         doc = """Optional package_name that this npm package may be imported as.""",
@@ -120,7 +115,7 @@ PKG_NPM_ATTRS = {
         default = Label("@nodejs//:run_npm.sh.template"),
         allow_single_file = True,
     ),
-}
+})
 
 # Used in angular/angular /packages/bazel/src/ng_package/ng_package.bzl
 PKG_NPM_OUTPUTS = {

--- a/packages/rollup/rollup_bundle.bzl
+++ b/packages/rollup/rollup_bundle.bzl
@@ -1,6 +1,6 @@
 "Rules for running Rollup under Bazel"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSEcmaScriptModuleInfo", "JSModuleInfo", "NodeContextInfo", "NpmPackageInfo", "node_modules_aspect", "run_node")
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSEcmaScriptModuleInfo", "JSModuleInfo", "NODE_CONTEXT_ATTRS", "NodeContextInfo", "NpmPackageInfo", "node_modules_aspect", "run_node")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "module_mappings_aspect")
 
 _DOC = """Runs the Rollup.js CLI under Bazel.
@@ -56,7 +56,7 @@ To get multiple output formats, wrap the rule with a macro or list comprehension
 This will produce one output per requested format.
 """
 
-_ROLLUP_ATTRS = {
+_ROLLUP_ATTRS = dict(NODE_CONTEXT_ATTRS, **{
     "args": attr.string_list(
         doc = """Command line arguments to pass to rollup. Can be used to override config file settings.
 
@@ -153,11 +153,6 @@ Either this attribute or `entry_point` must be specified, but not both.
         values = ["amd", "cjs", "esm", "iife", "umd", "system"],
         default = "esm",
     ),
-    "node_context_data": attr.label(
-        default = "@build_bazel_rules_nodejs//internal:node_context_data",
-        providers = [NodeContextInfo],
-        doc = "Internal use only",
-    ),
     "output_dir": attr.bool(
         doc = """Whether to produce a directory output.
 
@@ -217,7 +212,7 @@ When enabled, this rule invokes the "rollup_worker_bin"
 worker aware binary rather than "rollup_bin".""",
         default = False,
     ),
-}
+})
 
 def _desugar_entry_point_names(name, entry_point, entry_points):
     """Users can specify entry_point (sugar) or entry_points (long form).

--- a/providers.bzl
+++ b/providers.bzl
@@ -66,5 +66,19 @@ NodeContextInfo = provider(
     },
 )
 
+NODE_CONTEXT_ATTRS = {
+    "node_context_data": attr.label(
+        default = "@build_bazel_rules_nodejs//internal:node_context_data",
+        providers = [NodeContextInfo],
+        doc = """Provides info about the build context, such as stamping.
+        
+        By default it reads from the bazel command line, such as the `--stamp` argument.
+        Use this to override values for this target, such as enabling or disabling stamping.
+        You can use the `node_context_data` rule in `@build_bazel_rules_nodejs//internal/node:context.bzl`
+        to create a NodeContextInfo.
+        """,
+    ),
+}
+
 NodeRuntimeDepsInfo = _NodeRuntimeDepsInfo
 run_node = _run_node


### PR DESCRIPTION
It can be useful if you need to turn on/off stamping per-target.
`java_binary` gives a dedicated stamp attribute for this purpose

Fixes #1693
