### PR TITLE
Remove jasmine-core as a peer dep for @bazel/concatjs

### DIFF
--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -56,7 +56,6 @@
         "history-server": "^1.3.1",
         "html-insert-assets": "^0.6.0",
         "jasmine": "2.8.0",
-        "jasmine-core": "2.8.0",
         "karma": "~4.1.0",
         "karma-chrome-launcher": "2.2.0",
         "karma-firefox-launcher": "1.1.0",

--- a/examples/angular_bazel_architect/package.json
+++ b/examples/angular_bazel_architect/package.json
@@ -42,7 +42,6 @@
     "@types/node": "12.12.6",
     "codelyzer": "^6.0.0",
     "html-webpack-plugin": "^3.2.0",
-    "jasmine-core": "~3.5.0",
     "jasmine-spec-reporter": "~5.0.0",
     "karma": "~5.0.0",
     "karma-chrome-launcher": "~3.1.0",

--- a/examples/angular_view_engine/package.json
+++ b/examples/angular_view_engine/package.json
@@ -50,7 +50,6 @@
         "history-server": "^1.3.1",
         "html-insert-assets": "^0.6.0",
         "jasmine": "2.8.0",
-        "jasmine-core": "2.8.0",
         "karma": "~4.1.0",
         "karma-chrome-launcher": "2.2.0",
         "karma-firefox-launcher": "1.1.0",

--- a/examples/protocol_buffers/package.json
+++ b/examples/protocol_buffers/package.json
@@ -15,7 +15,6 @@
     "grpc-web": "1.1.0",
     "http-server": "^0.11.1",
     "jasmine": "2.8.0",
-    "jasmine-core": "2.8.0",
     "karma": "~4.1.0",
     "karma-chrome-launcher": "2.2.0",
     "karma-firefox-launcher": "1.1.0",

--- a/examples/web_testing/package.json
+++ b/examples/web_testing/package.json
@@ -4,7 +4,6 @@
     "@bazel/typescript": "^2.2.2",
     "@types/jasmine": "2.8.2",
     "@types/node": "11.11.1",
-    "jasmine-core": "^3.3.0",
     "karma": "~4.1.0",
     "karma-chrome-launcher": "2.2.0",
     "karma-firefox-launcher": "1.1.0",

--- a/packages/concatjs/package.json
+++ b/packages/concatjs/package.json
@@ -22,7 +22,6 @@
         "tsutils": "2.27.2"
     },
     "peerDependencies": {
-        "jasmine-core": ">=2.0.0",
         "karma": ">=4.0.0",
         "karma-chrome-launcher": ">=2.0.0",
         "karma-firefox-launcher": ">=1.0.0",

--- a/packages/concatjs/web_test/karma_web_test.bzl
+++ b/packages/concatjs/web_test/karma_web_test.bzl
@@ -21,7 +21,6 @@ load("@io_bazel_rules_webtesting//web/internal:constants.bzl", "DEFAULT_WRAPPED_
 KARMA_PEER_DEPS = [
     # NB: uncommented during pkg_npm
     #@external "@npm//@bazel/concatjs",
-    "@npm//jasmine-core",
     "@npm//karma",
     "@npm//karma-chrome-launcher",
     "@npm//karma-firefox-launcher",
@@ -132,7 +131,6 @@ def _write_karma_config(ctx, files, amd_names_shim):
     # The files in the bootstrap attribute come before the require.js support.
     # Note that due to frameworks = ['jasmine'], a few scripts will come before
     # the bootstrap entries:
-    # jasmine-core/lib/jasmine-core/jasmine.js
     # karma-jasmine/lib/boot.js
     # karma-jasmine/lib/adapter.js
     # This is desired so that the bootstrap entries can patch jasmine, as zone.js does.


### PR DESCRIPTION
Remove the `jasmine-core` peer dep from `@bazel/concatjs`. This PR also removes it from the examples that don't use `@bazel/jasmine` to test that it's not load bearing. 

With `strict_visibility` enabled now by default, previously this would have caused bazel visibility errors.