### PR TITLE
fix: forward srcs, deps and visibility of dummy_bzl_library to the filegroup when publishing

### DIFF
--- a/index.bzl
+++ b/index.bzl
@@ -49,8 +49,12 @@ js_library = _js_library
 # ANY RULES ADDED HERE SHOULD BE DOCUMENTED, see index.for_docs.bzl
 
 # Allows us to avoid a transitive dependency on bazel_skylib from leaking to users
-def dummy_bzl_library(name, **kwargs):
-    native.filegroup(name = name)
+def dummy_bzl_library(name, srcs = [], deps = [], visibility = ["//visibility:public"], **kwargs):
+    native.filegroup(
+        name = name,
+        srcs = srcs + deps,
+        visibility = visibility,
+    )
 
 # @unsorted-dict-items
 COMMON_REPLACEMENTS = {


### PR DESCRIPTION
Turns the name-only filegroup into a filegroup with sources in the published output. Visibility and deps are also forwarded.
This would allow downstream rule authors to depend on the `bzl` targets in `srcs` attributes of `bzl_library`, without imposing skylib on all users of rules_nodejs.

Slack thread context: https://bazelbuild.slack.com/archives/CA31HN1T3/p1611882849199500