### PR TITLE
docs: bump version in selector to 3.x

### DIFF
--- a/docs/Built-ins.html
+++ b/docs/Built-ins.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/Built-ins.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/Built-ins.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/Built-ins.html">2.3</option>
     </select>
 

--- a/docs/Concatjs.html
+++ b/docs/Concatjs.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/Concatjs.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/Concatjs.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/Concatjs.html">2.3</option>
     </select>
 

--- a/docs/Cypress.html
+++ b/docs/Cypress.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/Cypress.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/Cypress.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/Cypress.html">2.3</option>
     </select>
 

--- a/docs/Jasmine.html
+++ b/docs/Jasmine.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/Jasmine.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/Jasmine.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/Jasmine.html">2.3</option>
     </select>
 

--- a/docs/Labs.html
+++ b/docs/Labs.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/Labs.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/Labs.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/Labs.html">2.3</option>
     </select>
 

--- a/docs/Protractor.html
+++ b/docs/Protractor.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/Protractor.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/Protractor.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/Protractor.html">2.3</option>
     </select>
 

--- a/docs/Rollup.html
+++ b/docs/Rollup.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/Rollup.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/Rollup.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/Rollup.html">2.3</option>
     </select>
 

--- a/docs/Terser.html
+++ b/docs/Terser.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/Terser.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/Terser.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/Terser.html">2.3</option>
     </select>
 

--- a/docs/TypeScript.html
+++ b/docs/TypeScript.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/TypeScript.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/TypeScript.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/TypeScript.html">2.3</option>
     </select>
 

--- a/docs/_includes/sidenav.html
+++ b/docs/_includes/sidenav.html
@@ -7,8 +7,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="{{ page.url | relative_url }}">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="{{ page.url | relative_url }}">3.x</option>
       <option value="https://docs.aspect.dev{{ page.url | relative_url }}">2.3</option>
     </select>
 

--- a/docs/changing-rules.html
+++ b/docs/changing-rules.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/changing-rules.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/changing-rules.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/changing-rules.html">2.3</option>
     </select>
 

--- a/docs/debugging.html
+++ b/docs/debugging.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/debugging.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/debugging.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/debugging.html">2.3</option>
     </select>
 

--- a/docs/dependencies.html
+++ b/docs/dependencies.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/dependencies.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/dependencies.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/dependencies.html">2.3</option>
     </select>
 

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/examples.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/examples.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/examples.html">2.3</option>
     </select>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/">2.3</option>
     </select>
 

--- a/docs/install.html
+++ b/docs/install.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/install.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/install.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/install.html">2.3</option>
     </select>
 

--- a/docs/repositories.html
+++ b/docs/repositories.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/repositories.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/repositories.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/repositories.html">2.3</option>
     </select>
 

--- a/docs/stamping.html
+++ b/docs/stamping.html
@@ -78,8 +78,8 @@
 
   <nav class="sidebar collapse" id="sidebar-nav">
     <select onchange="location.href=this.value">
-      <option selected disabled hidden>Version: 3.0</option>
-      <option value="/rules_nodejs/stamping.html">3.0</option>
+      <option selected disabled hidden>Version: 3.x</option>
+      <option value="/rules_nodejs/stamping.html">3.x</option>
       <option value="https://docs.aspect.dev/rules_nodejs/stamping.html">2.3</option>
     </select>
 


### PR DESCRIPTION
Sets the version in the currently published docs and includes to show version 3.x in the version selector