### PR TITLE
chore: bump clang-format version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@types/semver": "6.2.0",
         "babel-jest": "^25.5.1",
         "bazel_workspaces_consistent": "file:./tools/npm_packages/bazel_workspaces_consistent",
-        "clang-format": "1.2.2",
+        "clang-format": "1.5.0",
         "conventional-changelog-cli": "^2.0.21",
         "core-util-is": "^1.0.2",
         "date-fns": "1.30.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2703,10 +2703,10 @@ cidr-regex@^2.0.10:
   dependencies:
     ip-regex "^2.1.0"
 
-clang-format@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.2.2.tgz#a7277a03fce9aa4e387ddaa83b60d99dab115737"
-  integrity sha512-6X9u1JBMak/9VbC0IZajEDvp19/PbjCanbRO3Z2xsluypQtbPPAGDvGGovLOWoUpXIvJH9vJExmzlqWvwItZxA==
+clang-format@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.5.0.tgz#1bd4c47b66a1a02556b192b93f5505e7ccec84fb"
+  integrity sha512-C1LucFX7E+ABVYcPEbBHM4PYQ2+WInXsqsLpFlQ9cmRfSbk7A7b1I06h/nE4bQ3MsyEkb31jY2gC0Dtc76b4IA==
   dependencies:
     async "^1.5.2"
     glob "^7.0.0"


### PR DESCRIPTION
Bumps the clang-format version used for formatting. While doing the docs work, the previous version does not handle the `??` operator within arrow functions correctly and produces broken code after formatting, this version fixes that.