### PR TITLE
chore: remove old stamping

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -80,9 +80,6 @@ pkg_npm(
         "BUILD.bazel",
         "LICENSE",
     ],
-    # Don't replace the default 0.0.0-PLACEHOLDER for this pkg_npm since
-    # we are packaging up the packager itself and this replacement will break it
-    replace_with_version = "",
     substitutions = COMMON_REPLACEMENTS,
     deps = [
         "//internal:package_contents",

--- a/internal/pkg_npm/test/BUILD.bazel
+++ b/internal/pkg_npm/test/BUILD.bazel
@@ -47,7 +47,10 @@ pkg_npm(
     ],
     nested_packages = [":dependent_pkg"],
     node_context_data = ":force_stamp",
-    substitutions = {"replace_me": "replaced"},
+    substitutions = {
+        "0.0.0-PLACEHOLDER": "{BUILD_SCM_VERSION}",
+        "replace_me": "replaced",
+    },
     vendor_external = [
         "internal_npm_package_test_vendored_external",
     ],

--- a/packages/rollup/rollup_bundle.bzl
+++ b/packages/rollup/rollup_bundle.bzl
@@ -308,9 +308,6 @@ def _rollup_bundle(ctx):
         output = config,
         substitutions = {
             "bazel_info_file": "\"%s\"" % ctx.info_file.path if stamp else "undefined",
-            # Back-compat: we used to replace a variable "bazel_stamp_file"
-            # Remove in 3.0: https://github.com/bazelbuild/rules_nodejs/issues/2158
-            "bazel_stamp_file": "\"%s\"" % ctx.version_file.path if stamp else "undefined",
             "bazel_version_file": "\"%s\"" % ctx.version_file.path if stamp else "undefined",
         },
     )


### PR DESCRIPTION
BREAKING CHANGE:
- rollup_bundle config_file no longer has substitutions from a "bazel_stamp_file" - use bazel_version_file instead
- pkg_npm no longer has replace_with_version attribute, use substitutions instead

Fixes #2158
