### PR TITLE
chore: allow node versions <= 14.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "repository": "https://github.com/bazelbuild/rules_nodejs",
     "license": "Apache-2.0",
     "engines": {
-        "node": ">=12.0.0 < 13",
+        "node": ">=12.0.0 <= 14.14.0",
         "yarn": ">=1.13.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Bump the allowed NodeJS version restriction in the main `package.json` file