### PR TITLE
fix(esbuild): add --preserve-symlinks flag by default and npm module mappings

### DIFF
--- a/examples/esbuild/WORKSPACE
+++ b/examples/esbuild/WORKSPACE
@@ -25,12 +25,12 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/3.2.0/rules_nodejs-3.2.0.tar.gz"],
 )
 
-_ESBUILD_VERSION = "0.8.34"
+_ESBUILD_VERSION = "0.8.48"
 
 http_archive(
     name = "esbuild_darwin",
     build_file_content = """exports_files(["bin/esbuild"])""",
-    sha256 = "3bf980b5175df873dd84fd614d57722f3b1b9c7e74929504e26192d23075d5c3",
+    sha256 = "d21a722873ed24586f071973b77223553fca466946f3d7e3976eeaccb14424e6",
     strip_prefix = "package",
     urls = [
         "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-%s.tgz" % _ESBUILD_VERSION,
@@ -40,7 +40,7 @@ http_archive(
 http_archive(
     name = "esbuild_windows",
     build_file_content = """exports_files(["esbuild.exe"])""",
-    sha256 = "826cd58553e7b6910dd22aba001cd72af34e05c9c3e9af567b5b2a6b1c9f3941",
+    sha256 = "fe5dcb97b4c47f9567012f0a45c19c655f3d2e0d76932f6dd12715dbebbd6eb0",
     strip_prefix = "package",
     urls = [
         "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-%s.tgz" % _ESBUILD_VERSION,
@@ -50,7 +50,7 @@ http_archive(
 http_archive(
     name = "esbuild_linux",
     build_file_content = """exports_files(["bin/esbuild"])""",
-    sha256 = "9dff3f5b06fd964a1cbb6aa9ea5ebf797767f1bd2bac71e084fb0bbefeba24a3",
+    sha256 = "60dabe141e5dfcf99e7113bded6012868132068a582a102b258fb7b1cfdac14b",
     strip_prefix = "package",
     urls = [
         "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-%s.tgz" % _ESBUILD_VERSION,

--- a/packages/esbuild/esbuild_repo.bzl
+++ b/packages/esbuild/esbuild_repo.bzl
@@ -4,7 +4,7 @@ Helper macro for fetching esbuild versions for internal tests and examples in ru
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-_VERSION = "0.8.34"
+_VERSION = "0.8.48"
 
 def esbuild_dependencies():
     """Helper to install required dependencies for the esbuild rules"""
@@ -18,7 +18,7 @@ def esbuild_dependencies():
         ],
         strip_prefix = "package",
         build_file_content = """exports_files(["bin/esbuild"])""",
-        sha256 = "3bf980b5175df873dd84fd614d57722f3b1b9c7e74929504e26192d23075d5c3",
+        sha256 = "d21a722873ed24586f071973b77223553fca466946f3d7e3976eeaccb14424e6",
     )
 
     http_archive(
@@ -28,7 +28,7 @@ def esbuild_dependencies():
         ],
         strip_prefix = "package",
         build_file_content = """exports_files(["esbuild.exe"])""",
-        sha256 = "826cd58553e7b6910dd22aba001cd72af34e05c9c3e9af567b5b2a6b1c9f3941",
+        sha256 = "fe5dcb97b4c47f9567012f0a45c19c655f3d2e0d76932f6dd12715dbebbd6eb0",
     )
 
     http_archive(
@@ -38,5 +38,5 @@ def esbuild_dependencies():
         ],
         strip_prefix = "package",
         build_file_content = """exports_files(["bin/esbuild"])""",
-        sha256 = "9dff3f5b06fd964a1cbb6aa9ea5ebf797767f1bd2bac71e084fb0bbefeba24a3",
+        sha256 = "60dabe141e5dfcf99e7113bded6012868132068a582a102b258fb7b1cfdac14b",
     )

--- a/packages/esbuild/test/typescript/BUILD.bazel
+++ b/packages/esbuild/test/typescript/BUILD.bazel
@@ -9,9 +9,11 @@ ts_library(
     srcs = [":main.ts"],
     tsconfig = ":tsconfig.json",
     deps = [
+        "//packages/esbuild/test/typescript/generated-module",
         "//packages/esbuild/test/typescript/module-dynamic",
         "//packages/esbuild/test/typescript/module-one",
         "//packages/esbuild/test/typescript/module-two",
+        "//packages/esbuild/test/typescript/relative-module",
     ],
 )
 

--- a/packages/esbuild/test/typescript/bundle.golden.txt
+++ b/packages/esbuild/test/typescript/bundle.golden.txt
@@ -14,7 +14,6 @@ var __commonJS = (callback, module) => () => {
   return module.exports;
 };
 var __exportStar = (target, module, desc) => {
-  __markAsModule(target);
   if (module && typeof module === "object" || typeof module === "function") {
     for (let key of __getOwnPropNames(module))
       if (!__hasOwnProp.call(target, key) && key !== "default")
@@ -25,7 +24,7 @@ var __exportStar = (target, module, desc) => {
 var __toModule = (module) => {
   if (module && module.__esModule)
     return module;
-  return __exportStar(__defProp(module != null ? __create(__getProtoOf(module)) : {}, "default", {value: module, enumerable: true}), module);
+  return __exportStar(__markAsModule(__defProp(module != null ? __create(__getProtoOf(module)) : {}, "default", {value: module, enumerable: true})), module);
 };
 
 
@@ -55,8 +54,15 @@ var getId = /* @__PURE__ */ __name(() => "module-one", "getId");
 var getId2 = /* @__PURE__ */ __name(() => "module-two", "getId");
 
 
-var main_default = `Full ID: ${getId} - ${getId2} - ${import_module_dynamic.getId}`;
+var getId3 = /* @__PURE__ */ __name(() => `generated-module`, "getId");
+
+
+var getId4 = /* @__PURE__ */ __name(() => "relative-module", "getId");
+
+
+var ID = `Full ID: ${getId()} - ${getId2()} - ${import_module_dynamic.getId()} - ${getId4()} - ${getId3()}`;
+console.log(ID);
 export {
-  main_default as default
+  ID
 };
 //# sourceMappingURL=bundle.js.map

--- a/packages/esbuild/test/typescript/generated-module/BUILD.bazel
+++ b/packages/esbuild/test/typescript/generated-module/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//packages/typescript:index.bzl", "ts_library")
+
+package(default_visibility = ["//packages/esbuild/test:__subpackages__"])
+
+genrule(
+    name = "lib",
+    outs = ["lib.ts"],
+    cmd = "echo 'export const getId = () => `generated-module`;' > $@",
+)
+
+ts_library(
+    name = "generated-module",
+    srcs = ["lib.ts"],
+    tsconfig = "//packages/esbuild/test/typescript:tsconfig.json",
+)

--- a/packages/esbuild/test/typescript/main.ts
+++ b/packages/esbuild/test/typescript/main.ts
@@ -2,4 +2,9 @@ import {getId as mdyn} from '@typescript/module-dynamic';
 import {getId as m1Id} from '@typescript/module-one';
 import {getId as m2Id} from '@typescript/module-two';
 
-export default `Full ID: ${m1Id} - ${m2Id} - ${mdyn}`;
+import {getId as mGenId} from './generated-module/lib';
+import {getId as mRelId} from './relative-module/lib';
+
+export const ID = `Full ID: ${m1Id()} - ${m2Id()} - ${mdyn()} - ${mRelId()} - ${mGenId()}`;
+
+console.log(ID);

--- a/packages/esbuild/test/typescript/relative-module/BUILD.bazel
+++ b/packages/esbuild/test/typescript/relative-module/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//packages/typescript:index.bzl", "ts_library")
+
+package(default_visibility = ["//packages/esbuild/test:__subpackages__"])
+
+ts_library(
+    name = "relative-module",
+    srcs = ["lib.ts"],
+    tsconfig = "//packages/esbuild/test/typescript:tsconfig.json",
+)

--- a/packages/esbuild/test/typescript/relative-module/lib.ts
+++ b/packages/esbuild/test/typescript/relative-module/lib.ts
@@ -1,0 +1,1 @@
+export const getId = () => 'relative-module';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
It was possible for esbuild to break out of the sandbox and find the `.ts` file inputs, this could be seen if the `.ts` file was generated, as it would live in bazel-out/

This also fixes an issue where external npm modules may not have gotten resolved correctly when bundling

Issue Number: N/A

## What is the new behavior?
Bumps the tested version of esbuild and adds the `--preserve-symlinks` flag by default. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] kinda

This will require uses to bump the version of esbuild used in their projects
