### PR TITLE
Update esbuild version in docs

### DIFF
--- a/packages/esbuild/_README.md
+++ b/packages/esbuild/_README.md
@@ -17,8 +17,9 @@ yarn add -D @bazel/esbuild
 
 Add an `http_archive` fetching the esbuild binary for each platform that you need to support. 
 
+<!-- IMPORTANT: Keep this in sync with ./esbuild_repo.bzl -->
 ```python
-_ESBUILD_VERSION = "0.8.48"
+_ESBUILD_VERSION = "0.8.48"  # reminder: update SHAs below when changing this value
 http_archive(
     name = "esbuild_darwin",
     urls = [

--- a/packages/esbuild/_README.md
+++ b/packages/esbuild/_README.md
@@ -18,7 +18,7 @@ yarn add -D @bazel/esbuild
 Add an `http_archive` fetching the esbuild binary for each platform that you need to support. 
 
 ```python
-_ESBUILD_VERSION = "0.8.34"
+_ESBUILD_VERSION = "0.8.48"
 http_archive(
     name = "esbuild_darwin",
     urls = [
@@ -26,7 +26,7 @@ http_archive(
     ],
     strip_prefix = "package",
     build_file_content = """exports_files(["bin/esbuild"])""",
-    sha256 = "3bf980b5175df873dd84fd614d57722f3b1b9c7e74929504e26192d23075d5c3",
+    sha256 = "d21a722873ed24586f071973b77223553fca466946f3d7e3976eeaccb14424e6",
 )
 
 http_archive(
@@ -36,7 +36,7 @@ http_archive(
     ],
     strip_prefix = "package",
     build_file_content = """exports_files(["esbuild.exe"])""",
-    sha256 = "826cd58553e7b6910dd22aba001cd72af34e05c9c3e9af567b5b2a6b1c9f3941",
+    sha256 = "fe5dcb97b4c47f9567012f0a45c19c655f3d2e0d76932f6dd12715dbebbd6eb0",
 )
 
 http_archive(
@@ -46,7 +46,7 @@ http_archive(
     ],
     strip_prefix = "package",
     build_file_content = """exports_files(["bin/esbuild"])""",
-    sha256 = "9dff3f5b06fd964a1cbb6aa9ea5ebf797767f1bd2bac71e084fb0bbefeba24a3",
+    sha256 = "60dabe141e5dfcf99e7113bded6012868132068a582a102b258fb7b1cfdac14b",
 )
 ```
 

--- a/packages/esbuild/_README.md
+++ b/packages/esbuild/_README.md
@@ -17,7 +17,6 @@ yarn add -D @bazel/esbuild
 
 Add an `http_archive` fetching the esbuild binary for each platform that you need to support. 
 
-<!-- IMPORTANT: Keep this in sync with ./esbuild_repo.bzl -->
 ```python
 _ESBUILD_VERSION = "0.8.48"  # reminder: update SHAs below when changing this value
 http_archive(

--- a/packages/esbuild/esbuild_repo.bzl
+++ b/packages/esbuild/esbuild_repo.bzl
@@ -4,7 +4,9 @@ Helper macro for fetching esbuild versions for internal tests and examples in ru
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-_VERSION = "0.8.48"
+# IMPORTANT: Keep this file in sync with the documentation in _README.md
+
+_VERSION = "0.8.48"  # reminder: update SHAs below when changing this version
 
 def esbuild_dependencies():
     """Helper to install required dependencies for the esbuild rules"""


### PR DESCRIPTION
* Sync the esbuild version in the docs so that it matches the deps file. The version mentioned in the README did not support the `--preserve-symlinks` flag, which looks like it is required by the latest version of these esbuild rules (I got a build error stating that `--preserve-symlinks` was not a valid flag)
* Add reminders to keep these docs in sync
* Also add reminders to bump SHAs -- I tried bumping the esbuild version, and forgot to update the SHAs, but this resulted in Bazel silently using the old archive. (BTW, instead of using the `_ESBUILD_VERSION` variable, I think it might be better to hard-code the full URLs without string interpolation, so that the SHA is right in your face as you're updating the URL, and you immediately think "ah right, I need to update the SHA too." -- WDYT?)

