### PR TITLE
docs(typescript): add `host` configuration to `rootDirs`

### DIFF
--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -388,6 +388,7 @@ def ts_project_macro(
     > "compilerOptions": {
     >     "rootDirs": [
     >         ".",
+    >         "../../bazel-out/host/bin/path/to",
     >         "../../bazel-out/darwin-fastbuild/bin/path/to",
     >         "../../bazel-out/k8-fastbuild/bin/path/to",
     >         "../../bazel-out/x64_windows-fastbuild/bin/path/to",


### PR DESCRIPTION
A `host` root directory is necessary for TypeScript to resolve imports for a tool executed at build time with `cfg = "host"`.

This is necessary for:

```
some_rule = rule(
    implementation = _some_rule_impl,
    attrs = {
        "_binary": attr.label({
            default: "//some/nodejs_binary/tool/built/with/ts_project",
            executable: True,
            cfg = "host",
        }),
    },
)
```

Because Bazel will build the tool in the `host` configuration, meaning generated *.js files will be dropped into `bazel-out/host/bin/...`, and `tsc` needs to know to look for dependent `ts_project()` outputs in that directory.

Arguably a similar change is also necessary for `cfg = "exec"`, however files would be in `bazel-out/k8-opt-exec-*/bin`, which can't be easily hard-coded in a tsconfig, so that's a problem to be tackled separately.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

While not a breaking change, many users are likely to have copy-pasted this content from the docs and will not easily discover this information or update their `tsconfig.json` file. This could add additional confusion due to a difference between new projects which copy-paste this content, and old projects which already did.