### PR TITLE
docs: fix load statements in examples for concatjs_devserver

### DIFF
--- a/packages/concatjs/_README.md
+++ b/packages/concatjs/_README.md
@@ -53,7 +53,8 @@ To use `concatjs_devserver`, you simply `load` the rule, and call it with `deps`
 point to your `ts_library` target(s):
 
 ```python
-load("//packages/typescript:index.bzl", "concatjs_devserver", "ts_library")
+load("//packages/concatjs:index.bzl", "concatjs_devserver")
+load("//packages/typescript:index.bzl", "ts_library")
 
 ts_library(
     name = "app",


### PR DESCRIPTION
Fix load statements in examples from the `ts_devserver` -> `concatjs_devserver` refactor

closes #2414