### PR TITLE
Fix docs

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -13,6 +13,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.2.0/anchor.min.js" type="text/javascript"></script>
 <script>
   // Automatically add anchors and links to all header elements that don't already have them.
+  anchors.options = { placement: 'left' };
   anchors.add();
 </script>
 

--- a/package.bzl
+++ b/package.bzl
@@ -56,13 +56,11 @@ def rules_nodejs_dev_dependencies():
     _maybe(
         http_archive,
         name = "io_bazel_stardoc",
-        # Workaround for https://github.com/bazelbuild/stardoc/issues/43
-        patches = ["@build_bazel_rules_nodejs//:stardoc.patch"],
-        sha256 = "6d07d18c15abb0f6d393adbd6075cd661a2219faab56a9517741f0fc755f6f3c",
-        strip_prefix = "stardoc-0.4.0",
+        sha256 = "04612d977b98896b5e0d3404b2aecf131d63a89fb5117640bf93f8158a647cdc",
+        strip_prefix = "stardoc-e25bed3afae3ad494ffc15759749ba3b3d979747",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/stardoc/archive/0.4.0.tar.gz",
-            "https://github.com/bazelbuild/stardoc/archive/0.4.0.tar.gz",
+            # TODO: switch back to upstream after bazelbuild/bazel#12286 is merged and available in a stardoc release
+            "https://github.com/alexeagle/stardoc/archive/e25bed3afae3ad494ffc15759749ba3b3d979747.tar.gz",
         ],
     )
 

--- a/tools/stardoc/post-process-docs.js
+++ b/tools/stardoc/post-process-docs.js
@@ -3,19 +3,11 @@ const md = process.argv[2];
 const title = process.argv[3];
 const content = readFileSync(md, {encoding: 'utf8'});
 
-// it seems more natural for devs to author with markdown, but the docs are generated into stardoc with HTML tables,
-// so we have to replace a single backtick with a <code></code> block, and a code fence ``` with
-// the Jekyll highlighter syntax
+// replace the //packages/foo from the docs with references to @npm//@bazel/foo
+// @npm is not the required name, but it seems to be the common case
+// this reflects the similar transformation made when publishing the packages to npm
+// via pkg_npm defined in //tools:defaults.bzl
 const out = content
-  .replace(/(?<!`)`([^`]+)`(?!`)/g, `<code>$1</code>`)
-  .replace(/```(\w*?)\n((?:(?!```)[\s\S])+)```/g, (str, lang, block) => {
-    // if no lang is defined, assume Python, it's likely right and the param is required
-    return `{% highlight ${lang ? lang.trim() : 'python'} %}\n${block}{% endhighlight %}`;
-  })
-  // replace the //packages/foo from the docs with references to @npm//@bazel/foo
-  // @npm is not the required name, but it seems to be the common case
-  // this reflects the similar transformation made when publishing the packages to npm
-  // via pkg_npm defined in //tools:defaults.bzl
   .replace(/(?:@.*)*?\/\/packages\/([^:"\s]*)/g, (str, pkg) => {
     const parts = pkg.split('/');
     return `@npm//@bazel/${parts[parts.length - 1]}`;

--- a/tools/stardoc/templates/aspect.vm
+++ b/tools/stardoc/templates/aspect.vm
@@ -1,5 +1,7 @@
 #[[##]]# ${aspectName}
 
+**USAGE**
+
 <pre>
 ${util.aspectSummary($aspectName, $aspectInfo)}
 </pre>
@@ -9,49 +11,23 @@ $aspectInfo.getDocString()
 **ASPECT ATTRIBUTES**
 
 #if (!$aspectInfo.getAttributeList().isEmpty())
-<table class="table table-params">
-  <thead>
-  <tr>
-    <th>Name</th>
-    <th>Type</th>
-  </tr>
-  </thead>
-  <tbody>
-      #foreach ($aspectAttribute in $aspectInfo.getAspectAttributeList())
-      <tr id="${aspectName}-${aspectAttribute}">
-        <td>${aspectAttribute}</td>
-        <td>String</td>
-      </tr>
-      #end
-  </tbody>
-</table>
+#foreach ($aspectAttribute in $aspectInfo.getAspectAttributeList())
+<h4>${aspectAttribute}</h4>
+#end
 #end
 
 **ATTRIBUTES**
 
 #if (!$aspectInfo.getAttributeList().isEmpty())
-<table class="table table-params">
-  <thead>
-  <tr>
-    <th>Name</th>
-    <th>Description</th>
-    <th>Type</th>
-    <th>Mandatory</th>
-    <th>Default</th>
-  </tr>
-  </thead>
-  <tbody>
-      #foreach ($attribute in $aspectInfo.getAttributeList())
-      <tr>
-        <td>${attribute.name}</td>
-        <td>
-            #if(!$attribute.docString.isEmpty()) $attribute.docString.trim() #else - #end
-        </td>
-        <td>${util.attributeTypeString($attribute)}</td>
-        <td>${util.mandatoryString($attribute)}</td>
-        <td>$attribute.defaultValue</td>
-      </tr>
-      #end
-  </tbody>
-</table>
+#foreach ($attribute in $aspectInfo.getAttributeList())
+<h4 id="${aspectName}-${attribute.name}">${attribute.name}</h4>
+
+(*${util.attributeTypeString($attribute)}, {util.mandatoryString($attribute)}*)
+#if(!$attribute.docString.isEmpty()) $attribute.docString.trim() #else - #end
+
+#if( !$attribute.defaultValue.isEmpty() )
+Defaults to `$attribute.defaultValue`
+#end
+
+#end
 #end

--- a/tools/stardoc/templates/func.vm
+++ b/tools/stardoc/templates/func.vm
@@ -1,36 +1,26 @@
 #[[##]]# ${funcInfo.functionName}
 
-$funcInfo.docString
+**USAGE**
 
 <pre>
 ${util.funcSummary($funcInfo)}
 </pre>
 
+$funcInfo.docString
+
 **PARAMETERS**
 
 #if (!$funcInfo.getParameterList().isEmpty())
-<table class="table table-params">
-  <thead>
-  <tr>
-    <th>Name</th>
-    <th>Description</th>
-    <th>Default</th>
-  </tr>
-  </thead>
-  <tbody>
-      #foreach ($param in $funcInfo.getParameterList())
-      <tr id="${funcInfo.functionName}-${param.name}">
-        <td>${param.name}</td>
-        <td>
-            #if (!$param.docString.isEmpty())
-                ${util.htmlEscape($param.docString.trim())}
-            #end
-        </td>
-        <td>
-            $param.defaultValue
-        </td>
-      </tr>
-      #end
-  </tbody>
-</table>
+#foreach ($param in $funcInfo.getParameterList())
+
+<h4 id="${funcInfo.functionName}-${param.name}">${param.name}</h4>
+
+#if (!$param.docString.isEmpty())
+${util.htmlEscape($param.docString.trim())}
+#end
+
+#if( !$param.defaultValue.isEmpty() )
+Defaults to `$param.defaultValue`#end
+
+#end
 #end

--- a/tools/stardoc/templates/provider.vm
+++ b/tools/stardoc/templates/provider.vm
@@ -1,5 +1,7 @@
 #[[##]]# ${providerName}
 
+**USAGE**
+
 <pre>
 ${util.providerSummary($providerName, $providerInfo)}
 </pre>
@@ -9,22 +11,9 @@ ${providerInfo.docString}
 **FIELDS**
 
 #if (!$providerInfo.fieldInfoList.isEmpty())
-<table class="table table-params">
-  <thead>
-  <tr>
-    <th>Name</th>
-    <th>Description</th>
-  </tr>
-  </thead>
-  <tbody>
-      #foreach ($field in $providerInfo.fieldInfoList)
-      <tr id="${providerName}-${field.name}">
-        <td>${field.name}</td>
-        <td>
-          #if(!$field.docString.isEmpty()) $field.docString.trim() #else - #end
-        </td>
-      </tr>
-      #end
-  </tbody>
-</table>
+#foreach ($field in $providerInfo.fieldInfoList)
+<h4 id="${providerName}-${field.name}">${field.name}</h4>
+
+#if(!$field.docString.isEmpty()) $field.docString.trim() #else - #end
+#end
 #end

--- a/tools/stardoc/templates/rule.vm
+++ b/tools/stardoc/templates/rule.vm
@@ -1,43 +1,27 @@
 #[[##]]# ${ruleName}
 
-$ruleInfo.docString
+**USAGE**
 
 <pre>
 ${util.ruleSummary($ruleName, $ruleInfo)}
 </pre>
 
+$ruleInfo.docString
+
 **ATTRIBUTES**
 
 #if (!$ruleInfo.getAttributeList().isEmpty())
-<table class="table table-params">
-  <thead>
-  <tr>
-    <th>Name</th>
-    <th>Description</th>
-    <th>Type</th>
-    <th>Mandatory</th>
-    <th>Default</th>
-  </tr>
-  </thead>
-  <tbody>
-      #foreach ($attribute in $ruleInfo.getAttributeList())
-      <tr id="${ruleName}-${attribute.name}">
-        <td>${attribute.name}</td>
-        <td>
-            #if (!$attribute.docString.isEmpty())
-                ${attribute.docString.trim()}
-            #end
-            #if (!$attribute.getProviderNameGroupList().isEmpty())
-              The dependencies of this attribute must provide: ${util.attributeProviders($attribute)}
-            #end
-        </td>
-        <td>${util.attributeTypeString($attribute)}</td>
-        <td>${util.mandatoryString($attribute)}</td>
-        <td>
-            $attribute.defaultValue
-        </td>
-      </tr>
-      #end
-  </tbody>
-</table>
+#foreach ($attribute in $ruleInfo.getAttributeList())
+
+<h4 id="${ruleName}-${attribute.name}">${attribute.name}</h4>
+
+(*${util.attributeTypeString($attribute)}#if( $attribute.mandatory ), mandatory#end*)#if (!$attribute.docString.isEmpty()): ${attribute.docString.trim()}#end
+#if (!$attribute.getProviderNameGroupList().isEmpty())
+  The dependencies of this attribute must provide: ${util.attributeProviders($attribute)}
+#end
+
+#if( !$attribute.defaultValue.isEmpty() )
+Defaults to `$attribute.defaultValue`#end
+
+#end
 #end


### PR DESCRIPTION
Alternative to https://github.com/bazelbuild/rules_nodejs/pull/2225

Go back to pure markdown rather than HTML tables which cause endless compat problems.
Can probably throw away our post-process-docs.js too

Preview: https://alexeagle.github.io/rules_nodejs/