### PR TITLE
fix: support running with --enable_runfiles on Windows

### DIFF
--- a/internal/common/windows_utils.bzl
+++ b/internal/common/windows_utils.bzl
@@ -35,6 +35,9 @@ if "%RUNFILES_MANIFEST_ONLY%" neq "1" (
   set %~2=%~1
   exit /b 0
 )
+if "%RUN_UNDER_RUNFILES%" equ "1" (
+  set RUNFILES_MANIFEST_FILE=%RUNFILES_DIR%\MANIFEST
+)
 if "%RUNFILES_MANIFEST_FILE%" equ "" (
   set RUNFILES_MANIFEST_FILE=%~f0.runfiles\MANIFEST
 )


### PR DESCRIPTION
I was finding the run and test commands on a 2.2.2 nodejs binary on
Windows gave an error message similar to the one mentioned in the
following post when --enable_runfiles is passed in on the command line:

https://github.com/bazelbuild/rules_nodejs/pull/2178#issuecomment-694146500

Running without runfiles, my nodejs tests worked correctly, but other packages
in my repo require runfiles, and switching the setting forces many things to be
recompiled.

This patch changes the resolution to use the MANIFEST file inside
the runfiles folder when runfiles are enabled, which seems to fix
the issue.

I'm new to the codebase, and only use it in a limited fashion at the moment,
so this change could benefit from a review by someone more familiar with the code.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

