### PR TITLE
fix(docs): fix regex that replaces //packages with @bazel

### DIFF
--- a/docs/Concatjs.html
+++ b/docs/Concatjs.html
@@ -357,14 +357,14 @@ concatjs_devserver(<a href="#concatjs_devserver-name">name</a>, <a href="#concat
         Defaults to precompiled go binary setup by @bazel/typescript npm package
 </code></pre></div></div>
 
-<p>Defaults to <code class="language-plaintext highlighter-rouge">@npm//@bazel/devserver:devserver</code></p>
+<p>Defaults to <code class="language-plaintext highlighter-rouge">@npm//@bazel/concatjs/devserver:devserver</code></p>
 
 <h4 id="concatjs_devserver-devserver_host">devserver_host</h4>
 
 <p>(<em><a href="https://bazel.build/docs/build-ref.html#labels">Label</a></em>): Go based devserver executable for the host platform.
             Defaults to precompiled go binary setup by @bazel/typescript npm package</p>
 
-<p>Defaults to <code class="language-plaintext highlighter-rouge">@npm//@bazel/devserver:devserver_darwin_amd64</code></p>
+<p>Defaults to <code class="language-plaintext highlighter-rouge">@npm//@bazel/concatjs/devserver:devserver_darwin_amd64</code></p>
 
 <h4 id="concatjs_devserver-entry_module">entry_module</h4>
 

--- a/docs/Concatjs.md
+++ b/docs/Concatjs.md
@@ -204,14 +204,14 @@ Defaults to `[]`
 
             Defaults to precompiled go binary setup by @bazel/typescript npm package
 
-Defaults to `@npm//@bazel/devserver:devserver`
+Defaults to `@npm//@bazel/concatjs/devserver:devserver`
 
 <h4 id="concatjs_devserver-devserver_host">devserver_host</h4>
 
 (*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>*): Go based devserver executable for the host platform.
             Defaults to precompiled go binary setup by @bazel/typescript npm package
 
-Defaults to `@npm//@bazel/devserver:devserver_darwin_amd64`
+Defaults to `@npm//@bazel/concatjs/devserver:devserver_darwin_amd64`
 
 <h4 id="concatjs_devserver-entry_module">entry_module</h4>
 

--- a/docs/Rollup.html
+++ b/docs/Rollup.html
@@ -487,7 +487,7 @@ Otherwise, the outputs are assumed to be a single file.</p>
 
 <p>(<em><a href="https://bazel.build/docs/build-ref.html#labels">Label</a></em>): Internal use only</p>
 
-<p>Defaults to <code class="language-plaintext highlighter-rouge">@npm//@bazel/bin:rollup-worker</code></p>
+<p>Defaults to <code class="language-plaintext highlighter-rouge">@npm//@bazel/rollup/bin:rollup-worker</code></p>
 
 <h4 id="rollup_bundle-silent">silent</h4>
 

--- a/docs/Rollup.md
+++ b/docs/Rollup.md
@@ -335,7 +335,7 @@ Defaults to `@npm//rollup/bin:rollup`
 
 (*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>*): Internal use only
 
-Defaults to `@npm//@bazel/bin:rollup-worker`
+Defaults to `@npm//@bazel/rollup/bin:rollup-worker`
 
 <h4 id="rollup_bundle-silent">silent</h4>
 

--- a/docs/Terser.html
+++ b/docs/Terser.html
@@ -298,7 +298,7 @@ If you want to do this, you can pass a filegroup here.</p>
 
 <p>(<em><a href="https://bazel.build/docs/build-ref.html#labels">Label</a></em>): An executable target that runs Terser</p>
 
-<p>Defaults to <code class="language-plaintext highlighter-rouge">@npm//@bazel/bin:terser</code></p>
+<p>Defaults to <code class="language-plaintext highlighter-rouge">@npm//@bazel/terser/bin:terser</code></p>
 
 
       </div>

--- a/docs/Terser.md
+++ b/docs/Terser.md
@@ -144,6 +144,6 @@ If you want to do this, you can pass a filegroup here.
 
 (*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>*): An executable target that runs Terser
 
-Defaults to `@npm//@bazel/bin:terser`
+Defaults to `@npm//@bazel/terser/bin:terser`
 
 

--- a/docs/install.html
+++ b/docs/install.html
@@ -194,8 +194,8 @@ containing:</p>
 <div class="language-python highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="n">load</span><span class="p">(</span><span class="s">"@bazel_tools//tools/build_defs/repo:http.bzl"</span><span class="p">,</span> <span class="s">"http_archive"</span><span class="p">)</span>
 <span class="n">http_archive</span><span class="p">(</span>
     <span class="n">name</span> <span class="o">=</span> <span class="s">"build_bazel_rules_nodejs"</span><span class="p">,</span>
-    <span class="n">sha256</span> <span class="o">=</span> <span class="s">"6142e9586162b179fdd570a55e50d1332e7d9c030efd853453438d607569721d"</span><span class="p">,</span>
-    <span class="n">urls</span> <span class="o">=</span> <span class="p">[</span><span class="s">"https://github.com/bazelbuild/rules_nodejs/releases/download/3.0.0/rules_nodejs-3.0.0.tar.gz"</span><span class="p">],</span>
+    <span class="n">sha256</span> <span class="o">=</span> <span class="s">"dd4dc46066e2ce034cba0c81aa3e862b27e8e8d95871f567359f7a534cccb666"</span><span class="p">,</span>
+    <span class="n">urls</span> <span class="o">=</span> <span class="p">[</span><span class="s">"https://github.com/bazelbuild/rules_nodejs/releases/download/3.1.0/rules_nodejs-3.1.0.tar.gz"</span><span class="p">],</span>
 <span class="p">)</span>
 
 <span class="n">load</span><span class="p">(</span><span class="s">"@build_bazel_rules_nodejs//:index.bzl"</span><span class="p">,</span> <span class="s">"node_repositories"</span><span class="p">)</span>

--- a/packages/terser/index.js
+++ b/packages/terser/index.js
@@ -165,8 +165,12 @@ function main() {
     // If necessary, get the new `terser` binary, added for >=4.3.0
     terserBinary = terserBinary || require.resolve('terser/bin/terser');
   } catch (e) {
-    // If necessary, get the old `uglifyjs` binary from <4.3.0
-    terserBinary = terserBinary || require.resolve('terser/bin/uglifyjs');
+    try {
+      // If necessary, get the old `uglifyjs` binary from <4.3.0
+      terserBinary = terserBinary || require.resolve('terser/bin/uglifyjs');
+    } catch (e) {
+      throw new Error('terser binary not found. Maybe you need to set the terser_bin attribute?')
+    }
   }
   // choose a default concurrency of the number of cores -1 but at least 1.
 

--- a/tools/stardoc/post-process-docs.js
+++ b/tools/stardoc/post-process-docs.js
@@ -7,11 +7,10 @@ const content = readFileSync(md, {encoding: 'utf8'});
 // @npm is not the required name, but it seems to be the common case
 // this reflects the similar transformation made when publishing the packages to npm
 // via pkg_npm defined in //tools:defaults.bzl
-const out = content
-  .replace(/(?:@.*)*?\/\/packages\/([^:"\s]*)/g, (str, pkg) => {
-    const parts = pkg.split('/');
-    return `@npm//@bazel/${parts[parts.length - 1]}`;
-  });
+const out = content.replace(/(?:@.*)*?\/\/packages\/([^/:"\s]*)/g, (str, pkg) => {
+  const parts = pkg.split('/');
+  return `@npm//@bazel/${parts[parts.length - 1]}`;
+});
 
 // stamp the frontmatter into the post processed stardoc HTML
 const frontmatter = [  


### PR DESCRIPTION
It was producing wrong outputs that dropped one path segment.
Also add a better error if the terser_bin attribute is missing (when not in a repo named @npm)
