### PR TITLE
fix: npm_package.pack on Windows should not generate undefined.tgz

### DIFF
--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -553,7 +553,7 @@ if %errorlevel% neq 0 exit /b %errorlevel%
     ))
 
     repository_ctx.file("run_npm.bat.template", content = """
-"{node}" "{script}" TMPL_args "%*"
+"{node}" "{script}" TMPL_args %*
 """.format(
         node = repository_ctx.path(node_entry),
         script = repository_ctx.path(npm_script),


### PR DESCRIPTION
In this commit https://github.com/bazelbuild/rules_nodejs/commit/bc36519, `npm_package.pack` supports windows, the `bat` file looks like 

```
"C:/users/jiali/_bazel_jiali/rud5dwj5/external/nodejs_windows_amd64/bin/node.cmd" "C:/users/jiali/_bazel_jiali/rud5dwj5/external/nodejs_windows_amd64/bin/nodejs/node_modules/npm/bin/npm-cli.js" pack "C:\users\jiali\_bazel_jiali\rud5dwj5\execroot\angular/bazel-out/x64_windows-fastbuild/bin/packages/zone.js/npm_package" "%*"
```

And the final "%*" become a `space` and finally the command will run as 
`npm pack package_name ""`
And it will generate an additional `undefined-0.10.0.tgz`, which is not needed at all.

This PR changed the `"%*"` to `%*`