### PR TITLE
fix(esbuild): set correct base url when rule is at root

### DIFF
--- a/examples/esbuild/package-lock.json
+++ b/examples/esbuild/package-lock.json
@@ -1,219 +1,6 @@
 {
-    "name": "esbuild",
-    "lockfileVersion": 2,
     "requires": true,
-    "packages": {
-        "": {
-            "devDependencies": {
-                "@bazel/esbuild": "^3.2.1",
-                "@bazel/typescript": "^3.2.1",
-                "@types/node": "12.6.3",
-                "tslib": "1.9.0",
-                "typescript": "3.5.3"
-            }
-        },
-        "node_modules/@bazel/esbuild": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@bazel/esbuild/-/esbuild-3.2.1.tgz",
-            "integrity": "sha512-8Y2Vd9KMxWfL9KzF9qbrUGHJZiJsee6xpT+dUCd29zYJA9Ddu4WCeNtS24Ejbm1y3NUgGPXh1nLgTQ/yIfCYng==",
-            "dev": true
-        },
-        "node_modules/@bazel/typescript": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@bazel/typescript/-/typescript-3.2.1.tgz",
-            "integrity": "sha512-2KgMqKcbqL89WWWVC2iwTCS0tMWmQ4LpQgFhaF3Lp56Edl0nv/fy0TOu+waw2Qs2rTBbTVKhk5/9DRiqJmOd2g==",
-            "dev": true,
-            "hasInstallScript": true,
-            "dependencies": {
-                "protobufjs": "6.8.8",
-                "semver": "5.6.0",
-                "source-map-support": "0.5.9",
-                "tsutils": "2.27.2"
-            },
-            "bin": {
-                "ts_project_options_validator": "internal/ts_project_options_validator.js",
-                "tsc_wrapped": "internal/tsc_wrapped/tsc_wrapped.js"
-            },
-            "peerDependencies": {
-                "typescript": ">=3.0.0 <4.3"
-            }
-        },
-        "node_modules/@protobufjs/aspromise": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-            "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
-            "dev": true
-        },
-        "node_modules/@protobufjs/base64": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-            "dev": true
-        },
-        "node_modules/@protobufjs/codegen": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-            "dev": true
-        },
-        "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
-            "dev": true
-        },
-        "node_modules/@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
-            "dev": true,
-            "dependencies": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
-            }
-        },
-        "node_modules/@protobufjs/float": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-            "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
-            "dev": true
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-            "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
-            "dev": true
-        },
-        "node_modules/@protobufjs/path": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-            "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
-            "dev": true
-        },
-        "node_modules/@protobufjs/pool": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-            "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
-            "dev": true
-        },
-        "node_modules/@protobufjs/utf8": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-            "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
-            "dev": true
-        },
-        "node_modules/@types/long": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-            "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
-            "dev": true
-        },
-        "node_modules/@types/node": {
-            "version": "12.6.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.3.tgz",
-            "integrity": "sha512-7TEYTQT1/6PP53NftXXabIZDaZfaoBdeBm8Md/i7zsWRoBe0YwOXguyK8vhHs8ehgB/w9U4K/6EWuTyp0W6nIA==",
-            "dev": true
-        },
-        "node_modules/buffer-from": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-            "dev": true
-        },
-        "node_modules/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-            "dev": true
-        },
-        "node_modules/protobufjs": {
-            "version": "6.8.8",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-            "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
-            "dev": true,
-            "dependencies": {
-                "@protobufjs/aspromise": "^1.1.2",
-                "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.4",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
-                "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.0",
-                "@protobufjs/path": "^1.1.2",
-                "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.0",
-                "@types/long": "^4.0.0",
-                "@types/node": "^10.1.0",
-                "long": "^4.0.0"
-            },
-            "bin": {
-                "pbjs": "bin/pbjs",
-                "pbts": "bin/pbts"
-            }
-        },
-        "node_modules/protobufjs/node_modules/@types/node": {
-            "version": "10.17.51",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
-            "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg==",
-            "dev": true
-        },
-        "node_modules/semver": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver"
-            }
-        },
-        "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/source-map-support": {
-            "version": "0.5.9",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-            "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-            "dev": true,
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-            }
-        },
-        "node_modules/tslib": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-            "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-            "dev": true
-        },
-        "node_modules/tsutils": {
-            "version": "2.27.2",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.2.tgz",
-            "integrity": "sha512-qf6rmT84TFMuxAKez2pIfR8UCai49iQsfB7YWVjV1bKpy/d0PWT5rEOSM6La9PiHZ0k1RRZQiwVdVJfQ3BPHgg==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^1.8.1"
-            }
-        },
-        "node_modules/typescript": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-            "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
-            "dev": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
-            }
-        }
-    },
+    "lockfileVersion": 1,
     "dependencies": {
         "@bazel/esbuild": {
             "version": "3.2.1",
@@ -309,11 +96,46 @@
             "integrity": "sha512-7TEYTQT1/6PP53NftXXabIZDaZfaoBdeBm8Md/i7zsWRoBe0YwOXguyK8vhHs8ehgB/w9U4K/6EWuTyp0W6nIA==",
             "dev": true
         },
+        "ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "requires": {
+                "color-convert": "^2.0.1"
+            }
+        },
         "buffer-from": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
+        },
+        "chalk": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+            "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+            "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            }
+        },
+        "color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "requires": {
+                "color-name": "~1.1.4"
+            }
+        },
+        "color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "long": {
             "version": "4.0.0",
@@ -370,6 +192,14 @@
             "requires": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
+            }
+        },
+        "supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "requires": {
+                "has-flag": "^4.0.0"
             }
         },
         "tslib": {

--- a/examples/esbuild/package.json
+++ b/examples/esbuild/package.json
@@ -7,6 +7,9 @@
         "tslib": "1.9.0",
         "typescript": "3.5.3"
     },
+    "dependencies": {
+        "chalk": "4.1.0"
+    },
     "scripts": {
         "test": "bazel test //..."
     }

--- a/examples/esbuild/src/BUILD.bazel
+++ b/examples/esbuild/src/BUILD.bazel
@@ -9,7 +9,14 @@ ts_project(
         "main.ts",
         "name.ts",
     ],
-    tsconfig = {},
+    tsconfig = {
+        "compilerOptions": {
+            "esModuleInterop": True,
+        },
+    },
+    deps = [
+        "@npm//chalk",
+    ],
 )
 
 # create a single bundle of the JS sources

--- a/examples/esbuild/src/main.ts
+++ b/examples/esbuild/src/main.ts
@@ -1,8 +1,10 @@
+import chalk from 'chalk';
+
 import {NAME} from './name';
 
 export function greeting(name: string): string {
-  return `Hello ${name}!`;
+  return `Hello ${chalk.bold(name)}!`;
 }
 
-const sentance = greeting(NAME);
-console.log(sentance);
+const sentence = greeting(NAME);
+console.log(sentence);

--- a/packages/esbuild/helpers.bzl
+++ b/packages/esbuild/helpers.bzl
@@ -82,6 +82,8 @@ def write_jsconfig_file(ctx, path_alias_mappings):
         ctx: The rule context
         path_alias_mappings: Dict with the mappings
 
+    Returns:
+        File object reference for the jsconfig file
     """
 
     # The package path
@@ -90,7 +92,10 @@ def write_jsconfig_file(ctx, path_alias_mappings):
     # Replace all segments in the path with .. join them with "/" and postfix
     # it with another / to get a relative path from the build file dir
     # to the workspace root.
-    base_url_path = "/".join([".." for segment in rule_path.split("/")]) + "/"
+    if len(rule_path) == 0:
+        base_url_path = "."
+    else:
+        base_url_path = "/".join([".." for segment in rule_path.split("/")]) + "/"
 
     # declare the jsconfig_file
     jsconfig_file = ctx.actions.declare_file("%s.config.json" % ctx.attr.name)


### PR DESCRIPTION
When the esbuild rule is in the root `BUILD.bazel` file, `rule_path` is empty, splitting on this results in a list with one empty string, which is then translated into one path segment. When `rule_path` is empty, the rule is already in the correct base path.

This also adds an npm dependency to the example to exercise node_module resolution when bundling.

closes #2503
