### PR TITLE
Fixes a visibility issue with rollup-worker

### DIFF
--- a/packages/rollup/bin/BUILD.bazel
+++ b/packages/rollup/bin/BUILD.bazel
@@ -17,5 +17,5 @@ nodejs_binary(
         "@npm//rollup",
     ],
     entry_point = "//packages/rollup:index.js",
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ x] Bugfix

## What is the current behavior?

When using rules_nodejs from source, I get visibility errors:

```
WARNING: /home/doug/Development/rules_typescript_proto/test/BUILD.bazel:103:14: in rollup_bundle rule //test:test_es6_bundling: Target '//test:test_es6_bundling' violates visibility of target '@build_bazel_rules_nodejs//packages/rollup/bin:rollup-worker'. Continuing because --nocheck_visibility is active
WARNING: /home/doug/Development/rules_typescript_proto/test/BUILD.bazel:103:14: in @build_bazel_rules_nodejs//internal/providers:npm_package_info.bzl%node_modules_aspect aspect on rollup_bundle rule //test:test_es6_bundling: Target '//test:test_es6_bundling' violates visibility of target '@build_bazel_rules_nodejs//packages/rollup/bin:rollup-worker'. Continuing because --nocheck_visibility is active
WARNING: /home/doug/Development/rules_typescript_proto/test/BUILD.bazel:103:14: in @build_bazel_rules_nodejs//internal/common:module_mappings.bzl%module_mappings_runtime_aspect aspect on rollup_bundle rule //test:test_es6_bundling: Target '//test:test_es6_bundling' violates visibility of target '@build_bazel_rules_nodejs//packages/rollup/bin:rollup-worker'. Continuing because --nocheck_visibility is active
WARNING: /home/doug/Development/rules_typescript_proto/test/BUILD.bazel:103:14: in @build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl%module_mappings_aspect aspect on rollup_bundle rule //test:test_es6_bundling: Target '//test:test_es6_bundling' violates visibility of target '@build_bazel_rules_nodejs//packages/rollup/bin:rollup-worker'. Continuing because --nocheck_visibility is active
```

## What is the new behavior?

This PR makes this target public, which should fix it.

## Does this PR introduce a breaking change?

- [x ] No

