### PR TITLE
fix(typescript): don't depend on protobufjs, it's transitive

### DIFF
--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -629,19 +629,17 @@ def ts_project_macro(
 
     if supports_workers:
         tsc_worker = "%s_worker" % name
-        protobufjs = (
-            # BEGIN-INTERNAL
-            "@npm" +
-            # END-INTERNAL
-            "//protobufjs"
-        )
         nodejs_binary(
             name = tsc_worker,
             data = [
+                # BEGIN-INTERNAL
+                # Users get this dependency transitively from @bazel/typescript
+                # but that's our own code, so we don't.
+                "@npm//protobufjs",
+                # END-INTERNAL
                 Label("//packages/typescript/internal/worker:worker"),
                 Label(worker_tsc_bin),
                 Label(worker_typescript_module),
-                Label(protobufjs),
                 tsconfig,
             ],
             entry_point = Label("//packages/typescript/internal/worker:worker_adapter"),


### PR DESCRIPTION
On the 3.x branch we now have strict visibility for npm deps. The example app doesn't have protobufjs in the package.json dependencies (as it shouldn't) so we can't add `@npm//protobufjs` to the users `:tsconfig_worker` program generated by the macro.

Error was
```
ERROR: /private/var/folders/r7/2kp53v7n091gcz93xlt7wtd80000gn/T/tmp-86197YyCMi6BVlKJ1/BUILD.bazel:16:1: in nodejs_binary rule //:tsconfig_worker: target '@npm//protobufjs:protobufjs' is not visible from target '//:tsconfig_worker'. Check the visibility declaration of the former target if you think the dependency is legitimate
```