### PR TITLE
fix(examples): angualr universal_server

### DIFF
--- a/examples/angular/src/BUILD.bazel
+++ b/examples/angular/src/BUILD.bazel
@@ -311,4 +311,5 @@ nodejs_binary(
         ":universal_server_lib",
     ],
     entry_point = ":server.ts",
+    templated_args = ["--bazel_patch_module_resolver"],
 )


### PR DESCRIPTION
Since rules_nodejs v3 the `--bazel_patch_module_resolver` flag is required to run the universal server