### PR TITLE
fix(typescript): capture js files in outputs of ts_project if allow_js

### DIFF
--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -668,7 +668,7 @@ def ts_project_macro(
     typing_maps_outs = []
 
     if not emit_declaration_only:
-        js_outs.extend(_out_paths(srcs, out_dir, root_dir, False, ".js"))
+        js_outs.extend(_out_paths(srcs, out_dir, root_dir, allow_js, ".js"))
     if source_map and not emit_declaration_only:
         map_outs.extend(_out_paths(srcs, out_dir, root_dir, False, ".js.map"))
     if declaration or composite:

--- a/packages/typescript/test/ts_project/allow_js/BUILD.bazel
+++ b/packages/typescript/test/ts_project/allow_js/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
 load("//packages/typescript:index.bzl", "ts_project")
 
-# Ensure that a.js produces outDir/a.js and outDir/a.d.ts
+# Ensure that a.js produces outDir/a.js, outDir/a.d.ts, and outDir/a.d.ts.map
 SRCS = [
     "a.js",
 ]

--- a/packages/typescript/test/ts_project/allow_js/verify.js
+++ b/packages/typescript/test/ts_project/allow_js/verify.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 
 const types_files = process.argv.slice(2, 4);
-const code_files = process.argv.slice(4, 6);
+const code_file = process.argv[4];
 assert.ok(types_files.some(f => f.endsWith('out/a.d.ts')), 'Missing a.d.ts');
 assert.ok(types_files.some(f => f.endsWith('out/a.d.ts.map')), 'Missing a.d.ts.map');
+assert.ok(code_file.endsWith('out/a.js'), 'Missing a.js');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)

- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
.js files are not captured as outputs of ts_project if allow_js is set to true and .js files are passed as inputs

https://github.com/bazelbuild/rules_nodejs/issues/2390

## What is the new behavior?
This change will make .js files outputs of ts_project if allow_js is true when js files are passed in

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Although this behavior is probably desired, this will break anyone who currently uses `ts_project` with `allow_js`  and passes in js files to generate typings and does not pass in an `out_dir` because bazel will say that file is both an input and output. This is technically the same behavior as running `tsc` on js files without an out_dir because it will refuse to overwrite the file but a change in how the ts_project rule would have worked in the past

## Other information
First attempt at contributing here, it seemed like the existing test already had a comment that implied this was the expected behavior so I mostly just modified the test. Let me know if there is anything that isn't quite right.
