### PR TITLE
refactor(typescript): ts_library plugins use custom compiler

### DIFF
--- a/packages/typescript/test/angular_plugin/BUILD.bazel
+++ b/packages/typescript/test/angular_plugin/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+
+# Custom ts_library compiler that runs tsc_wrapped with angular/compiler-cli statically linked
+# This can be used with worker mode because we don't need the linker at runtime to make
+# the angular plugin loadable
+# Just a clone of @build_bazel_rules_typescript//internal:tsc_wrapped with added deps
+nodejs_binary(
+    name = "tsc_wrapped_with_angular",
+    data = [
+        "@build_bazel_rules_typescript//internal:tsc_wrapped",
+        "@build_bazel_rules_typescript//third_party/github.com/bazelbuild/bazel/src/main/protobuf:worker_protocol.proto",
+        "@npm//@angular/compiler-cli",
+        "@npm//protobufjs",
+        "@npm//source-map-support",
+        "@npm//tsickle",
+        "@npm//tsutils",
+        "@npm//typescript",
+    ],
+    entry_point = "@build_bazel_rules_typescript//internal:tsc_wrapped/tsc_wrapped.js",
+    # TODO: turn on --worker_sandboxing and remove this flag to see failure to load the plugin
+    templated_args = ["--bazel_patch_module_resolver"],
+    visibility = ["//packages/typescript/test/angular_plugin:__subpackages__"],
+)

--- a/packages/typescript/test/angular_plugin/compiled_output/BUILD.bazel
+++ b/packages/typescript/test/angular_plugin/compiled_output/BUILD.bazel
@@ -21,11 +21,10 @@ ts_library(
     angular_assets = [
         "comp.ng.html",
     ],
+    compiler = "//packages/typescript/test/angular_plugin:tsc_wrapped_with_angular",
     tsconfig = ":tsconfig.json",
     use_angular_plugin = True,
     deps = [
-        # Needed for the angular compiler plugin
-        "@npm//@angular/compiler-cli",
         "@npm//@angular/core",
     ],
 )

--- a/packages/typescript/test/angular_plugin/diagnostic/BUILD.bazel
+++ b/packages/typescript/test/angular_plugin/diagnostic/BUILD.bazel
@@ -20,14 +20,13 @@ ts_library(
     angular_assets = [
         "comp.ng.html",
     ],
+    compiler = "//packages/typescript/test/angular_plugin:tsc_wrapped_with_angular",
     expected_diagnostics = [
         "TS2339: \\[ngtsc\\] Property 'thing' does not exist on type 'Comp'",
     ],
     tsconfig = ":tsconfig.json",
     use_angular_plugin = True,
     deps = [
-        # Needed for the angular compiler plugin
-        "@npm//@angular/compiler-cli",
         "@npm//@angular/core",
     ],
 )

--- a/packages/typescript/test/lit_plugin/BUILD.bazel
+++ b/packages/typescript/test/lit_plugin/BUILD.bazel
@@ -12,11 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("//packages/typescript:index.bzl", "ts_library")
+
+# Custom ts_library compiler that runs tsc_wrapped with ts-lit-plugin statically linked
+# This can be used with worker mode because we don't need the linker at runtime to make
+# the plugin loadable
+# Just a clone of @build_bazel_rules_typescript//internal:tsc_wrapped with added deps
+nodejs_binary(
+    name = "tsc_wrapped_with_lit_plugin",
+    data = [
+        "@build_bazel_rules_typescript//internal:tsc_wrapped",
+        "@build_bazel_rules_typescript//third_party/github.com/bazelbuild/bazel/src/main/protobuf:worker_protocol.proto",
+        "@npm//protobufjs",
+        "@npm//source-map-support",
+        "@npm//ts-lit-plugin",
+        "@npm//tsickle",
+        "@npm//tsutils",
+        "@npm//typescript",
+    ],
+    entry_point = "@build_bazel_rules_typescript//internal:tsc_wrapped/tsc_wrapped.js",
+    # TODO: turn on --worker_sandboxing and remove this flag to see failure to load the plugin
+    templated_args = ["--bazel_patch_module_resolver"],
+    visibility = ["//packages/typescript/test/angular_plugin:__subpackages__"],
+)
 
 ts_library(
     name = "lit_plugin",
     srcs = glob(["*.ts"]),
+    compiler = "tsc_wrapped_with_lit_plugin",
     expected_diagnostics = [
         """TS2322: \\[lit\\] Unknown tag "unknown-element". Did you mean 'lit-element'?""",
         "TS2322: \\[lit\\] Type '222' is not assignable to 'string",
@@ -26,14 +50,8 @@ ts_library(
         "TS2322: \\[lit\\] Type '444' is not assignable to 'string",
         "TS2322: \\[lit\\] Type '{ field: number; }' is not assignable to '{ field: string; }'",
     ],
-    # We need the linker to set up a node_modules tree to discover the plugin
-    # but it isn't compatible with worker mode;
-    # see https://github.com/bazelbuild/rules_nodejs/issues/1803
-    supports_workers = False,
     tsconfig = ":tsconfig.json",
     deps = [
         "@npm//lit-element",
-        # TODO(#850): plugins["@npm//ts-lit-plugin"] instead?
-        "@npm//ts-lit-plugin",
     ],
 )


### PR DESCRIPTION
This is conceptually simpler than having the compiler resolve dependencies out of one compilation request that uses it.
It's also more compatible with the linker under worker sandboxing, where the compiler won't see the plugins at startup before the first compilation job is sent.
