### PR TITLE
Add es2019 and es2020 script targets

### DIFF
--- a/packages/typescript/internal/build_defs.bzl
+++ b/packages/typescript/internal/build_defs.bzl
@@ -32,7 +32,7 @@ _TYPESCRIPT_TYPINGS = Label(
     "//typescript:typescript__typings",
 )
 
-_TYPESCRIPT_SCRIPT_TARGETS = ["es3", "es5", "es2015", "es2016", "es2017", "es2018", "esnext"]
+_TYPESCRIPT_SCRIPT_TARGETS = ["es3", "es5", "es2015", "es2016", "es2017", "es2018", "es2019", "es2020", "esnext"]
 _TYPESCRIPT_MODULE_KINDS = ["none", "commonjs", "amd", "umd", "system", "es2015", "esnext"]
 
 _DEVMODE_TARGET_DEFAULT = "es2015"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

"es2019" and  "es2020" are not listed in the list of available targets, and bazel returns the following error message
> invalid value in 'devmode_target' attribute: has to be one of 'es3', 'es5', 'es2015', 'es2016', 'es2017', 'es2018' or 'esnext' instead of 'es2020'

## What is the new behavior?

Authorize "es2019" and  "es2020"

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

