### PR TITLE
fix: don't glob yarn or node files when using vendored_node or vendored_yarn

### DIFF
--- a/examples/vendored_node_and_yarn/.bazelrc
+++ b/examples/vendored_node_and_yarn/.bazelrc
@@ -1,1 +1,5 @@
 import %workspace%/../../common.bazelrc
+
+# ensure that the globs that are used in node_repositories are removed when
+# using vendored node or yarn
+build --incompatible_disallow_empty_glob

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -630,17 +630,19 @@ filegroup(
 )
 filegroup(
   name = "yarn_files",
-  srcs = glob(["bin/yarnpkg/**"]) + [":node_files"],
+  srcs = {yarn_files_glob}[":node_files"],
 )
 filegroup(
   name = "npm_files",
-  srcs = glob(["bin/nodejs/**"]) + [":node_files"],
+  srcs = {npm_files_glob}[":node_files"],
 )
 """.format(
         node_bin_export = "" if repository_ctx.attr.vendored_node else ("\n  \"%s\"," % node_bin),
         npm_bin_export = "" if repository_ctx.attr.vendored_node else ("\n  \"%s\"," % npm_bin),
         npx_bin_export = "" if repository_ctx.attr.vendored_node else ("\n  \"%s\"," % npx_bin),
+        npm_files_glob = "" if repository_ctx.attr.vendored_node else "glob([\"bin/nodejs/**\"]) + ",
         yarn_bin_export = "" if repository_ctx.attr.vendored_yarn else ("\n  \"%s\"," % yarn_bin),
+        yarn_files_glob = "" if repository_ctx.attr.vendored_yarn else "glob([\"bin/yarnpkg/**\"]) + ",
         node_bin_label = node_bin_label,
         npm_bin_label = npm_bin_label,
         npx_bin_label = npx_bin_label,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #2185


## What is the new behavior?
When using vendored_node or vendored_yarn, don't add globs to the generated node_repositories `BUILD.bazel` files, allowing users to set `--incompatible_disallow_empty_glob`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No