### PR TITLE
fix(builtin): don't set --preserve-symlinks-main by default

### DIFF
--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -19,7 +19,6 @@ See https://docs.bazel.build/versions/master/skylark/repository_rules.html
 """
 
 load("//internal/common:check_bazel_version.bzl", "check_bazel_version")
-load("//internal/common:check_version.bzl", "check_version")
 load("//internal/common:os_name.bzl", "OS_ARCH_NAMES", "os_name")
 load("//internal/node:node_versions.bzl", "NODE_VERSIONS")
 load("//third_party/github.com/bazelbuild/bazel-skylib:lib/paths.bzl", "paths")
@@ -189,9 +188,7 @@ a stronger guarantee of hermeticity which is required for remote execution.""",
         allow_single_file = True,
         doc = """the local path to a pre-installed NodeJS runtime.
 
-If set then also set node_version to the version that of node that is vendored.
-Bazel will automatically turn on features such as --preserve-symlinks-main if they
-are supported by the node version being used.""",
+If set then also set node_version to the version that of node that is vendored.""",
     ),
     "vendored_yarn": attr.label(
         allow_single_file = True,
@@ -413,13 +410,7 @@ def _prepare_node(repository_ctx):
     yarn_script_relative = yarn_script if repository_ctx.attr.vendored_yarn else paths.relativize(yarn_script, "bin")
 
     if repository_ctx.attr.preserve_symlinks:
-        # --preserve-symlinks-main flag added in node 10.2.0
-        # See https://nodejs.org/api/cli.html#cli_preserve_symlinks_main
-        preserve_symlinks_main_support = check_version(repository_ctx.attr.node_version, "10.2.0")
-        if preserve_symlinks_main_support:
-            node_args = "--preserve-symlinks --preserve-symlinks-main"
-        else:
-            node_args = "--preserve-symlinks"
+        node_args = "--preserve-symlinks"
     else:
         node_args = ""
 


### PR DESCRIPTION
This option should not be on by default as it creates issues when running programs out of `node_modules/.bin` which are all symlinks and for these programs to work it is convention that node be able to resolve their symlinks to their actual `node_module` location.

Also, with our node patches, node will not be able to resolve a main symlink out of the sandbox anymore which was the original reason that `--preserve-symlinks-main` was set.

If users want to use this option they can still pass it to their program with `--node_options=--preserve-symlinks-main`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No (since we have node patches enabled now)


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

