### PR TITLE
fix(esbuild): run npm version check as postinstall

### DIFF
--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -13,5 +13,8 @@
   },
   "keywords": [
     "bazel"
-  ]
+  ],
+  "scripts": {
+    "postinstall": "node npm_version_check.js"
+  }
 }


### PR DESCRIPTION
Adds the missing postinstall check on the rules_nodejs versions. The script was included in the package, but not run.
closes #2493 