### PR TITLE
docs(rollup): mention including the rollup library in devDependencies

### DIFF
--- a/docs/Rollup.md
+++ b/docs/Rollup.md
@@ -17,7 +17,7 @@ The Rollup rules run the [rollup.js](https://rollupjs.org/) bundler with Bazel.
 
 ## Installation
 
-Add the `@bazel/rollup` npm package to your `devDependencies` in `package.json`.
+Add the `@bazel/rollup` npm package to your `devDependencies` in `package.json`. (`rollup` itself should also be included in `devDependencies`, unless you plan on providing it via a custom target.)
 
 
 ### Installing with user-managed dependencies

--- a/packages/rollup/install.md
+++ b/packages/rollup/install.md
@@ -4,7 +4,7 @@ The Rollup rules run the [rollup.js](https://rollupjs.org/) bundler with Bazel.
 
 ## Installation
 
-Add the `@bazel/rollup` npm package to your `devDependencies` in `package.json`.
+Add the `@bazel/rollup` npm package to your `devDependencies` in `package.json`. (`rollup` itself should also be included in `devDependencies`, unless you plan on providing it via a custom target.)
 
 ### Installing with user-managed dependencies
 


### PR DESCRIPTION
This is a possible docs update to mention including `rollup` itself as a dev dependency, since I ran into errors when I tried to use the rollup rules without having the `rollup` library itself installed.