### PR TITLE
fix: use ':' instead of '=' for esbuild 'define' argument

### DIFF
--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -49,7 +49,7 @@ def _esbuild_impl(ctx):
     args.add_joined(["--target", ctx.attr.target], join_with = "=")
     args.add_joined(["--log-level", "info"], join_with = "=")
     args.add_joined(["--metafile", metafile.path], join_with = "=")
-    args.add_all(ctx.attr.define, format_each = "--define=%s")
+    args.add_all(ctx.attr.define, format_each = "--define:%s")
     args.add_all(ctx.attr.external, format_each = "--external=%s")
 
     # disable the error limit and show all errors

--- a/packages/esbuild/test/define/BUILD.bazel
+++ b/packages/esbuild/test/define/BUILD.bazel
@@ -1,0 +1,28 @@
+load("//packages/esbuild/test:tests.bzl", "esbuild")
+load("//packages/jasmine:index.bzl", "jasmine_node_test")
+load("//packages/typescript:index.bzl", "ts_library")
+
+ts_library(
+    name = "main",
+    srcs = [
+        "main.ts",
+    ],
+    deps = [
+        "@npm//@types/node",
+    ],
+)
+
+esbuild(
+    name = "bundle",
+    define = [
+        "process.env.NODE_ENV=\"defined_in_bundle\"",
+    ],
+    entry_point = "main.ts",
+    deps = [":main"],
+)
+
+jasmine_node_test(
+    name = "bundle_test",
+    srcs = ["bundle_test.js"],
+    data = [":bundle"],
+)

--- a/packages/esbuild/test/define/bundle_test.js
+++ b/packages/esbuild/test/define/bundle_test.js
@@ -1,0 +1,11 @@
+const {readFileSync} = require('fs');
+
+const helper = require(process.env.BAZEL_NODE_RUNFILES_HELPER);
+const location = helper.resolve('build_bazel_rules_nodejs/packages/esbuild/test/define/bundle.js');
+
+describe('esbuild define', () => {
+  it('defines variables', () => {
+    const bundle = readFileSync(location, {encoding: 'utf8'});
+    expect(bundle).toContain(`nodeEnv = "defined_in_bundle"`);
+  });
+})

--- a/packages/esbuild/test/define/main.ts
+++ b/packages/esbuild/test/define/main.ts
@@ -1,0 +1,1 @@
+export const nodeEnv = process.env.NODE_ENV;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`esbuild` passes global definitions as `--define=the_var=value` instead of `--define:the_var=value` [as documented](https://esbuild.github.io/api/#define).
Issue Number: N/A


## What is the new behavior?
Pass global definitions as `--define:the_var=value`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

