### PR TITLE
fix: linker fix for invalid symlink creation path in createSymlinkAndPreserveContents

### DIFF
--- a/internal/linker/index.js
+++ b/internal/linker/index.js
@@ -490,9 +490,10 @@ function main(args, runfiles) {
                             }
                             break;
                     }
-                    if (target) {
-                        const stats = yield gracefulLstat(m.name);
-                        if (stats !== null && (yield isLeftoverDirectoryFromLinker(stats, m.name))) {
+                    const stats = yield gracefulLstat(m.name);
+                    const isLeftOver = (stats !== null && (yield isLeftoverDirectoryFromLinker(stats, m.name)));
+                    if (target && (yield exists(target))) {
+                        if (stats !== null && isLeftOver) {
                             yield createSymlinkAndPreserveContents(stats, m.name, target);
                         }
                         else {
@@ -500,7 +501,15 @@ function main(args, runfiles) {
                         }
                     }
                     else {
-                        log_verbose(`no symlink target found for module ${m.name}`);
+                        if (!target) {
+                            log_verbose(`no symlink target found for module ${m.name}`);
+                        }
+                        else {
+                            log_verbose(`potential target ${target} does not exists for module ${m.name}`);
+                        }
+                        if (isLeftOver) {
+                            yield unlink(m.name);
+                        }
                     }
                 }
                 if (m.children) {

--- a/internal/linker/index.js
+++ b/internal/linker/index.js
@@ -99,9 +99,6 @@ function deleteDirectory(p) {
 function symlink(target, p) {
     return __awaiter(this, void 0, void 0, function* () {
         log_verbose(`symlink( ${p} -> ${target} )`);
-        if (!(yield exists(target))) {
-            return false;
-        }
         try {
             yield fs.promises.symlink(target, p, 'junction');
             return true;
@@ -455,7 +452,7 @@ function main(args, runfiles) {
                 yield mkdirp(path.dirname(m.name));
                 if (m.link) {
                     const [root, modulePath] = m.link;
-                    let target = '<package linking failed>';
+                    let target;
                     switch (root) {
                         case 'execroot':
                             if (isExecroot) {
@@ -487,17 +484,23 @@ function main(args, runfiles) {
                                     }
                                 }
                             }
-                            catch (_a) {
-                                target = '<runfiles resolution failed>';
+                            catch (err) {
+                                target = undefined;
+                                log_verbose(`runfiles resolve failed for module '${m.name}': ${err.message}`);
                             }
                             break;
                     }
-                    const stats = yield gracefulLstat(m.name);
-                    if (stats !== null && (yield isLeftoverDirectoryFromLinker(stats, m.name))) {
-                        yield createSymlinkAndPreserveContents(stats, m.name, target);
+                    if (target) {
+                        const stats = yield gracefulLstat(m.name);
+                        if (stats !== null && (yield isLeftoverDirectoryFromLinker(stats, m.name))) {
+                            yield createSymlinkAndPreserveContents(stats, m.name, target);
+                        }
+                        else {
+                            yield symlink(target, m.name);
+                        }
                     }
                     else {
-                        yield symlink(target, m.name);
+                        log_verbose(`no symlink target found for module ${m.name}`);
                     }
                 }
                 if (m.children) {

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -744,23 +744,41 @@ export async function main(args: string[], runfiles: Runfiles) {
           break;
       }
 
-      if (target) {
-        const stats = await gracefulLstat(m.name);
-        // In environments where runfiles are not symlinked (e.g. Windows), existing linked
-        // modules are preserved. This could cause issues when a link is created at higher level
-        // as a conflicting directory is already on disk. e.g. consider in a previous run, we
-        // linked the modules `my-pkg/overlay`. Later on, in another run, we have a module mapping
-        // for `my-pkg` itself. The linker cannot create `my-pkg` because the directory `my-pkg`
-        // already exists. To ensure that the desired link is generated, we create the new desired
-        // link and move all previous nested links from the old module into the new link. Read more
-        // about this in the description of `createSymlinkAndPreserveContents`.
-        if (stats !== null && await isLeftoverDirectoryFromLinker(stats, m.name)) {
+      // In environments where runfiles are not symlinked (e.g. Windows), existing linked
+      // modules are preserved. This could cause issues when a link is created at higher level
+      // as a conflicting directory is already on disk. e.g. consider in a previous run, we
+      // linked the modules `my-pkg/overlay`. Later on, in another run, we have a module mapping
+      // for `my-pkg` itself. The linker cannot create `my-pkg` because the directory `my-pkg`
+      // already exists. To ensure that the desired link is generated, we create the new desired
+      // link and move all previous nested links from the old module into the new link. Read more
+      // about this in the description of `createSymlinkAndPreserveContents`.
+      const stats = await gracefulLstat(m.name);
+      const isLeftOver = (stats !== null && await isLeftoverDirectoryFromLinker(stats, m.name));
+
+      // Check if the target exists before creating the symlink.
+      // This is an extra filesystem access on top of the symlink but
+      // it is necessary for the time being.
+      if (target && await exists(target)) {
+        if (stats !== null && isLeftOver) {
           await createSymlinkAndPreserveContents(stats, m.name, target);
         } else {
           await symlink(target, m.name);
         }
       } else {
-        log_verbose(`no symlink target found for module ${m.name}`);
+        if (!target) {
+          log_verbose(`no symlink target found for module ${m.name}`);
+        } else {
+          // This can happen if a module mapping is propogated from a dependency
+          // but the target that generated the mapping in not in the deps. We don't
+          // want to create symlinks to non-existant targets as this will
+          // break any nested symlinks that may be created under the module name
+          // after this.
+          log_verbose(`potential target ${target} does not exists for module ${m.name}`);
+        }
+        if (isLeftOver) {
+          // Remove left over directory if it exists
+          await unlink(m.name);
+        }
       }
     }
 

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -108,18 +108,6 @@ async function deleteDirectory(p: string) {
 async function symlink(target: string, p: string): Promise<boolean> {
   log_verbose(`symlink( ${p} -> ${target} )`);
 
-  // Check if the target exists before creating the symlink.
-  // This is an extra filesystem access on top of the symlink but
-  // it is necessary for the time being.
-  if (!await exists(target)) {
-    // This can happen if a module mapping is propogated from a dependency
-    // but the target that generated the mapping in not in the deps. We don't
-    // want to create symlinks to non-existant targets as this will
-    // break any nested symlinks that may be created under the module name
-    // after this.
-    return false;
-  }
-
   // Use junction on Windows since symlinks require elevated permissions.
   // We only link to directories so junctions work for us.
   try {
@@ -714,7 +702,7 @@ export async function main(args: string[], runfiles: Runfiles) {
 
     if (m.link) {
       const [root, modulePath] = m.link;
-      let target: string = '<package linking failed>';
+      let target: string|undefined;
       switch (root) {
         case 'execroot':
           if (isExecroot) {
@@ -749,25 +737,30 @@ export async function main(args: string[], runfiles: Runfiles) {
                 throw e;
               }
             }
-          } catch {
-            target = '<runfiles resolution failed>';
+          } catch (err) {
+            target = undefined;
+            log_verbose(`runfiles resolve failed for module '${m.name}': ${err.message}`);
           }
           break;
       }
 
-      const stats = await gracefulLstat(m.name);
-      // In environments where runfiles are not symlinked (e.g. Windows), existing linked
-      // modules are preserved. This could cause issues when a link is created at higher level
-      // as a conflicting directory is already on disk. e.g. consider in a previous run, we
-      // linked the modules `my-pkg/overlay`. Later on, in another run, we have a module mapping
-      // for `my-pkg` itself. The linker cannot create `my-pkg` because the directory `my-pkg`
-      // already exists. To ensure that the desired link is generated, we create the new desired
-      // link and move all previous nested links from the old module into the new link. Read more
-      // about this in the description of `createSymlinkAndPreserveContents`.
-      if (stats !== null && await isLeftoverDirectoryFromLinker(stats, m.name)) {
-        await createSymlinkAndPreserveContents(stats, m.name, target);
+      if (target) {
+        const stats = await gracefulLstat(m.name);
+        // In environments where runfiles are not symlinked (e.g. Windows), existing linked
+        // modules are preserved. This could cause issues when a link is created at higher level
+        // as a conflicting directory is already on disk. e.g. consider in a previous run, we
+        // linked the modules `my-pkg/overlay`. Later on, in another run, we have a module mapping
+        // for `my-pkg` itself. The linker cannot create `my-pkg` because the directory `my-pkg`
+        // already exists. To ensure that the desired link is generated, we create the new desired
+        // link and move all previous nested links from the old module into the new link. Read more
+        // about this in the description of `createSymlinkAndPreserveContents`.
+        if (stats !== null && await isLeftoverDirectoryFromLinker(stats, m.name)) {
+          await createSymlinkAndPreserveContents(stats, m.name, target);
+        } else {
+          await symlink(target, m.name);
+        }
       } else {
-        await symlink(target, m.name);
+        log_verbose(`no symlink target found for module ${m.name}`);
       }
     }
 


### PR DESCRIPTION
This latent bug was hit recently by the Angular team when upgrading to rules_nodejs 2.3.2.

The logic was clearly wrong in that a symlink with a target of `<runfiles resolution failed>` is attempted under certain conditions and then in a no-sandbox-environment, if that module had been previously linked successfully by another target, `await fs.promises.rename(tmpPath, modulePath);` would fail inside `createSymlinkAndPreserveContents`.

```
[link_node_modules.js] symlink( @angular/upgrade__linker_tmp -> <runfiles resolution failed> )
```

from larger log of 

```
link_node_modules.js] createSymlinkAndPreserveContents( @angular/upgrade )
[link_node_modules.js] symlink( @angular/upgrade__linker_tmp -> <runfiles resolution failed> )
[link_node_modules.js] symlink( @angular/compiler-cli/src/ngtsc/testing -> C:/users/gmago/_bazel_greg/qn75o2gq/execroot/angular/bazel-out/x64_windows-fastbuild/bin/packages/compiler-cli/src/ngtsc/testing )
[link_node_modules.js] Removing existing module so that new link can take place ( @angular/upgrade )
[link_node_modules.js] unlink( @angular/upgrade )
[link_node_modules.js] Deleting children of @angular/upgrade
[link_node_modules.js] Deleting children of @angular\upgrade\src
[link_node_modules.js] Cleaning up dir @angular\upgrade\src
[link_node_modules.js] Cleaning up dir @angular/upgrade
[link_node_modules.js] An error has been reported: [Error: ENOENT: no such file or directory, rename 'C:\users\gmago\_bazel_greg\qn75o2gq\external\npm\node_modules\@angular\upgrade__linker_tmp' -> 'C:\users\gmago\_bazel_greg\qn75o2gq\external\npm\node_modules\@angular\upgrade'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'rename',
  path: 'C:\\users\\gmago\\_bazel_greg\\qn75o2gq\\external\\npm\\node_modules\\@angular\\upgrade__linker_tmp',
  dest: 'C:\\users\\gmago\\_bazel_greg\\qn75o2gq\\external\\npm\\node_modules\\@angular\\upgrade'
} Error: ENOENT: no such file or directory, rename 'C:\users\gmago\_bazel_greg\qn75o2gq\external\npm\node_modules\@angular\upgrade__linker_tmp' -> 'C:\users\gmago\_bazel_greg\qn75o2gq\external\npm\node_modules\@angular\upgrade'
```
