### PR TITLE
fix: npm_package.pack should work in windows os

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -462,7 +462,7 @@ tasks:
     build_flags:
     # TODO(gregmagolan): figure out how to install missing shared libs
     # Without this filter the @cypress external repository will be built and that build will fail due to missing shared libs.
-    - "--build_tag_filters=-cypress"
+    - "--build_tag_filters=-cypress,-pkg_npm.pack"
     test_flags:
     # TODO(gregmagolan): figure out how to install missing shared libs
     - "--test_arg=-cypress"

--- a/index.bzl
+++ b/index.bzl
@@ -32,7 +32,7 @@ load(
 load("//internal/node:node_repositories.bzl", _node_repositories = "node_repositories")
 load("//internal/node:npm_package_bin.bzl", _npm_bin = "npm_package_bin")
 load("//internal/npm_install:npm_install.bzl", _npm_install = "npm_install", _yarn_install = "yarn_install")
-load("//internal/pkg_npm:pkg_npm.bzl", _pkg_npm = "pkg_npm")
+load("//internal/pkg_npm:pkg_npm.bzl", _pkg_npm = "pkg_npm_macro")
 load("//internal/pkg_web:pkg_web.bzl", _pkg_web = "pkg_web")
 
 check_bazel_version = _check_bazel_version

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -527,6 +527,13 @@ if %errorlevel% neq 0 exit /b %errorlevel%
         script = repository_ctx.path(npm_script),
     ))
 
+    repository_ctx.file("run_npm.bat.template", content = """
+"{node}" "{script}" TMPL_args "%*"
+""".format(
+        node = repository_ctx.path(node_entry),
+        script = repository_ctx.path(npm_script),
+    ))
+
     # The entry points for yarn for osx/linux and windows.
     # Runs yarn using appropriate node entry point.
     # Unset YARN_IGNORE_PATH before calling yarn incase it is set so that
@@ -609,6 +616,7 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 package(default_visibility = ["//visibility:public"])
 exports_files([
   "run_npm.sh.template",
+  "run_npm.bat.template",
   "bin/node_repo_args.sh",{node_bin_export}{npm_bin_export}{npx_bin_export}{yarn_bin_export}
   "{node_entry}",
   "{npm_entry}",
@@ -674,6 +682,7 @@ def _nodejs_host_os_alias_impl(repository_ctx):
 package(default_visibility = ["//visibility:public"])
 # aliases for exports_files
 alias(name = "run_npm.sh.template", actual = "{node_repository}//:run_npm.sh.template")
+alias(name = "run_npm.bat.template", actual = "{node_repository}//:run_npm.bat.template")
 alias(name = "bin/node_repo_args.sh", actual = "{node_repository}//:bin/node_repo_args.sh")
 # aliases for other aliases
 alias(name = "node_bin", actual = "{node_repository}//:node_bin")

--- a/internal/pkg_npm/npm_script_generator.js
+++ b/internal/pkg_npm/npm_script_generator.js
@@ -23,15 +23,23 @@
 const fs = require('fs');
 
 function main(args) {
-  const [outDir, packPath, publishPath, runNpmTemplatePath] = args;
-  const npmTemplate = fs.readFileSync(runNpmTemplatePath, {encoding: 'utf-8'});
+  const
+      [outDir, packPath, publishPath, runNpmTemplatePath, packBatPath, publishBatPath,
+       runNpmBatTemplatePath] = args;
   const cwd = process.cwd();
   if (/[\//]sandbox[\//]/.test(cwd)) {
     console.error('Error: npm_script_generator must be run with no sandbox');
     process.exit(1);
   }
+
+  const npmTemplate = fs.readFileSync(runNpmTemplatePath, {encoding: 'utf-8'});
   fs.writeFileSync(packPath, npmTemplate.replace('TMPL_args', `pack "${cwd}/${outDir}"`));
   fs.writeFileSync(publishPath, npmTemplate.replace('TMPL_args', `publish "${cwd}/${outDir}"`));
+
+  const npmBatTemplate = fs.readFileSync(runNpmBatTemplatePath, {encoding: 'utf-8'});
+  fs.writeFileSync(packBatPath, npmBatTemplate.replace('TMPL_args', `pack "${cwd}/${outDir}"`));
+  fs.writeFileSync(
+      publishBatPath, npmBatTemplate.replace('TMPL_args', `publish "${cwd}/${outDir}"`));
 }
 
 if (require.main === module) {

--- a/internal/pkg_npm/test/BUILD.bazel
+++ b/internal/pkg_npm/test/BUILD.bazel
@@ -76,6 +76,32 @@ pkg_npm(
     srcs = [":rollup/bundle/subdirectory"],
 )
 
+genrule(
+    name = "gen_test_pkg_pack",
+    outs = [
+        "test-pkg.tgz",
+    ],
+    cmd = "$(location :test_pkg.pack) && cp test-pkg-1.2.3.tgz $@",
+    tags = ["pkg_npm.pack"],
+    tools = [
+        ":test_pkg.pack",
+    ],
+)
+
+sh_test(
+    name = "test_pkg_pack",
+    srcs = ["diff_pack_dir.sh"],
+    args = [
+        "$(location :gen_test_pkg_pack)",
+        "$(location :test_pkg)",
+    ],
+    data = [
+        ":gen_test_pkg_pack",
+        ":test_pkg",
+    ],
+    tags = ["pkg_npm.pack"],
+)
+
 jasmine_node_test(
     name = "test",
     srcs = ["pkg_npm.spec.js"],

--- a/internal/pkg_npm/test/diff_pack_dir.sh
+++ b/internal/pkg_npm/test/diff_pack_dir.sh
@@ -1,0 +1,25 @@
+archived=$1
+if [ -f "$archived" ]; then
+    echo "RUNFILES are supported in this OS"
+    # run files are supported (not windows os), we can read the
+    # input from arguments directly
+    rm -rf ./pack && mkdir ./pack
+    tar -xvzf $1 -C ./pack
+    diff -r ./pack/package $2
+    if [ $? -ne 0 ]; then
+        echo "The directory was modified";
+        exit 1
+    fi
+else
+    # runfiles are not supported in Windows,
+    # hard coding the test input for now
+    rm -rf ./pack && mkdir ./pack
+    tar -xvzf ../../test-pkg.tgz -C ./pack
+    diff ./pack/package ../../test_pkg
+    if [ $? -ne 0 ]; then
+        echo "The directory was modified";
+        exit 1
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
`npm_package.pack` rule not work in Windows OS since it will generate a `run_npm.sh` which is not work in Windows, so this PR will generate a `bat` file to make it workable.