### PR TITLE
chore(typescript): remove deprecated extends[]

### DIFF
--- a/examples/app/BUILD.bazel
+++ b/examples/app/BUILD.bazel
@@ -66,7 +66,7 @@ ts_project(
     name = "tsconfig-test",
     testonly = 1,
     srcs = ["app.e2e-spec.ts"],
-    extends = ["tsconfig.json"],
+    extends = "tsconfig.json",
     deps = [
         "@npm//@types/jasmine",
         "@npm//@types/node",

--- a/packages/typescript/test/ts_project/a/BUILD.bazel
+++ b/packages/typescript/test/ts_project/a/BUILD.bazel
@@ -1,11 +1,17 @@
-load("//packages/typescript:index.bzl", "ts_project")
+load("//packages/typescript:index.bzl", "ts_config", "ts_project")
+
+ts_config(
+    name = "config",
+    src = "tsconfig.json",
+    deps = [
+        "tsconfig-extended.json",
+        "//packages/typescript/test/ts_project:tsconfig",
+    ],
+)
 
 ts_project(
     composite = True,
-    extends = [
-        ":tsconfig-extended.json",
-        "//packages/typescript/test/ts_project:tsconfig-base.json",
-    ],
+    tsconfig = "config",
     # Intentionally not syncing this option from tsconfig, to test validator suppression
     # source_map = True,
     validate = False,

--- a/packages/typescript/test/ts_project/b/BUILD.bazel
+++ b/packages/typescript/test/ts_project/b/BUILD.bazel
@@ -9,7 +9,7 @@ ts_project(
     # just a test for the pass-through args attribute
     args = ["--emitBOM"],
     composite = True,
-    extends = ["//packages/typescript/test/ts_project:tsconfig-base.json"],
+    extends = "//packages/typescript/test/ts_project:tsconfig-base.json",
     deps = ["//packages/typescript/test/ts_project/a:tsconfig"],
 )
 
@@ -18,7 +18,7 @@ ts_project(
     testonly = True,
     srcs = [":b.spec.ts"],
     composite = True,
-    extends = ["//packages/typescript/test/ts_project:tsconfig-base.json"],
+    extends = "//packages/typescript/test/ts_project:tsconfig-base.json",
     deps = [
         ":tsconfig",
         "@npm//@types/jasmine",

--- a/packages/typescript/test/ts_project/c/BUILD.bazel
+++ b/packages/typescript/test/ts_project/c/BUILD.bazel
@@ -4,7 +4,7 @@ ts_project(
     name = "compile",
     srcs = [":c.ts"],
     composite = True,
-    extends = ["//packages/typescript/test/ts_project:tsconfig-base.json"],
+    extends = "//packages/typescript/test/ts_project:tsconfig-base.json",
     tsconfig = "tsconfig.json",
     deps = ["//packages/typescript/test/ts_project/b:tsconfig"],
 )


### PR DESCRIPTION
BREAKING CHANGES
ts_project extends attribute no longer accepts a list, it should be a single tsconfig.json file or a ts_config label

Fixes #2140
