### PR TITLE
fix: skip update NodeJS versions action on forks

### DIFF
--- a/.github/workflows/update-nodejs-versions.yml
+++ b/.github/workflows/update-nodejs-versions.yml
@@ -9,6 +9,9 @@ jobs:
   updateNodejsVersions:
     runs-on: ubuntu-latest
 
+    # Skip this on forks
+    if: github.repository == 'bazelbuild/rules_nodejs'
+
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
I've been getting regular emails from my fork telling me that this
action has failed. We really only need to run this on the original
repo anyway, and we can achieve this by using the `if` option.

More info:

  https://github.community/t/stop-github-actions-running-on-a-fork/17965/2

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I get emails from my fork saying that this action has failed.

Issue Number: N/A


## What is the new behavior?
This action should no longer run on forks of this repo.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

