### PR TITLE
build: ensure common substitutions are replaced on all packages by default

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -48,9 +48,11 @@ def pkg_npm(**kwargs):
     pkg = native.package_name().split("/")[-1]
 
     # Default substitutions to scrub things like skylib references
-    substitutions = dict(kwargs.pop("substitutions", _COMMON_REPLACEMENTS), **{
+    default_substitutions = dict(_COMMON_REPLACEMENTS, **{
         "//packages/%s" % pkg: "//@bazel/%s" % pkg,
     })
+    substitutions = dict(kwargs.pop("substitutions", {}), **default_substitutions)
+
     stamped_substitutions = dict(substitutions, **{
         "0.0.0-PLACEHOLDER": "{STABLE_BUILD_SCM_VERSION}",
     })


### PR DESCRIPTION
If an `npm_package` used for packaging overrides the `substitutions` attribute, then common replacements will not be merged into the dict. These are required to remove load statements such as `bazel_skylib`

