### PR TITLE
Fix compilation issue due to string mismatch

### DIFF
--- a/third_party/github.com/bazelbuild/rules_typescript/internal/tsc_wrapped/compiler_host.ts
+++ b/third_party/github.com/bazelbuild/rules_typescript/internal/tsc_wrapped/compiler_host.ts
@@ -373,7 +373,7 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
     // if it exists
     const pkgFile = path.posix.join(typePath, 'package.json');
     if (this.fileExists(pkgFile)) {
-      const pkg = JSON.parse(fs.readFileSync(pkgFile, 'UTF-8')) as packageJson;
+      const pkg = JSON.parse(fs.readFileSync(pkgFile, 'utf-8')) as packageJson;
       let typings = pkg['typings'];
       if (typings) {
         if (typings === '.' || typings === './') {


### PR DESCRIPTION
Facing the following error when building using Bazel typescript

```
external/build_bazel_rules_typescript/internal/BUILD.bazel:49:4: Action external/build_bazel_rules_typescript/internal/tsc_wrapped/cache.js failed (Exit 2): tsc.sh failed: error executing command bazel-out/host/bin/external/npm/typescript/bin/tsc.sh --declaration -p external/build_bazel_rules_typescript/internal/tsconfig.json --outDir ... (remaining 3 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox tsc.sh failed: error executing command bazel-out/host/bin/external/npm/typescript/bin/tsc.sh --declaration -p external/build_bazel_rules_typescript/internal/tsconfig.json --outDir ... (remaining 3 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
external/build_bazel_rules_typescript/internal/tsc_wrapped/compiler_host.ts(372,55): error TS2769: No overload matches this call.
  Overload 1 of 3, '(path: string | number | Buffer | URL, options?: { encoding?: null | undefined; flag?: string | undefined; } | null | undefined): Buffer', gave the following error.
    Argument of type '"UTF-8"' is not assignable to parameter of type '{ encoding?: null | undefined; flag?: string | undefined; } | null | undefined'.
  Overload 2 of 3, '(path: string | number | Buffer | URL, options: "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex" | { encoding: BufferEncoding; flag?: string | undefined; }): string', gave the following error.
    Argument of type '"UTF-8"' is not assignable to parameter of type '"ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex" | { encoding: BufferEncoding; flag?: string | undefined; }'.
  Overload 3 of 3, '(path: string | number | Buffer | URL, options?: "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex" | (BaseEncodingOptions & { ...; }) | null | undefined): string | Buffer', gave the following error.
    Argument of type '"UTF-8"' is not assignable to parameter of type '"ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex" | (BaseEncodingOptions & { flag?: string | undefined; }) | null | undefined'.
```

per https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7789a59cad6d4630db8116abe6b21ca1255df507/types/node/globals.d.ts#L74, it support "utf-8" and not "UTF-8"

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

