### PR TITLE
fix(builtin): give a longer timeout for _create_build_files

### DIFF
--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -131,7 +131,7 @@ def _create_build_files(repository_ctx, rule_type, node, lock_file):
         str(repository_ctx.attr.strict_visibility),
         ",".join(repository_ctx.attr.included_files),
         native.bazel_version,
-    ])
+    ], timeout = 1200)  # double the default timeout in case of many packages, see #2231
     if result.return_code:
         fail("generate_build_file.ts failed: \nSTDOUT:\n%s\nSTDERR:\n%s" % (result.stdout, result.stderr))
 


### PR DESCRIPTION
A user reports that their build file generation takes longer than 600 seconds.
It's probably a bug that we are so slow, but let's address that separately (maybe in our work for npm v7)

Also note we could have made this timeout user-configurable, but I think the extra API surface isn't worth the benefit.

Fixes #2231
