### PR TITLE
chore: update rules_sass to latest

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -79,6 +79,7 @@ pkg_npm(
     srcs = glob(["*.bzl"]) + [
         "BUILD.bazel",
         "LICENSE",
+        "rules_sass.issue127.patch",
     ],
     substitutions = COMMON_REPLACEMENTS,
     deps = [

--- a/examples/angular/WORKSPACE
+++ b/examples/angular/WORKSPACE
@@ -36,11 +36,17 @@ http_archive(
 # Fetch sass rules for compiling sass files
 http_archive(
     name = "io_bazel_rules_sass",
-    sha256 = "c78be58f5e0a29a04686b628cf54faaee0094322ae0ac99da5a8a8afca59a647",
-    strip_prefix = "rules_sass-1.25.0",
+    patch_args = ["-p1"],
+    # We need the latest rules_sass to get the --bazel_patch_module_resolver behavior
+    # However it seems to have a bug, so we patch back to the prior dart-sass version.
+    # See https://github.com/bazelbuild/rules_sass/issues/127
+    # TODO(alexeagle): fix upstream and remove patch
+    patches = ["@build_bazel_rules_nodejs//:rules_sass.issue127.patch"],
+    sha256 = "8392cf8910db2b1dc3b488ea18113bfe4fd666037bf8ec30d2a3f08fc602a6d8",
+    strip_prefix = "rules_sass-1.30.0",
     urls = [
-        "https://github.com/bazelbuild/rules_sass/archive/1.25.0.zip",
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.25.0.zip",
+        "https://github.com/bazelbuild/rules_sass/archive/1.30.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.30.0.zip",
     ],
 )
 

--- a/examples/angular_view_engine/WORKSPACE
+++ b/examples/angular_view_engine/WORKSPACE
@@ -23,11 +23,17 @@ http_archive(
 # Fetch sass rules for compiling sass files
 http_archive(
     name = "io_bazel_rules_sass",
-    sha256 = "c78be58f5e0a29a04686b628cf54faaee0094322ae0ac99da5a8a8afca59a647",
-    strip_prefix = "rules_sass-1.25.0",
+    patch_args = ["-p1"],
+    # We need the latest rules_sass to get the --bazel_patch_module_resolver behavior
+    # However it seems to have a bug, so we patch back to the prior dart-sass version.
+    # See https://github.com/bazelbuild/rules_sass/issues/127
+    # TODO(alexeagle): fix upstream and remove patch
+    patches = ["@build_bazel_rules_nodejs//:rules_sass.issue127.patch"],
+    sha256 = "8392cf8910db2b1dc3b488ea18113bfe4fd666037bf8ec30d2a3f08fc602a6d8",
+    strip_prefix = "rules_sass-1.30.0",
     urls = [
-        "https://github.com/bazelbuild/rules_sass/archive/1.25.0.zip",
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.25.0.zip",
+        "https://github.com/bazelbuild/rules_sass/archive/1.30.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.30.0.zip",
     ],
 )
 

--- a/package.bzl
+++ b/package.bzl
@@ -31,11 +31,17 @@ def rules_nodejs_dev_dependencies():
     _maybe(
         http_archive,
         name = "io_bazel_rules_sass",
-        sha256 = "c78be58f5e0a29a04686b628cf54faaee0094322ae0ac99da5a8a8afca59a647",
-        strip_prefix = "rules_sass-1.25.0",
+        patch_args = ["-p1"],
+        # We need the latest rules_sass to get the --bazel_patch_module_resolver behavior
+        # However it seems to have a bug, so we patch back to the prior dart-sass version.
+        # See https://github.com/bazelbuild/rules_sass/issues/127
+        # TODO(alexeagle): fix upstream and remove patch
+        patches = ["@build_bazel_rules_nodejs//:rules_sass.issue127.patch"],
+        sha256 = "8392cf8910db2b1dc3b488ea18113bfe4fd666037bf8ec30d2a3f08fc602a6d8",
+        strip_prefix = "rules_sass-1.30.0",
         urls = [
-            "https://github.com/bazelbuild/rules_sass/archive/1.25.0.zip",
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.25.0.zip",
+            "https://github.com/bazelbuild/rules_sass/archive/1.30.0.zip",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_sass/archive/1.30.0.zip",
         ],
     )
 

--- a/rules_sass.issue127.patch
+++ b/rules_sass.issue127.patch
@@ -1,0 +1,12 @@
+diff --git a/sass/package.json b/sass/package.json
+index 584a86c..1f54da3 100644
+--- a/sass/package.json
++++ b/sass/package.json
+@@ -1,6 +1,6 @@
+ {
+   "devDependencies": {
+     "@bazel/worker": "2.3.1",
+-    "sass": "1.30.0"
++    "sass": "1.29.0"
+   }
+ }


### PR DESCRIPTION
This includes an explicit opt-in to the --bazel_patch_module_resolver flag, which we need before flipping the default.
Note that there's some issue upstream AFAICT so I filed https://github.com/bazelbuild/rules_sass/issues/127 and patched that here
