### PR TITLE
fix(builtin): only generate a .tar pkg_npm output when requested

### DIFF
--- a/internal/pkg_npm/test/tgz_out/BUILD.bazel
+++ b/internal/pkg_npm/test/tgz_out/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+
+pkg_npm(
+    name = "pkg",
+    srcs = [
+        "main.js",
+        "package.json",
+    ],
+    tgz = "my_tar.tgz",
+)
+
+sh_test(
+    name = "pkg_test",
+    size = "small",
+    srcs = [
+        "test.sh",
+    ],
+    data = [
+        "my_tar.tgz",
+        "//third_party/github.com/bazelbuild/bazel-skylib:tests/unittest.bash",
+    ],
+    # Disabled on windows due to how tar interprets the colons in file paths as remotes, and the --force-local
+    # only being an option in GNU tar...
+    # This feature has additional coverage as it used by all bazel tests for examples
+    tags = [
+        "fix-windows",
+    ],
+    deps = [
+        "@build_bazel_rules_nodejs//third_party/github.com/bazelbuild/bazel/tools/bash/runfiles",
+    ],
+)

--- a/internal/pkg_npm/test/tgz_out/main.js
+++ b/internal/pkg_npm/test/tgz_out/main.js
@@ -1,0 +1,1 @@
+export const MAIN = 'MAIN';

--- a/internal/pkg_npm/test/tgz_out/package.json
+++ b/internal/pkg_npm/test/tgz_out/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "awesome-package",
+    "private": true,
+    "version": "0.0.0-PLACEHOLDER"
+}

--- a/internal/pkg_npm/test/tgz_out/test.sh
+++ b/internal/pkg_npm/test/tgz_out/test.sh
@@ -1,0 +1,23 @@
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=build_bazel_rules_nodejs/third_party/github.com/bazelbuild/bazel/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+source "$(rlocation build_bazel_rules_nodejs/third_party/github.com/bazelbuild/bazel-skylib/tests/unittest.bash)" \
+  || { echo "Could not source build_bazel_rules_nodejs/third_party/github.com/bazelbuild/bazel-skylib/tests/unittest.bash" >&2; exit 1; }
+
+function test_tgz_package_json() {
+    TGZ=$(rlocation build_bazel_rules_nodejs/internal/pkg_npm/test/tgz_out/my_tar.tgz)
+    tar -vxf "${TGZ}"
+    
+    assert_contains "awesome-package" "./package/package.json"
+    assert_contains "MAIN" "./package/main.js"
+}
+
+run_suite "test_tgz_package_json"

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -55,8 +55,12 @@ def pkg_npm(**kwargs):
         "0.0.0-PLACEHOLDER": "{STABLE_BUILD_SCM_VERSION}",
     })
 
+    name = kwargs.pop("name")
+
     # Call through to the rule with our defaults set
     _pkg_npm(
+        name = name,
+        tgz = "%s.tgz" % name,
         deps = deps,
         substitutions = select({
             "@build_bazel_rules_nodejs//internal:stamp": stamped_substitutions,


### PR DESCRIPTION
Adds an optional attribute to the `pkg_npm` macro to generate the `.tar` target. When set, the value is used as the filename, which must end in `.tgz`. If using this, the `pkg_npm` files must include a valid `package.json` file, otherwise npm will error.