### PR TITLE
chore: allow node versions >=12 <=14

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "repository": "https://github.com/bazelbuild/rules_nodejs",
     "license": "Apache-2.0",
     "engines": {
-        "node": ">=12.0.0 <= 14.14.0",
+        "node": ">=12 <=14",
         "yarn": ">=1.13.0"
     },
     "devDependencies": {


### PR DESCRIPTION
I think we should use a more relaxed node engine restriction as I don't see no reason why not to allow always the most up to date LTS version being in use at the moment. \cc @alexeagle 