### PR TITLE
feat(typescript): add allow_js support to ts_project

### DIFF
--- a/packages/typescript/internal/ts_project_options_validator.ts
+++ b/packages/typescript/internal/ts_project_options_validator.ts
@@ -64,6 +64,7 @@ function main([tsconfigPath, output, target, attrsStr]: string[]): 0|1 {
     }
   }
 
+  check('allowJs', 'allow_js');
   check('declarationMap', 'declaration_map');
   check('emitDeclarationOnly', 'emit_declaration_only');
   check('sourceMap', 'source_map');
@@ -89,6 +90,7 @@ function main([tsconfigPath, output, target, attrsStr]: string[]): 0|1 {
   require('fs').writeFileSync(
       output, `
 // ${process.argv[1]} checked attributes for ${target}
+// allow_js:              ${attrs.allow_js}
 // composite:             ${attrs.composite}
 // declaration:           ${attrs.declaration}
 // declaration_map:       ${attrs.declaration_map}

--- a/packages/typescript/test/ts_project/allow_js/BUILD.bazel
+++ b/packages/typescript/test/ts_project/allow_js/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
+load("//packages/typescript:index.bzl", "ts_project")
+
+# Ensure that a.js produces outDir/a.js and outDir/a.d.ts
+SRCS = [
+    "a.js",
+]
+
+ts_project(
+    name = "tsconfig",
+    srcs = SRCS,
+    allow_js = True,
+    declaration = True,
+    declaration_map = True,
+    out_dir = "out",
+    source_map = True,
+)
+
+filegroup(
+    name = "types",
+    srcs = [":tsconfig"],
+    output_group = "types",
+)
+
+nodejs_test(
+    name = "test",
+    data = [
+        ":tsconfig",
+        ":types",
+    ],
+    entry_point = "verify.js",
+    templated_args = [
+        "$(locations :types)",
+        "$(locations :tsconfig)",
+    ],
+)

--- a/packages/typescript/test/ts_project/allow_js/a.js
+++ b/packages/typescript/test/ts_project/allow_js/a.js
@@ -1,0 +1,3 @@
+'use strict';
+exports.__esModule = true;
+exports.a = 'a';

--- a/packages/typescript/test/ts_project/allow_js/tsconfig.json
+++ b/packages/typescript/test/ts_project/allow_js/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+      "allowJs": true,
+      "sourceMap": true,
+      "declaration": true,
+      "declarationMap": true,
+      "types": []
+  }
+}

--- a/packages/typescript/test/ts_project/allow_js/verify.js
+++ b/packages/typescript/test/ts_project/allow_js/verify.js
@@ -1,0 +1,6 @@
+const assert = require('assert');
+
+const types_files = process.argv.slice(2, 4);
+const code_files = process.argv.slice(4, 6);
+assert.ok(types_files.some(f => f.endsWith('out/a.d.ts')), 'Missing a.d.ts');
+assert.ok(types_files.some(f => f.endsWith('out/a.d.ts.map')), 'Missing a.d.ts.map');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current behavior for `ts_project` is to ignore `.js` files and not generate `.d.ts` files from them.

Issue Number: N/A


## What is the new behavior?

As of TypeScript 3.7, tsc can now create [`.d.ts` files from `.js` files](https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html).

The new behavior is allow the user to pass `allow_js` to `ts_project` in order to expect `.d.ts` files from `tsc`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

