### PR TITLE
docs: escape HTML entities

### DIFF
--- a/docs/Built-ins.html
+++ b/docs/Built-ins.html
@@ -767,7 +767,7 @@ Some test runners like Karma and Jasmine have custom rules with added features, 
 <p>Bazel always runs tests with a working directory set to your workspace root.
 If your test needs to run in a different directory, you can write a <code>process.chdir</code> helper script
 and invoke it before the test with a <code>--require</code> argument, like
-<code>templated_args = ["--node_options=--require=./$(rootpath chdir.js)"]</code>.
+<code>templated_args = [&quot;--node_options=--require=./$(rootpath chdir.js)&quot;]</code>.
 See rules_nodejs/internal/node/test/chdir for an example.</p>
 
 <p>To debug a Node.js test, we recommend saving a group of flags together in a “config”.
@@ -1453,8 +1453,8 @@ pkg_npm(<a href="#pkg_npm-name">name</a>, <a href="#pkg_npm-deps">deps</a>, <a h
         <td>
                             DEPRECATED: use substitutions instead.
         
-        <code>replace_with_version = "my_version_placeholder"</code> is just syntax sugar for
-        <code>substitutions = {"my_version_placeholder": "{BUILD_SCM_VERSION}"}</code>.
+        <code>replace_with_version = &quot;my_version_placeholder&quot;</code> is just syntax sugar for
+        <code>substitutions = {&quot;my_version_placeholder&quot;: &quot;{BUILD_SCM_VERSION}&quot;}</code>.
 
         Follow this deprecation at https://github.com/bazelbuild/rules_nodejs/issues/2158
                                 </td>
@@ -1481,7 +1481,7 @@ pkg_npm(<a href="#pkg_npm-name">name</a>, <a href="#pkg_npm-deps">deps</a>, <a h
                             Key-value pairs which are replaced in all the files while building the package.
         
         You can use values from the workspace status command using curly braces, for example
-        <code>{"0.0.0-PLACEHOLDER": "{STABLE_GIT_VERSION}"}</code>.
+        <code>{&quot;0.0.0-PLACEHOLDER&quot;: &quot;{STABLE_GIT_VERSION}&quot;}</code>.
         See the section on stamping in the README
                                 </td>
         <td><a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -&gt; String</a></td>
@@ -1582,7 +1582,7 @@ pkg_web(<a href="#pkg_web-name">name</a>, <a href="#pkg_web-additional_root_path
                             Key-value pairs which are replaced in all the files while building the package.
         
         You can use values from the workspace status command using curly braces, for example
-        <code>{"0.0.0-PLACEHOLDER": "{STABLE_GIT_VERSION}"}</code>.
+        <code>{&quot;0.0.0-PLACEHOLDER&quot;: &quot;{STABLE_GIT_VERSION}&quot;}</code>.
         See the section on stamping in the README.
                                 </td>
         <td><a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -&gt; String</a></td>
@@ -1881,7 +1881,7 @@ check_bazel_version(<a href="#check_bazel_version-minimum_bazel_version">minimum
 
 <p>Copies a source file to bazel-bin at the same workspace-relative path.</p>
 
-<p>e.g. <code><workspace_root>/foo/bar/a.txt -&gt; <bazel-bin>/foo/bar/a.txt&lt;/code&gt;</bazel-bin></workspace_root></code></p>
+<p>e.g. <code>&lt;workspace_root&gt;/foo/bar/a.txt -&gt; &lt;bazel-bin&gt;/foo/bar/a.txt</code></p>
 
 <p>This is useful to populate the output folder with all files needed at runtime, even
 those which aren’t outputs of a Bazel rule.</p>
@@ -2152,7 +2152,7 @@ links the node_modules tree before running the program.</p>
 <p>Bazel always runs actions with a working directory set to your workspace root.
 If your tool needs to run in a different directory, you can write a <code>process.chdir</code> helper script
 and invoke it before the action with a <code>--require</code> argument, like
-<code>args = ["--node_options=--require=./$(execpath chdir.js)"]</code>
+<code>args = [&quot;--node_options=--require=./$(execpath chdir.js)&quot;]</code>
 See rules_nodejs/internal/node/test/chdir for an example.</p>
 
 <p>This is a great candidate to wrap with a macro, as documented:
@@ -2591,13 +2591,13 @@ In the future, the linker may validate that the names match the name in a packag
 
 Path must be relative to execroot/wksp. It can either an output dir path such as,
 
-<code>bazel-out/&lt;platform&gt;-&lt;build&gt;/bin/path/to/package</code> or
-<code>bazel-out/&lt;platform&gt;-&lt;build&gt;/bin/external/&llt;external_wksp&gt;/path/to/package</code>
+<code>bazel-out/&amp;lt;platform&amp;gt;-&amp;lt;build&amp;gt;/bin/path/to/package</code> or
+<code>bazel-out/&amp;lt;platform&amp;gt;-&amp;lt;build&amp;gt;/bin/external/&amp;llt;external_wksp&amp;gt;/path/to/package</code>
 
 or a source file path such as,
 
 <code>path/to/package</code> or
-<code>external/&lt;external_wksp&gt;/path/to/package</code>         </td>
+<code>external/&amp;lt;external_wksp&amp;gt;/path/to/package</code>         </td>
       </tr>
             <tr id="LinkablePackageInfo-_tslibrary">
         <td>_tslibrary</td>

--- a/docs/Built-ins.md
+++ b/docs/Built-ins.md
@@ -635,7 +635,7 @@ Some test runners like Karma and Jasmine have custom rules with added features, 
 Bazel always runs tests with a working directory set to your workspace root.
 If your test needs to run in a different directory, you can write a <code>process.chdir</code> helper script
 and invoke it before the test with a <code>--require</code> argument, like
-<code>templated_args = ["--node_options=--require=./$(rootpath chdir.js)"]</code>.
+<code>templated_args = [&quot;--node_options=--require=./$(rootpath chdir.js)&quot;]</code>.
 See rules_nodejs/internal/node/test/chdir for an example.
 
 To debug a Node.js test, we recommend saving a group of flags together in a "config".
@@ -1338,8 +1338,8 @@ pkg_npm(<a href="#pkg_npm-name">name</a>, <a href="#pkg_npm-deps">deps</a>, <a h
         <td>
                             DEPRECATED: use substitutions instead.
         
-        <code>replace_with_version = "my_version_placeholder"</code> is just syntax sugar for
-        <code>substitutions = {"my_version_placeholder": "{BUILD_SCM_VERSION}"}</code>.
+        <code>replace_with_version = &quot;my_version_placeholder&quot;</code> is just syntax sugar for
+        <code>substitutions = {&quot;my_version_placeholder&quot;: &quot;{BUILD_SCM_VERSION}&quot;}</code>.
 
         Follow this deprecation at https://github.com/bazelbuild/rules_nodejs/issues/2158
                                 </td>
@@ -1366,7 +1366,7 @@ pkg_npm(<a href="#pkg_npm-name">name</a>, <a href="#pkg_npm-deps">deps</a>, <a h
                             Key-value pairs which are replaced in all the files while building the package.
         
         You can use values from the workspace status command using curly braces, for example
-        <code>{"0.0.0-PLACEHOLDER": "{STABLE_GIT_VERSION}"}</code>.
+        <code>{&quot;0.0.0-PLACEHOLDER&quot;: &quot;{STABLE_GIT_VERSION}&quot;}</code>.
         See the section on stamping in the README
                                 </td>
         <td><a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a></td>
@@ -1469,7 +1469,7 @@ pkg_web(<a href="#pkg_web-name">name</a>, <a href="#pkg_web-additional_root_path
                             Key-value pairs which are replaced in all the files while building the package.
         
         You can use values from the workspace status command using curly braces, for example
-        <code>{"0.0.0-PLACEHOLDER": "{STABLE_GIT_VERSION}"}</code>.
+        <code>{&quot;0.0.0-PLACEHOLDER&quot;: &quot;{STABLE_GIT_VERSION}&quot;}</code>.
         See the section on stamping in the README.
                                 </td>
         <td><a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a></td>
@@ -1774,7 +1774,7 @@ check_bazel_version(<a href="#check_bazel_version-minimum_bazel_version">minimum
 
 Copies a source file to bazel-bin at the same workspace-relative path.
 
-e.g. <code><workspace_root>/foo/bar/a.txt -> <bazel-bin>/foo/bar/a.txt</code>
+e.g. <code>&lt;workspace_root&gt;/foo/bar/a.txt -&gt; &lt;bazel-bin&gt;/foo/bar/a.txt</code>
 
 This is useful to populate the output folder with all files needed at runtime, even
 those which aren't outputs of a Bazel rule.
@@ -2052,7 +2052,7 @@ links the node_modules tree before running the program.
 Bazel always runs actions with a working directory set to your workspace root.
 If your tool needs to run in a different directory, you can write a <code>process.chdir</code> helper script
 and invoke it before the action with a <code>--require</code> argument, like
-<code>args = ["--node_options=--require=./$(execpath chdir.js)"]</code>
+<code>args = [&quot;--node_options=--require=./$(execpath chdir.js)&quot;]</code>
 See rules_nodejs/internal/node/test/chdir for an example.
 
 This is a great candidate to wrap with a macro, as documented:
@@ -2508,13 +2508,13 @@ In the future, the linker may validate that the names match the name in a packag
 
 Path must be relative to execroot/wksp. It can either an output dir path such as,
 
-<code>bazel-out/&lt;platform&gt;-&lt;build&gt;/bin/path/to/package</code> or
-<code>bazel-out/&lt;platform&gt;-&lt;build&gt;/bin/external/&llt;external_wksp&gt;/path/to/package</code>
+<code>bazel-out/&amp;lt;platform&amp;gt;-&amp;lt;build&amp;gt;/bin/path/to/package</code> or
+<code>bazel-out/&amp;lt;platform&amp;gt;-&amp;lt;build&amp;gt;/bin/external/&amp;llt;external_wksp&amp;gt;/path/to/package</code>
 
 or a source file path such as,
 
 <code>path/to/package</code> or
-<code>external/&lt;external_wksp&gt;/path/to/package</code>         </td>
+<code>external/&amp;lt;external_wksp&amp;gt;/path/to/package</code>         </td>
       </tr>
             <tr id="LinkablePackageInfo-_tslibrary">
         <td>_tslibrary</td>

--- a/docs/Karma.html
+++ b/docs/Karma.html
@@ -235,7 +235,7 @@ Other <code>browsers</code> and <code>customLaunchers</code> may be set using th
 specified in the <code>config_file</code> attribute.</p>
 
 <p>By default we open a headless Chrome. To use a real Chrome browser window, you can pass
-<code>--define DISPLAY=true</code> to Bazel, along with <code>configuration_env_vars = ["DISPLAY"]</code> on
+<code>--define DISPLAY=true</code> to Bazel, along with <code>configuration_env_vars = [&quot;DISPLAY&quot;]</code> on
 <code>karma_web_test</code>.</p>
 
 <pre>
@@ -320,7 +320,7 @@ karma_web_test(<a href="#karma_web_test-srcs">srcs</a>, <a href="#karma_web_test
         <td>
                             Arbitrary files which are available to be served on request.
     Files are served at:
-    <code>/base/&lt;WORKSPACE_NAME&gt;/&lt;path-to-file&gt;</code>, e.g.
+    <code>/base/&amp;lt;WORKSPACE_NAME&amp;gt;/&amp;lt;path-to-file&amp;gt;</code>, e.g.
     <code>/base/npm_bazel_typescript/examples/testing/static_script.js</code>
                     </td>
         <td>

--- a/docs/Karma.md
+++ b/docs/Karma.md
@@ -87,7 +87,7 @@ Other <code>browsers</code> and <code>customLaunchers</code> may be set using th
 specified in the <code>config_file</code> attribute.
 
 By default we open a headless Chrome. To use a real Chrome browser window, you can pass
-<code>--define DISPLAY=true</code> to Bazel, along with <code>configuration_env_vars = ["DISPLAY"]</code> on
+<code>--define DISPLAY=true</code> to Bazel, along with <code>configuration_env_vars = [&quot;DISPLAY&quot;]</code> on
 <code>karma_web_test</code>.
 
 
@@ -173,7 +173,7 @@ karma_web_test(<a href="#karma_web_test-srcs">srcs</a>, <a href="#karma_web_test
         <td>
                             Arbitrary files which are available to be served on request.
     Files are served at:
-    <code>/base/&lt;WORKSPACE_NAME&gt;/&lt;path-to-file&gt;</code>, e.g.
+    <code>/base/&amp;lt;WORKSPACE_NAME&amp;gt;/&amp;lt;path-to-file&amp;gt;</code>, e.g.
     <code>/base/npm_bazel_typescript/examples/testing/static_script.js</code>
                     </td>
         <td>

--- a/docs/Labs.html
+++ b/docs/Labs.html
@@ -212,7 +212,7 @@ a <code>ts_library</code> can appear, such as in the <code>deps[]</code> of anot
 
 <p>Note in this example we named the <code>ts_proto_library</code> rule <code>car</code> so that the
 result will be <code>car.d.ts</code>. This means our TypeScript code can just
-<code>import {symbols} from './car'</code>. Use the <code>output_name</code> attribute if you want to
+<code>import {symbols} from &#039;./car&#039;</code>. Use the <code>output_name</code> attribute if you want to
 name the rule differently from the output file.</p>
 
 <p>The JavaScript produced by protobuf.js has a runtime dependency on a support library.

--- a/docs/Labs.md
+++ b/docs/Labs.md
@@ -55,7 +55,7 @@ ts_library(
 
 Note in this example we named the <code>ts_proto_library</code> rule <code>car</code> so that the
 result will be <code>car.d.ts</code>. This means our TypeScript code can just
-<code>import {symbols} from './car'</code>. Use the <code>output_name</code> attribute if you want to
+<code>import {symbols} from &#039;./car&#039;</code>. Use the <code>output_name</code> attribute if you want to
 name the rule differently from the output file.
 
 The JavaScript produced by protobuf.js has a runtime dependency on a support library.

--- a/docs/Rollup.html
+++ b/docs/Rollup.html
@@ -445,8 +445,8 @@ Either this attribute or <code>entry_point</code> must be specified, but not bot
 
 - <code>amd</code>: Asynchronous Module Definition, used with module loaders like RequireJS
 - <code>cjs</code>: CommonJS, suitable for Node and other bundlers
-- <code>esm</code>: Keep the bundle as an ES module file, suitable for other bundlers and inclusion as a <code><script type="module"></code> tag in modern browsers
-- <code>iife</code>: A self-executing function, suitable for inclusion as a <code><script></code> tag. (If you want to create a bundle for your application, you probably want to use this.)
+- <code>esm</code>: Keep the bundle as an ES module file, suitable for other bundlers and inclusion as a <code>&lt;script type=module&gt;</code> tag in modern browsers
+- <code>iife</code>: A self-executing function, suitable for inclusion as a <code>&lt;script&gt;</code> tag. (If you want to create a bundle for your application, you probably want to use this.)
 - <code>umd</code>: Universal Module Definition, works as amd, cjs and iife all in one
 - <code>system</code>: Native format of the SystemJS loader
                                 </td>
@@ -583,8 +583,6 @@ worker aware binary rather than "rollup_bin".
         </tbody>
 </table>
 
-
-</script></code></td></tr></tbody></table>
 
       </div>
     </div>

--- a/docs/Rollup.md
+++ b/docs/Rollup.md
@@ -302,8 +302,8 @@ Either this attribute or <code>entry_point</code> must be specified, but not bot
 
 - <code>amd</code>: Asynchronous Module Definition, used with module loaders like RequireJS
 - <code>cjs</code>: CommonJS, suitable for Node and other bundlers
-- <code>esm</code>: Keep the bundle as an ES module file, suitable for other bundlers and inclusion as a <code><script type=module></code> tag in modern browsers
-- <code>iife</code>: A self-executing function, suitable for inclusion as a <code><script></code> tag. (If you want to create a bundle for your application, you probably want to use this.)
+- <code>esm</code>: Keep the bundle as an ES module file, suitable for other bundlers and inclusion as a <code>&lt;script type=module&gt;</code> tag in modern browsers
+- <code>iife</code>: A self-executing function, suitable for inclusion as a <code>&lt;script&gt;</code> tag. (If you want to create a bundle for your application, you probably want to use this.)
 - <code>umd</code>: Universal Module Definition, works as amd, cjs and iife all in one
 - <code>system</code>: Native format of the SystemJS loader
                                 </td>

--- a/docs/Terser.html
+++ b/docs/Terser.html
@@ -264,7 +264,7 @@ Bazel will make a copy of your config file, treating it as a template.
 
 Run bazel with <code>--subcommands</code> to see the path to the copied file.
 
-If you use the magic strings <code>"bazel_debug"</code> or <code>"bazel_no_debug"</code>, these will be
+If you use the magic strings <code>&quot;bazel_debug&quot;</code> or <code>&quot;bazel_no_debug&quot;</code>, these will be
 replaced with <code>true</code> and <code>false</code> respecting the value of the <code>debug</code> attribute
 or the <code>--compilation_mode=dbg</code> bazel flag.
 

--- a/docs/Terser.md
+++ b/docs/Terser.md
@@ -114,7 +114,7 @@ Bazel will make a copy of your config file, treating it as a template.
 
 Run bazel with <code>--subcommands</code> to see the path to the copied file.
 
-If you use the magic strings <code>"bazel_debug"</code> or <code>"bazel_no_debug"</code>, these will be
+If you use the magic strings <code>&quot;bazel_debug&quot;</code> or <code>&quot;bazel_no_debug&quot;</code>, these will be
 replaced with <code>true</code> and <code>false</code> respecting the value of the <code>debug</code> attribute
 or the <code>--compilation_mode=dbg</code> bazel flag.
 

--- a/docs/TypeScript.html
+++ b/docs/TypeScript.html
@@ -185,7 +185,7 @@ Any behavior of <code>ts_project</code> should be reproducible outside of Bazel,
 
 <blockquote>
   <p>We used to recommend using the <code>tsc</code> rule directly from the <code>typescript</code> project, like
-<code>load("@npm//typescript:index.bzl", "tsc")</code>
+<code>load(&quot;@npm//typescript:index.bzl&quot;, &quot;tsc&quot;)</code>
 However <code>ts_project</code> is strictly better and should be used instead.</p>
 </blockquote>
 
@@ -591,7 +591,7 @@ ts_devserver(<a href="#ts_devserver-name">name</a>, <a href="#ts_devserver-addit
         <td>additional_root_paths</td>
         <td>
                             Additional root paths to serve <code>static_files</code> from.
-            Paths should include the workspace name such as <code>["__main__/resources"]</code>
+            Paths should include the workspace name such as <code>[&quot;__main__/resources&quot;]</code>
                                 </td>
         <td>List of strings</td>
         <td>optional</td>
@@ -649,15 +649,15 @@ ts_devserver(<a href="#ts_devserver-name">name</a>, <a href="#ts_devserver-addit
         <td><a href="https://bazel.build/docs/build-ref.html#labels">Label</a></td>
         <td>optional</td>
         <td>
-            @npm//@bazel/devserver:devserver_darwin_amd64
+            @npm//@bazel/devserver:devserver_linux_amd64
         </td>
       </tr>
             <tr id="ts_devserver-entry_module">
         <td>entry_module</td>
         <td>
-                            The <code>entry_module</code> should be the AMD module name of the entry module such as <code>"__main__/src/index".</code>
+                            The <code>entry_module</code> should be the AMD module name of the entry module such as <code>&quot;__main__/src/index&quot;.</code>
             <code>ts_devserver</code> concats the following snippet after the bundle to load the application:
-            <code>require(["entry_module"]);</code>
+            <code>require([&quot;entry_module&quot;]);</code>
                                 </td>
         <td>String</td>
         <td>optional</td>
@@ -1045,7 +1045,7 @@ either:
 
 - Have your <code>tsconfig.json</code> file in the workspace root directory
 - Use an alias in the root BUILD.bazel file to point to the location of tsconfig:
-    <code>alias(name="tsconfig.json", actual="//path/to:tsconfig-something.json")</code>
+    <code>alias(name=&quot;tsconfig.json&quot;, actual=&quot;//path/to:tsconfig-something.json&quot;)</code>
 - Give an explicit <code>tsconfig</code> attribute to all <code>ts_library</code> targets
                                 </td>
         <td><a href="https://bazel.build/docs/build-ref.html#labels">Label</a></td>
@@ -1163,7 +1163,7 @@ observe these problems which require workarounds:</p>
    indicate where the outputs were written. However the <code>outDir</code> is determined by this Bazel rule so
    it cannot be known from reading the <code>tsconfig.json</code> file.
    This problem is manifested as a TypeScript diagnostic like
-   <code>error TS6305: Output file '/path/to/execroot/a.d.ts' has not been built from source file '/path/to/execroot/a.ts'.</code>
+   <code>error TS6305: Output file &#039;/path/to/execroot/a.d.ts&#039; has not been built from source file &#039;/path/to/execroot/a.ts&#039;.</code>
    As a workaround, you can give the Windows “fastbuild” output directory as the <code>outDir</code> in your tsconfig file.
    On other platforms, the value isn’t read so it does no harm.
    See https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/ts_project as an example.
@@ -1224,8 +1224,8 @@ ts_project(<a href="#ts_project-name">name</a>, <a href="#ts_project-tsconfig">t
 
     In this case, a tsconfig.json file will be generated for this compilation, in the following way:
     - all top-level keys will be copied by converting the dict to json.
-      So <code>tsconfig = {"compilerOptions": {"declaration": True}}</code>
-      will result in a generated <code>tsconfig.json</code> with <code>{"compilerOptions": {"declaration": true}}</code>
+      So <code>tsconfig = {&quot;compilerOptions&quot;: {&quot;declaration&quot;: True}}</code>
+      will result in a generated <code>tsconfig.json</code> with <code>{&quot;compilerOptions&quot;: {&quot;declaration&quot;: true}}</code>
     - each file in srcs will be converted to a relative path in the <code>files</code> section.
     - the <code>extends</code> attribute will be converted to a relative path
 
@@ -1374,7 +1374,7 @@ ts_project(<a href="#ts_project-name">name</a>, <a href="#ts_project-tsconfig">t
         <td>
                             Label of the TypeScript compiler binary to run.
 
-    For example, <code>tsc = "@my_deps//typescript/bin:tsc"</code>
+    For example, <code>tsc = &quot;@my_deps//typescript/bin:tsc&quot;</code>
     Or you can pass a custom compiler binary instead.
                     </td>
         <td>

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -27,7 +27,7 @@ It is intended as an easy on-boarding for existing TypeScript code and should be
 Any behavior of <code>ts_project</code> should be reproducible outside of Bazel, with a couple of caveats noted in the rule documentation below.
 
 > We used to recommend using the <code>tsc</code> rule directly from the <code>typescript</code> project, like
-> <code>load("@npm//typescript:index.bzl", "tsc")</code>
+> <code>load(&quot;@npm//typescript:index.bzl&quot;, &quot;tsc&quot;)</code>
 > However <code>ts_project</code> is strictly better and should be used instead.
 
 <code>ts_library</code> is an open-sourced version of the rule we use to compile TS code at Google.
@@ -475,7 +475,7 @@ ts_devserver(<a href="#ts_devserver-name">name</a>, <a href="#ts_devserver-addit
         <td>additional_root_paths</td>
         <td>
                             Additional root paths to serve <code>static_files</code> from.
-            Paths should include the workspace name such as <code>["__main__/resources"]</code>
+            Paths should include the workspace name such as <code>[&quot;__main__/resources&quot;]</code>
                                 </td>
         <td>List of strings</td>
         <td>optional</td>
@@ -533,15 +533,15 @@ ts_devserver(<a href="#ts_devserver-name">name</a>, <a href="#ts_devserver-addit
         <td><a href="https://bazel.build/docs/build-ref.html#labels">Label</a></td>
         <td>optional</td>
         <td>
-            @npm//@bazel/devserver:devserver_darwin_amd64
+            @npm//@bazel/devserver:devserver_linux_amd64
         </td>
       </tr>
             <tr id="ts_devserver-entry_module">
         <td>entry_module</td>
         <td>
-                            The <code>entry_module</code> should be the AMD module name of the entry module such as <code>"__main__/src/index".</code>
+                            The <code>entry_module</code> should be the AMD module name of the entry module such as <code>&quot;__main__/src/index&quot;.</code>
             <code>ts_devserver</code> concats the following snippet after the bundle to load the application:
-            <code>require(["entry_module"]);</code>
+            <code>require([&quot;entry_module&quot;]);</code>
                                 </td>
         <td>String</td>
         <td>optional</td>
@@ -932,7 +932,7 @@ either:
 
 - Have your <code>tsconfig.json</code> file in the workspace root directory
 - Use an alias in the root BUILD.bazel file to point to the location of tsconfig:
-    <code>alias(name="tsconfig.json", actual="//path/to:tsconfig-something.json")</code>
+    <code>alias(name=&quot;tsconfig.json&quot;, actual=&quot;//path/to:tsconfig-something.json&quot;)</code>
 - Give an explicit <code>tsconfig</code> attribute to all <code>ts_library</code> targets
                                 </td>
         <td><a href="https://bazel.build/docs/build-ref.html#labels">Label</a></td>
@@ -1050,7 +1050,7 @@ observe these problems which require workarounds:
    indicate where the outputs were written. However the <code>outDir</code> is determined by this Bazel rule so
    it cannot be known from reading the <code>tsconfig.json</code> file.
    This problem is manifested as a TypeScript diagnostic like
-   <code>error TS6305: Output file '/path/to/execroot/a.d.ts' has not been built from source file '/path/to/execroot/a.ts'.</code>
+   <code>error TS6305: Output file &#039;/path/to/execroot/a.d.ts&#039; has not been built from source file &#039;/path/to/execroot/a.ts&#039;.</code>
    As a workaround, you can give the Windows "fastbuild" output directory as the <code>outDir</code> in your tsconfig file.
    On other platforms, the value isn't read so it does no harm.
    See https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/ts_project as an example.
@@ -1112,8 +1112,8 @@ ts_project(<a href="#ts_project-name">name</a>, <a href="#ts_project-tsconfig">t
 
     In this case, a tsconfig.json file will be generated for this compilation, in the following way:
     - all top-level keys will be copied by converting the dict to json.
-      So <code>tsconfig = {"compilerOptions": {"declaration": True}}</code>
-      will result in a generated <code>tsconfig.json</code> with <code>{"compilerOptions": {"declaration": true}}</code>
+      So <code>tsconfig = {&quot;compilerOptions&quot;: {&quot;declaration&quot;: True}}</code>
+      will result in a generated <code>tsconfig.json</code> with <code>{&quot;compilerOptions&quot;: {&quot;declaration&quot;: true}}</code>
     - each file in srcs will be converted to a relative path in the <code>files</code> section.
     - the <code>extends</code> attribute will be converted to a relative path
 
@@ -1260,7 +1260,7 @@ ts_project(<a href="#ts_project-name">name</a>, <a href="#ts_project-tsconfig">t
         <td>
                             Label of the TypeScript compiler binary to run.
 
-    For example, <code>tsc = "@my_deps//typescript/bin:tsc"</code>
+    For example, <code>tsc = &quot;@my_deps//typescript/bin:tsc&quot;</code>
     Or you can pass a custom compiler binary instead.
                     </td>
         <td>

--- a/docs/install.html
+++ b/docs/install.html
@@ -187,8 +187,8 @@ containing:</p>
 <div class="language-python highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="n">load</span><span class="p">(</span><span class="s">"@bazel_tools//tools/build_defs/repo:http.bzl"</span><span class="p">,</span> <span class="s">"http_archive"</span><span class="p">)</span>
 <span class="n">http_archive</span><span class="p">(</span>
     <span class="n">name</span> <span class="o">=</span> <span class="s">"build_bazel_rules_nodejs"</span><span class="p">,</span>
-    <span class="n">sha256</span> <span class="o">=</span> <span class="s">"4952ef879704ab4ad6729a29007e7094aef213ea79e9f2e94cbe1c9a753e63ef"</span><span class="p">,</span>
-    <span class="n">urls</span> <span class="o">=</span> <span class="p">[</span><span class="s">"https://github.com/bazelbuild/rules_nodejs/releases/download/2.2.0/rules_nodejs-2.2.0.tar.gz"</span><span class="p">],</span>
+    <span class="n">sha256</span> <span class="o">=</span> <span class="s">"64a71a64ac58b8969bb19b1c9258a973b6433913e958964da698943fb5521d98"</span><span class="p">,</span>
+    <span class="n">urls</span> <span class="o">=</span> <span class="p">[</span><span class="s">"https://github.com/bazelbuild/rules_nodejs/releases/download/2.2.1/rules_nodejs-2.2.1.tar.gz"</span><span class="p">],</span>
 <span class="p">)</span>
 
 <span class="n">load</span><span class="p">(</span><span class="s">"@build_bazel_rules_nodejs//:index.bzl"</span><span class="p">,</span> <span class="s">"node_repositories"</span><span class="p">)</span>

--- a/tools/stardoc/post-process-docs.js
+++ b/tools/stardoc/post-process-docs.js
@@ -7,7 +7,7 @@ const content = readFileSync(md, {encoding: 'utf8'});
 // so we have to replace a single backtick with a <code></code> block, and a code fence ``` with
 // the Jekyll highlighter syntax
 const out = content
-  .replace(/(?<!`)`([^`]+)`(?!`)/g, `<code>$1</code>`)
+  .replace(/(?<!`)`([^`]+)`(?!`)/g, (_, p1) => `<code>${escapeHtml(p1)}</code>`)
   .replace(/```(\w*?)\n((?:(?!```)[\s\S])+)```/g, (str, lang, block) => {
     // if no lang is defined, assume Python, it's likely right and the param is required
     return `{% highlight ${lang ? lang.trim() : 'python'} %}\n${block}{% endhighlight %}`;
@@ -22,7 +22,7 @@ const out = content
   });
 
 // stamp the frontmatter into the post processed stardoc HTML
-const frontmatter = [  
+const frontmatter = [
   '---',
   `title: ${title}`,
   'layout: default',
@@ -39,3 +39,13 @@ const frontmatter = [
 
 // write out to stdout, this script is run as part of a genrule that redirects the output the to expected file
 process.stdout.write(frontmatter + out);
+
+function escapeHtml(unsafe) {
+  // From https://stackoverflow.com/questions/6234773
+  return unsafe
+       .replace(/&/g, "&amp;")
+       .replace(/</g, "&lt;")
+       .replace(/>/g, "&gt;")
+       .replace(/"/g, "&quot;")
+       .replace(/'/g, "&#039;");
+}


### PR DESCRIPTION
Stardoc extracts the documentation from .bzl files and generate them
as Markdown, but some contents are in HTML table. For such content,
we need to escape HTML entities otherwise they'll be rendered as
HTML node. This not only messes up the actual docs page, but could also
lead to potential security vulnerability.
For example, see the `format` attribute of `rollup_bundle` on
https://bazelbuild.github.io/rules_nodejs/Rollup.html (end of page).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

