### PR TITLE
fix: launcher script terminates while nodejs is still running on SIGTERM

### DIFF
--- a/internal/node/launcher.sh
+++ b/internal/node/launcher.sh
@@ -332,6 +332,12 @@ readonly child=$!
 trap _term SIGTERM
 trap _int SIGINT
 wait "${child}"
+# Remove trap after first signal has been receieved and wait for child to exit
+# (first wait returns immediatel if SIGTERM is received while waiting). Second
+# wait is a no-op if child has already terminated.
+trap - SIGTERM SIGINT
+wait "${child}"
+
 RESULT="$?"
 set -e
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The launcher script as produced by nodejs_binary targets does forward SIGTERM/SIGINT to the child node process, however it currently does not wait for the child process to actually terminate in that case.
The reason is that `wait` command used [more details in the 3rd example here](http://veithen.io/2014/11/16/sigterm-propagation.html) terminates instantly in that case.
So the launcher script terminates, while the child process is still running.

E.g. the output of [this demo script](https://github.com/Schibum/rules_nodejs/blob/sigterm_demo/examples/sigterm_demo/demo.sh):
```bash
#!/bin/bash
launcher=`bazel run --run_under "echo " :bin`
$launcher & pid=$!; sleep 1; kill -TERM $pid; wait $pid;
echo "launcher script terminated"
```

Running this simple js script:
```js
console.log('started');
process.on('SIGTERM', () => {
  console.log('SIGTERM received, terminating in 5s...');
  setTimeout(() => {
    console.log('terminating');
    process.exit(0);
  }, 5000);
});
// just do nothing but don't terminate
setTimeout(() => null, 1000000);
```

Produces this output:
```bash
$ ./demo.sh
started
SIGTERM received, terminating in 5s...
launcher script terminated
$
# 'terminating' printed from zombie process after a while
```

This is impacts graceful shutdown e.g. if used in [k8s pods as described here.](https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-terminating-with-grace). Once the launcher script terminates, the k8s pod would get deleted, preventing any graceful shutdown in application code.

## What is the new behavior?
Output of same script after patch is this:

```bash
$./demo.sh
started
SIGTERM received, terminating in 5s...
terminating
launcher script terminated
$
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

