### PR TITLE
fix: use ':' instead of '=' for esbuild 'external' argument

### DIFF
--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -50,7 +50,7 @@ def _esbuild_impl(ctx):
     args.add_joined(["--log-level", "info"], join_with = "=")
     args.add_joined(["--metafile", metafile.path], join_with = "=")
     args.add_all(ctx.attr.define, format_each = "--define:%s")
-    args.add_all(ctx.attr.external, format_each = "--external=%s")
+    args.add_all(ctx.attr.external, format_each = "--external:%s")
 
     # disable the error limit and show all errors
     args.add_joined(["--error-limit", "0"], join_with = "=")

--- a/packages/esbuild/test/external-flag/BUILD.bazel
+++ b/packages/esbuild/test/external-flag/BUILD.bazel
@@ -1,0 +1,28 @@
+load("//packages/esbuild/test:tests.bzl", "esbuild")
+load("//packages/jasmine:index.bzl", "jasmine_node_test")
+load("//packages/typescript:index.bzl", "ts_library")
+
+ts_library(
+    name = "main",
+    srcs = [
+        "main.ts",
+    ],
+    deps = [
+        "@npm//@types/node",
+    ],
+)
+
+esbuild(
+    name = "bundle",
+    entry_point = "main.ts",
+    external = [
+        "fs",
+    ],
+    deps = [":main"],
+)
+
+jasmine_node_test(
+    name = "bundle_test",
+    srcs = ["bundle_test.js"],
+    data = [":bundle"],
+)

--- a/packages/esbuild/test/external-flag/bundle_test.js
+++ b/packages/esbuild/test/external-flag/bundle_test.js
@@ -1,0 +1,12 @@
+const {readFileSync} = require('fs');
+
+const helper = require(process.env.BAZEL_NODE_RUNFILES_HELPER);
+const location =
+    helper.resolve('build_bazel_rules_nodejs/packages/esbuild/test/external-flag/bundle.js');
+
+describe('esbuild external-flag', () => {
+  it('compiles with the external module \'fs\'', () => {
+    const bundle = readFileSync(location, {encoding: 'utf8'});
+    expect(bundle).toContain('console.log(fs)');
+  });
+})

--- a/packages/esbuild/test/external-flag/main.ts
+++ b/packages/esbuild/test/external-flag/main.ts
@@ -1,0 +1,4 @@
+import * as fs from 'fs';
+
+// Prevent 'fs' from being tree-shaken.
+console.log(fs);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
esbuild passes externals as `--external=the_dependency` instead of `--external:the_dependency` [as documented](https://esbuild.github.io/api/#external).
Issue Number: N/A


## What is the new behavior?
Pass externals as `--external:the_dependency`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I named the test directory `external-flag` since I thought `external` might be confused with external dependencies.

The test uses `fs` as the external dependency and runs a Jasmine test to check if `console.log(fs)` appears in the bundle. This isn't strictly necessary since the bundle will fail to build if `fs` is not available, but I thought it would be best to have a test target in the PR. It might be more correct to check for `var fs = __toModule(require("fs"));`, but I think that may change depending on esbuild's implementation. Maybe it's safe to check for `require("fs")`. What do you think?
