### PR TITLE
fix(builtin): make linker deterministic when resolving from manifest & fix link_workspace_root with no runfiles

### DIFF
--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -9,6 +9,10 @@ import * as path from 'path';
 // Run Bazel with --define=VERBOSE_LOGS=1 to enable this logging
 const VERBOSE_LOGS = !!process.env['VERBOSE_LOGS'];
 
+// NB: on windows thanks to legacy 8-character path segments it might be like
+// c:/b/ojvxx6nx/execroot/build_~1/bazel-~1/x64_wi~1/bin/internal/npm_in~1/test
+const BAZEL_OUT_REGEX = /(\/bazel-out\/|\/bazel-~1\/x64_wi~1\/)/;
+
 function log_verbose(...m: string[]) {
   if (VERBOSE_LOGS) console.error('[link_node_modules.js]', ...m);
 }
@@ -175,9 +179,7 @@ async function resolveRoot(
   // runfiles on rbe, bazel runs the process in a directory such as
   // `/b/f/w/bazel-out/k8-fastbuild/bin/path/to/pkg/some_test.sh.runfiles/my_wksp`. From here we can
   // determine the execroot `b/f/w` by finding the first instance of bazel-out.
-  // NB: on windows thanks to legacy 8-character path segments it might be like
-  // c:/b/ojvxx6nx/execroot/build_~1/bazel-~1/x64_wi~1/bin/internal/npm_in~1/test
-  const match = startCwd.match(/(\/bazel-out\/|\/bazel-~1\/x64_wi~1\/)/);
+  const match = startCwd.match(BAZEL_OUT_REGEX);
   if (!match) {
     // No execroot found. This can happen if we are inside a nodejs_image or a nodejs_binary is
     // run manually.
@@ -278,6 +280,7 @@ export class Runfiles {
   lookupDirectory(dir: string): string|undefined {
     if (!this.manifest) return undefined;
 
+    let result: string|undefined;
     for (const [k, v] of this.manifest) {
       // Account for Bazel --legacy_external_runfiles
       // which pollutes the workspace with 'my_wksp/external/...'
@@ -289,9 +292,15 @@ export class Runfiles {
       // calculate l = length(`/semver/LICENSE`)
       if (k.startsWith(dir)) {
         const l = k.length - dir.length;
-        return v.substring(0, v.length - l);
+        const maybe = v.substring(0, v.length - l);
+        if (maybe.match(BAZEL_OUT_REGEX)) {
+          return maybe;
+        } else {
+          result = maybe;
+        }
       }
     }
+    return result;
   }
 
 
@@ -731,6 +740,15 @@ export async function main(args: string[], runfiles: Runfiles) {
           }
           try {
             target = runfiles.resolve(runfilesPath);
+            // if we're resolving from a manifest then make sure we don't resolve
+            // into the source tree when we are expecting the output tree
+            if (runfiles.manifest && root == 'execroot' && modulePath.startsWith(`${bin}/`)) {
+              if (!target.includes(`/${bin}/`)) {
+                const e = new Error(`could not resolve modulePath ${modulePath}`);
+                (e as any).code = 'MODULE_NOT_FOUND';
+                throw e;
+              }
+            }
           } catch {
             target = '<runfiles resolution failed>';
           }

--- a/internal/linker/test/workspace_link/BUILD.bazel
+++ b/internal/linker/test/workspace_link/BUILD.bazel
@@ -4,7 +4,6 @@ jasmine_node_test(
     name = "test",
     srcs = ["test.js"],
     link_workspace_root = True,
-    tags = ["fix-windows"],
     templated_args = ["--nobazel_patch_module_resolver"],
     deps = [
         "//internal/linker/test/workspace_link/bar",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

When resolving runfiles from MANIFEST, resolution is non-deterministic as it depends on order of entries MANIFEST if source tree or output tree is resolved to (first match is returned).

When linking link_workspace_root with no runfiles (on Windows for example), link may be to the source tree which is incorrect.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Resolving from MANIFEST is now deterministic. Resolution will prefer output tree over source tree if there is a single output tree match in the MANIFEST.

When linking link_workspace_root with no runfiles (on Windows for example), linker no longer links against source tree if there is no output tree resolution available. The solution is a generalized one so all 'execroot' links that point into output tree artifacts must be linked to output tree.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

