### PR TITLE
fix(builtin): give better error when linker runs on Node <10

### DIFF
--- a/internal/linker/index.js
+++ b/internal/linker/index.js
@@ -519,6 +519,12 @@ function main(args, runfiles) {
 exports.main = main;
 exports.runfiles = new Runfiles(process.env);
 if (require.main === module) {
+    if (Number(process.versions.node.split('.')[0]) < 10) {
+        console.error(`ERROR: rules_nodejs linker requires Node v10 or greater, but is running on ${process.versions.node}`);
+        console.error('Note that earlier Node versions are no longer in long-term-support, see');
+        console.error('https://nodejs.org/en/about/releases/');
+        process.exit(1);
+    }
     (() => __awaiter(void 0, void 0, void 0, function* () {
         try {
             process.exitCode = yield main(process.argv.slice(2), exports.runfiles);

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -795,6 +795,13 @@ export async function main(args: string[], runfiles: Runfiles) {
 export const runfiles = new Runfiles(process.env);
 
 if (require.main === module) {
+  if (Number(process.versions.node.split('.')[0]) < 10) {
+    console.error(`ERROR: rules_nodejs linker requires Node v10 or greater, but is running on ${
+        process.versions.node}`);
+    console.error('Note that earlier Node versions are no longer in long-term-support, see');
+    console.error('https://nodejs.org/en/about/releases/');
+    process.exit(1);
+  }
   (async () => {
     try {
       process.exitCode = await main(process.argv.slice(2), runfiles);


### PR DESCRIPTION
Example how this looks now:

```
[20 / 21] Bundling JavaScript bundle.js [parcel]; 4s remote-cache, darwin-sandbox
ERROR: /private/var/folders/r7/2kp53v7n091gcz93xlt7wtd80000gn/T/tmp-48948DHy4HrXTwhRy/BUILD.bazel:4:1: Bundling JavaScript bundle.js [parcel] failed (Exit 1) parcel.sh failed: error executing command bazel-out/host/bin/external/npm/parcel-bundler/bin/parcel.sh build foo.js --out-dir bazel-out/darwin-fastbuild/bin --out-file bundle.js ... (remaining 2 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
ERROR: rules_nodejs linker requires Node v10 or greater, but is running on 8.11.2
Note that earlier Node versions are no longer in long-term-support, see
https://nodejs.org/en/about/releases/
INFO: Elapsed time: 40.360s, Critical Path: 12.97s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
//:test                                                               NO STATUS
```

Fixes #2304
