### PR TITLE
fix: remove `--keep-names`

### DIFF
--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -55,7 +55,6 @@ def _esbuild_impl(ctx):
 
     args.add("--bundle", entry_point.path)
     args.add("--sourcemap")
-    args.add("--keep-names")
     args.add("--preserve-symlinks")
     args.add_joined(["--platform", ctx.attr.platform], join_with = "=")
     args.add_joined(["--target", ctx.attr.target], join_with = "=")

--- a/packages/esbuild/test/alias-mapping/BUILD.bazel
+++ b/packages/esbuild/test/alias-mapping/BUILD.bazel
@@ -3,6 +3,7 @@ load("//packages/esbuild/test:tests.bzl", "esbuild")
 
 esbuild(
     name = "bundle",
+    args = ["--keep-names"],
     entry_point = "main.js",
     format = "esm",
     deps = [

--- a/packages/esbuild/test/bundle/BUILD.bazel
+++ b/packages/esbuild/test/bundle/BUILD.bazel
@@ -16,12 +16,14 @@ ts_library(
 
 esbuild(
     name = "bundle",
+    args = ["--keep-names"],
     entry_point = "a.ts",
     deps = [":lib"],
 )
 
 esbuild(
     name = "bundle.min",
+    args = ["--keep-names"],
     entry_point = "a.ts",
     minify = True,
     deps = [":lib"],
@@ -29,6 +31,7 @@ esbuild(
 
 esbuild(
     name = "bundle.split",
+    args = ["--keep-names"],
     entry_point = "a.ts",
     output_dir = True,
     deps = [":lib"],

--- a/packages/esbuild/test/define/BUILD.bazel
+++ b/packages/esbuild/test/define/BUILD.bazel
@@ -14,6 +14,7 @@ ts_library(
 
 esbuild(
     name = "bundle",
+    args = ["--keep-names"],
     define = [
         "process.env.NODE_ENV=\"defined_in_bundle\"",
     ],

--- a/packages/esbuild/test/external-flag/BUILD.bazel
+++ b/packages/esbuild/test/external-flag/BUILD.bazel
@@ -14,6 +14,7 @@ ts_library(
 
 esbuild(
     name = "bundle",
+    args = ["--keep-names"],
     entry_point = "main.ts",
     external = [
         "fs",

--- a/packages/esbuild/test/splitting/BUILD.bazel
+++ b/packages/esbuild/test/splitting/BUILD.bazel
@@ -16,6 +16,7 @@ ts_library(
 
 esbuild(
     name = "bundle",
+    args = ["--keep-names"],
     entry_point = "main.ts",
     output_dir = True,
     deps = [":main"],

--- a/packages/esbuild/test/typescript/BUILD.bazel
+++ b/packages/esbuild/test/typescript/BUILD.bazel
@@ -19,6 +19,7 @@ ts_library(
 
 esbuild(
     name = "bundle",
+    args = ["--keep-names"],
     entry_point = "main.ts",
     format = "esm",
     deps = [":main"],

--- a/packages/esbuild/test/workspace-mapping/BUILD.bazel
+++ b/packages/esbuild/test/workspace-mapping/BUILD.bazel
@@ -3,6 +3,7 @@ load("//packages/esbuild/test:tests.bzl", "esbuild")
 
 esbuild(
     name = "bundle",
+    args = ["--keep-names"],
     entry_point = "main.js",
     format = "esm",
     link_workspace_root = True,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
This option injects a `defineProperty` to existing function to keep its names for debugging purposes. 
```js
function foo () {}
Object.defineProperty(foo, 'name', {value: 'foo'})
```
This however breaks older browsers since you cannot re-define a function name.

## What is the new behavior?
`defineProperty` for name is no longer injected

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Reference fix upstream: https://github.com/formatjs/formatjs/commit/450d3047cdffbb64a86a31240999b7f4248908db
