### PR TITLE
fix(rollup): include externals config in worker cache key

### DIFF
--- a/packages/rollup/index.js
+++ b/packages/rollup/index.js
@@ -82,7 +82,16 @@ async function runRollup(cacheKeyData, inputOptions, outputOptions) {
 async function runRollupBundler(args /*, inputs */) {
   const {inputOptions, outputOptions} = await parseCLIArgs(args);
 
-  return runRollup(inputOptions.input, inputOptions, outputOptions);
+  const cacheKeyData = [
+    inputOptions.input,
+
+    // Include changes to externals in the cache key because rollup currently
+    // ignores such changes when using the caching API
+    // See https://github.com/rollup/rollup/issues/3874
+    inputOptions.external
+  ];
+
+  return runRollup(cacheKeyData, inputOptions, outputOptions);
 }
 
 // Processing of --environment CLI options into environment vars


### PR DESCRIPTION
This works around https://github.com/rollup/rollup/issues/3874 by not using the old cache at all when this property changes. Seems weird we have to work around such a thing but I sure wasted a lot of time wondering why changes in the config file weren't being picked up by rollup.