### PR TITLE
fix: linker fix for invalid symlink creation path in createSymlinkAndPreserveContents

### DIFF
--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -108,18 +108,6 @@ async function deleteDirectory(p: string) {
 async function symlink(target: string, p: string): Promise<boolean> {
   log_verbose(`symlink( ${p} -> ${target} )`);
 
-  // Check if the target exists before creating the symlink.
-  // This is an extra filesystem access on top of the symlink but
-  // it is necessary for the time being.
-  if (!await exists(target)) {
-    // This can happen if a module mapping is propogated from a dependency
-    // but the target that generated the mapping in not in the deps. We don't
-    // want to create symlinks to non-existant targets as this will
-    // break any nested symlinks that may be created under the module name
-    // after this.
-    return false;
-  }
-
   // Use junction on Windows since symlinks require elevated permissions.
   // We only link to directories so junctions work for us.
   try {
@@ -714,7 +702,7 @@ export async function main(args: string[], runfiles: Runfiles) {
 
     if (m.link) {
       const [root, modulePath] = m.link;
-      let target: string = '<package linking failed>';
+      let target: string|undefined;
       switch (root) {
         case 'execroot':
           if (isExecroot) {
@@ -749,13 +737,13 @@ export async function main(args: string[], runfiles: Runfiles) {
                 throw e;
               }
             }
-          } catch {
-            target = '<runfiles resolution failed>';
+          } catch (err) {
+            target = undefined;
+            log_verbose(`runfiles resolve failed for module '${m.name}': ${err.message}`);
           }
           break;
       }
 
-      const stats = await gracefulLstat(m.name);
       // In environments where runfiles are not symlinked (e.g. Windows), existing linked
       // modules are preserved. This could cause issues when a link is created at higher level
       // as a conflicting directory is already on disk. e.g. consider in a previous run, we
@@ -764,10 +752,33 @@ export async function main(args: string[], runfiles: Runfiles) {
       // already exists. To ensure that the desired link is generated, we create the new desired
       // link and move all previous nested links from the old module into the new link. Read more
       // about this in the description of `createSymlinkAndPreserveContents`.
-      if (stats !== null && await isLeftoverDirectoryFromLinker(stats, m.name)) {
-        await createSymlinkAndPreserveContents(stats, m.name, target);
+      const stats = await gracefulLstat(m.name);
+      const isLeftOver = (stats !== null && await isLeftoverDirectoryFromLinker(stats, m.name));
+
+      // Check if the target exists before creating the symlink.
+      // This is an extra filesystem access on top of the symlink but
+      // it is necessary for the time being.
+      if (target && await exists(target)) {
+        if (stats !== null && isLeftOver) {
+          await createSymlinkAndPreserveContents(stats, m.name, target);
+        } else {
+          await symlink(target, m.name);
+        }
       } else {
-        await symlink(target, m.name);
+        if (!target) {
+          log_verbose(`no symlink target found for module ${m.name}`);
+        } else {
+          // This can happen if a module mapping is propogated from a dependency
+          // but the target that generated the mapping in not in the deps. We don't
+          // want to create symlinks to non-existant targets as this will
+          // break any nested symlinks that may be created under the module name
+          // after this.
+          log_verbose(`potential target ${target} does not exists for module ${m.name}`);
+        }
+        if (isLeftOver) {
+          // Remove left over directory if it exists
+          await unlink(m.name);
+        }
       }
     }
 


### PR DESCRIPTION
2.x branch version of https://github.com/bazelbuild/rules_nodejs/pull/2421