### PR TITLE
docs: fix a typo of angular-architect example

### DIFF
--- a/examples/angular_bazel_architect/README.md
+++ b/examples/angular_bazel_architect/README.md
@@ -5,5 +5,5 @@ There are a few ways to use Angular with Bazel. See https://bazelbuild.github.io
 This example showcases building and testing a project with the Angular CLI.
 Instead of using the Angular CLI directly we use Architect here, which is the lower level api for the Angular CLI.
 
-This requies one patch, which can be found under ./patches.
+This requires one patch, which can be found under [./patches](./patches).
 This patch adjusts how the architect-cli prints stdio so that when running under Bazel you don't lose your logs.


### PR DESCRIPTION
Fix a typo in the readme of Angular architect example.

