### PR TITLE
Ensure using the nodejs source-map support

### DIFF
--- a/internal/node/require_patch.js
+++ b/internal/node/require_patch.js
@@ -491,7 +491,7 @@ module.constructor._resolveFilename =
 try {
   const sourcemap_support_package = path.resolve(
       process.cwd(), '../build_bazel_rules_nodejs/third_party/github.com/source-map-support');
-  require(sourcemap_support_package).install();
+  require(sourcemap_support_package).install({ environment: 'node' });
 } catch (_) {
   log_verbose(`WARNING: source-map-support module not installed.
     Stack traces from languages like TypeScript will point to generated .js files.`);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [X] Other... Please describe:

Performance enhancement

## What is the current behavior?

Issue Number: N/A


## What is the new behavior?


When using libraries like js-dom that provide a browser-like api inside nodejs, the source map support can be tricked into thinking that it is running in a browsers, which will attempt to use `XMLHttpRequest` instead of `require('fs')`. Depending on implementation of the XMLHttpRequest (presumably loaded by js-dom or alternative), this can be much slower to load source maps from disk, causing a higher latency run of nodejs. 

Even if the user is using a browser-like experience within nodejs, the nodejs implementation of source map support should always be superior, thus we should hint to the source map support to always use the nodejs fs module to load source maps. 

For me, I noticed this slow down in test runs, and found an 80% speedup across some runs. Other's mileage may vary.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


