### PR TITLE
chore: Fix JSModuleInfo and JSNamedModuleInfo case typo in docs

### DIFF
--- a/docs/Built-ins.html
+++ b/docs/Built-ins.html
@@ -1529,8 +1529,8 @@ It will also provide <a href="https://docs.bazel.build/versions/master/skylark/l
 <p>It also provides:</p>
 <ul>
   <li><a href="#externalnpmpackageinfo">ExternalNpmPackageInfo</a> to interop with rules that expect third-party npm packages.</li>
-  <li><a href="#jsmoduleinfo">JsModuleInfo</a> so rules like bundlers can collect the transitive set of .js files</li>
-  <li><a href="#jsnamedmoduleinfo">JsNamedModuleInfo</a> for rules that expect named AMD or <code class="language-plaintext highlighter-rouge">goog.module</code> format JS</li>
+  <li><a href="#jsmoduleinfo">JSModuleInfo</a> so rules like bundlers can collect the transitive set of .js files</li>
+  <li><a href="#jsnamedmoduleinfo">JSNamedModuleInfo</a> for rules that expect named AMD or <code class="language-plaintext highlighter-rouge">goog.module</code> format JS</li>
 </ul>
 
 <p><strong>PARAMETERS</strong></p>

--- a/docs/Built-ins.md
+++ b/docs/Built-ins.md
@@ -1455,7 +1455,7 @@ In order to work with the linker (similar to `npm link` for first-party monorepo
 It also provides:
 - [ExternalNpmPackageInfo](#externalnpmpackageinfo) to interop with rules that expect third-party npm packages.
 - [JSModuleInfo](#jsmoduleinfo) so rules like bundlers can collect the transitive set of .js files
-- [JsNamedModuleInfo](#jsnamedmoduleinfo) for rules that expect named AMD or `goog.module` format JS
+- [JSNamedModuleInfo](#jsnamedmoduleinfo) for rules that expect named AMD or `goog.module` format JS
 
 [OutputGroupInfo]: https://docs.bazel.build/versions/master/skylark/lib/OutputGroupInfo.html
 [DefaultInfo]: https://docs.bazel.build/versions/master/skylark/lib/DefaultInfo.html

--- a/docs/Built-ins.md
+++ b/docs/Built-ins.md
@@ -1454,7 +1454,7 @@ In order to work with the linker (similar to `npm link` for first-party monorepo
 
 It also provides:
 - [ExternalNpmPackageInfo](#externalnpmpackageinfo) to interop with rules that expect third-party npm packages.
-- [JsModuleInfo](#jsmoduleinfo) so rules like bundlers can collect the transitive set of .js files
+- [JSModuleInfo](#jsmoduleinfo) so rules like bundlers can collect the transitive set of .js files
 - [JsNamedModuleInfo](#jsnamedmoduleinfo) for rules that expect named AMD or `goog.module` format JS
 
 [OutputGroupInfo]: https://docs.bazel.build/versions/master/skylark/lib/OutputGroupInfo.html

--- a/internal/js_library/js_library.bzl
+++ b/internal/js_library/js_library.bzl
@@ -320,8 +320,8 @@ def js_library(
 
     It also provides:
     - [ExternalNpmPackageInfo](#externalnpmpackageinfo) to interop with rules that expect third-party npm packages.
-    - [JsModuleInfo](#jsmoduleinfo) so rules like bundlers can collect the transitive set of .js files
-    - [JsNamedModuleInfo](#jsnamedmoduleinfo) for rules that expect named AMD or `goog.module` format JS
+    - [JSModuleInfo](#jsmoduleinfo) so rules like bundlers can collect the transitive set of .js files
+    - [JSNamedModuleInfo](#jsnamedmoduleinfo) for rules that expect named AMD or `goog.module` format JS
 
     [OutputGroupInfo]: https://docs.bazel.build/versions/master/skylark/lib/OutputGroupInfo.html
     [DefaultInfo]: https://docs.bazel.build/versions/master/skylark/lib/DefaultInfo.html


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
`JsModuleInfo` had a typo, fixing to `JSModuleInfo`
`JsNamedModuleInfo` had a typo, fixing to `JSNamedModuleInfo`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

