### PR TITLE
feat(builtin): yarn install use --frozen-lockfile as default

### DIFF
--- a/internal/bazel_integration_test/test_runner.js
+++ b/internal/bazel_integration_test/test_runner.js
@@ -219,7 +219,13 @@ if (config.bazelrcAppend) {
     const replacement =
         `load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")\nhttp_archive(\n  name = "${
             repositoryKey}",\n  url="file:${archiveFile}"\n`;
-    workspaceContents = workspaceContents.replace(regex, replacement);
+
+    workspaceContents = workspaceContents.replace(regex, replacement)
+    // We have to disable the frozen lockfile option for the tests it won't match with the version
+    // from the yarn.lock file.
+    workspaceContents =
+        workspaceContents.replace(/(yarn_lock[\s\S]+?,)/gm, 'frozen_lockfile = False,\n    $1')
+
     if (!workspaceContents.includes(archiveFile)) {
       console.error(
           `bazel_integration_test: WORKSPACE replacement for repository ${repositoryKey} failed!`)


### PR DESCRIPTION
To be more hermetic with the install of the dependencies use the frozen lockfile flag to install the exact version from the `yarn.lock` file.

To update a dependency use the vendored yarn binary with `bazel run @nodejs//:yarn upgrade <dep-name>`.

Fixes #941

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently the `yarn_install` rule will use the `yarn install` command and installs the latest version that is possible in the range of the `packag.json`

Issue Number: #941


## What is the new behavior?

The new behaviour is using the frozen lock file option for yarn installs, this means that it will install the exact version from the `yarn.lock` file

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

