### PR TITLE
docs: export esbuild rule for docs

### DIFF
--- a/packages/esbuild/BUILD.bazel
+++ b/packages/esbuild/BUILD.bazel
@@ -38,7 +38,7 @@ stardoc(
     name = "docs",
     testonly = True,
     out = "index.md",
-    input = "index.bzl",
+    input = "index.docs.bzl",
     tags = ["fix-windows"],
     deps = [":bzl"],
 )

--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -105,7 +105,7 @@ def _esbuild_impl(ctx):
         DefaultInfo(files = depset(outputs + [jsconfig_file])),
     ]
 
-_esbuild = rule(
+esbuild = rule(
     attrs = {
         "args": attr.string_list(
             default = [],
@@ -236,13 +236,13 @@ def esbuild_macro(name, output_dir = False, **kwargs):
     """
 
     if output_dir == True:
-        _esbuild(
+        esbuild(
             name = name,
             output_dir = True,
             **kwargs
         )
     else:
-        _esbuild(
+        esbuild(
             name = name,
             output = "%s.js" % name,
             output_map = "%s.js.map" % name,

--- a/packages/esbuild/index.docs.bzl
+++ b/packages/esbuild/index.docs.bzl
@@ -1,0 +1,12 @@
+"""This contains references to the symbols we want documented.
+"""
+
+load(
+    "@build_bazel_rules_nodejs//packages/esbuild:esbuild.bzl",
+    _esbuild = "esbuild",
+)
+
+esbuild = _esbuild
+
+# DO NOT ADD MORE rules here unless they appear in the generated docsite.
+# Run yarn stardoc to re-generate the docsite.


### PR DESCRIPTION
The current esbuild doc pages only shows the wrapper macro and not the full rule. This change exports the rule under the `index.docs.bzl` pattern ready to be picked up on the next publish