### PR TITLE
fix(typescript): fixed build for external ts_project targets

### DIFF
--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -91,6 +91,7 @@ def _calculate_root_dir(ctx):
 
     return _join(
         root_path,
+        ctx.label.workspace_root,
         ctx.label.package,
         ctx.attr.root_dir,
     )
@@ -115,7 +116,7 @@ def _ts_project_impl(ctx):
         "--project",
         ctx.file.tsconfig.path,
         "--outDir",
-        _join(ctx.bin_dir.path, ctx.label.package, ctx.attr.out_dir),
+        _join(ctx.bin_dir.path, ctx.label.workspace_root, ctx.label.package, ctx.attr.out_dir),
         "--rootDir",
         _calculate_root_dir(ctx),
     ])
@@ -123,7 +124,7 @@ def _ts_project_impl(ctx):
         declaration_dir = ctx.attr.declaration_dir if ctx.attr.declaration_dir else ctx.attr.out_dir
         arguments.add_all([
             "--declarationDir",
-            _join(ctx.bin_dir.path, ctx.label.package, declaration_dir),
+            _join(ctx.bin_dir.path, ctx.label.workspace_root, ctx.label.package, declaration_dir),
         ])
 
     # When users report problems, we can ask them to re-build with


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When the user tries to build the `ts_project` target from external repositories, the build will fail with the message that the `rootDir` is not configured correctly and some source files are missing.

```
» bazel build //demo/openapi/ui:ts_default_project
(08:57:00) INFO: Invocation ID: 659b8763-ef47-4764-a3e3-d218cad6f4ec
(08:57:00) INFO: Current date is 2021-02-11
(08:57:21) INFO: Analyzed target //demo/openapi/ui:ts_default_project (698 packages loaded, 25793 targets configured).
(08:57:21) INFO: Found 1 target...
(08:57:43) ERROR: /private/var/tmp/_bazel_antonignatov/763a2cabf15dec26eb96cb2ab1f1b9f8/external/org_bitbucket_projectplato_frontlib/lib/BUILD.bazel:21:11: Compiling TypeScript project @org_bitbucket_projectplato_frontlib//lib:ts_default_project [tsc -p ../org_bitbucket_projectplato_frontlib/lib/tsconfig.project.json] failed (Exit 2): tsc.sh failed: error executing command bazel-out/darwin-py2-dbg/bin/external/npm/typescript/bin/tsc.sh --project external/org_bitbucket_projectplato_frontlib/lib/tsconfig.project.json --outDir bazel-out/darwin-py2-dbg/bin/lib --rootDir lib ... (remaining 3 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox tsc.sh failed: error executing command bazel-out/darwin-py2-dbg/bin/external/npm/typescript/bin/tsc.sh --project external/org_bitbucket_projectplato_frontlib/lib/tsconfig.project.json --outDir bazel-out/darwin-py2-dbg/bin/lib --rootDir lib ... (remaining 3 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
error TS6059: File '/private/var/tmp/_bazel_antonignatov/763a2cabf15dec26eb96cb2ab1f1b9f8/sandbox/darwin-sandbox/29/execroot/org_bitbucket_projectplato_motor/external/org_bitbucket_projectplato_frontlib/lib/api/hooks.ts' is not under 'rootDir' '/private/var/tmp/_bazel_antonignatov/763a2cabf15dec26eb96cb2ab1f1b9f8/sandbox/darwin-sandbox/29/execroot/org_bitbucket_projectplato_motor/lib'. 'rootDir' is expected to contain all source files.
```

Issue Number: N/A


## What is the new behavior?
External `ts_project` targets builds without problems

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I didn't find any existing tests for external repositories and I'm not sure how to cover the broken use case. If adding a test is mandatory, I would need a help