### PR TITLE
refactor(protractor): load protractor-utils from @bazel/protractor

### DIFF
--- a/packages/protractor/BUILD.bazel
+++ b/packages/protractor/BUILD.bazel
@@ -62,7 +62,8 @@ nodejs_test(
 ts_library(
     name = "protractor",
     srcs = ["protractor-utils.ts"],
-    module_name = "@bazel/protractor/protractor-utils",
+    data = ["package.json"],
+    module_name = "@bazel/protractor",
     module_root = "protractor-utils",
     deps = ["@npm//@types/node"],
 )

--- a/packages/protractor/package.json
+++ b/packages/protractor/package.json
@@ -15,6 +15,7 @@
       "protractor",
       "bazel"
   ],
+  "main": "protractor-utils.js",
   "peerDependencies": {
       "protractor": ">=5.0.0"
   },

--- a/packages/protractor/test/protractor-2/on-prepare.js
+++ b/packages/protractor/test/protractor-2/on-prepare.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-const protractorUtils = require('@bazel/protractor/protractor-utils');
+const protractorUtils = require('@bazel/protractor');
 const protractor = require('protractor');
 const path = require('path');
 

--- a/packages/protractor/test/protractor-utils/index_test.ts
+++ b/packages/protractor/test/protractor-utils/index_test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {runServer} from '@bazel/protractor/protractor-utils';
+import {runServer} from '@bazel/protractor';
 
 describe('Bazel protractor utils', () => {
   it('should be able to start devserver', async () => {

--- a/packages/protractor/test/protractor/conf.ts
+++ b/packages/protractor/test/protractor/conf.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import * as protractorUtils from '@bazel/protractor/protractor-utils';
+import * as protractorUtils from '@bazel/protractor';
 import {browser} from 'protractor';
 
 const http = require('http');


### PR DESCRIPTION
This makes it 'linkable' for local consumption, so we don't rely as much on the --bazel_patch_module_resolver
patched require() function. Evidently from the examples, this is non-breaking and users can continue to deep-import the helper, though it's no longer necessary
