### PR TITLE
fix(builtin): js_library: correctly propagate DeclarationInfos

### DIFF
--- a/internal/js_library/js_library.bzl
+++ b/internal/js_library/js_library.bzl
@@ -214,7 +214,7 @@ def _impl(ctx):
 
     # Don't provide DeclarationInfo if there are no typings to provide.
     # Improves error messaging downstream if DeclarationInfo is required.
-    if len(typings):
+    if len(typings) or len(typings_depsets) > 1:
         providers.append(declaration_info(
             declarations = depset(transitive = typings_depsets),
             deps = ctx.attr.deps,

--- a/internal/js_library/test/transitive/BUILD.bazel
+++ b/internal/js_library/test/transitive/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//:index.bzl", "js_library")
+load(":transitive_declarations_test.bzl", "transitive_declarations_test_suite")
+
+js_library(
+    name = "a",
+    srcs = ["a.d.ts"],
+)
+
+js_library(
+    name = "b",
+    deps = ["a"],
+)
+
+transitive_declarations_test_suite()

--- a/internal/js_library/test/transitive/a.d.ts
+++ b/internal/js_library/test/transitive/a.d.ts
@@ -1,0 +1,1 @@
+export declare const a: string;

--- a/internal/js_library/test/transitive/transitive_declarations_test.bzl
+++ b/internal/js_library/test/transitive/transitive_declarations_test.bzl
@@ -1,0 +1,20 @@
+"Unit tests for js_library rule"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//:providers.bzl", "DeclarationInfo")
+
+def _impl(ctx):
+    env = unittest.begin(ctx)
+    decls = []
+    for decl in ctx.attr.lib[DeclarationInfo].declarations.to_list():
+        decls.append(decl.basename)
+    asserts.equals(env, ctx.attr.declarations, decls)
+    return unittest.end(env)
+
+transitive_declarations_test = unittest.make(_impl, attrs = {
+    "declarations": attr.string_list(default = ["a.d.ts"]),
+    "lib": attr.label(default = ":b"),
+})
+
+def transitive_declarations_test_suite():
+    unittest.suite("transitive_declarations_tests", transitive_declarations_test)


### PR DESCRIPTION
Transitive typings are added to typings_depsets, but we were checking
the typings array instead.

Signed-off-by: Duarte Nunes <duarte@hey.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, a `ts_project` cannot depend on a `js_library` with transitive declaration files (such as when the `js_library` depends on another `ts_project`. This PR fixes this.

Issue Number: N/A


## What is the new behavior?

Now the `js_library` propagates declarations downstream.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

