### PR TITLE
Add strip_prefix attr to js_library

### DIFF
--- a/internal/common/module_mappings.bzl
+++ b/internal/common/module_mappings.bzl
@@ -74,6 +74,8 @@ def _get_module_mappings(target, ctx):
         # the runfiles directory. This requires the workspace_name to be prefixed on
         # each module root.
         mr = "/".join([p for p in [workspace_name, target.label.package] if p])
+        if hasattr(ctx.rule.attr, "strip_prefix") and ctx.rule.attr.strip_prefix:
+            mr += "/" + ctx.rule.attr.strip_prefix
         if hasattr(ctx.rule.attr, "module_root") and ctx.rule.attr.module_root and ctx.rule.attr.module_root != ".":
             if ctx.rule.attr.module_root.endswith(".ts"):
                 # Validate that sources are underneath the module root.

--- a/internal/common/module_mappings.bzl
+++ b/internal/common/module_mappings.bzl
@@ -73,7 +73,7 @@ def _get_module_mappings(target, ctx):
         # When building a mapping for use at runtime, we need paths to be relative to
         # the runfiles directory. This requires the workspace_name to be prefixed on
         # each module root.
-        mr = "/".join([p for p in [workspace_name, target.label.package, ctx.rule.attr.strip_prefix] if p])
+        mr = "/".join([p for p in [workspace_name, target.label.package] if p])
         if hasattr(ctx.rule.attr, "module_root") and ctx.rule.attr.module_root and ctx.rule.attr.module_root != ".":
             if ctx.rule.attr.module_root.endswith(".ts"):
                 # Validate that sources are underneath the module root.

--- a/internal/common/module_mappings.bzl
+++ b/internal/common/module_mappings.bzl
@@ -73,7 +73,7 @@ def _get_module_mappings(target, ctx):
         # When building a mapping for use at runtime, we need paths to be relative to
         # the runfiles directory. This requires the workspace_name to be prefixed on
         # each module root.
-        mr = "/".join([p for p in [workspace_name, target.label.package] if p])
+        mr = "/".join([p for p in [workspace_name, target.label.package, ctx.rule.attr.strip_prefix] if p])
         if hasattr(ctx.rule.attr, "module_root") and ctx.rule.attr.module_root and ctx.rule.attr.module_root != ".":
             if ctx.rule.attr.module_root.endswith(".ts"):
                 # Validate that sources are underneath the module root.

--- a/internal/js_library/js_library.bzl
+++ b/internal/js_library/js_library.bzl
@@ -228,7 +228,9 @@ def _impl(ctx):
 
     if ctx.attr.package_name:
         path = "/".join([
-            p for p in [ctx.bin_dir.path, ctx.label.workspace_root, ctx.label.package] if p
+            p
+            for p in [ctx.bin_dir.path, ctx.label.workspace_root, ctx.label.package]
+            if p
         ])
 
         # Strip a prefix from the package require path

--- a/internal/js_library/js_library.bzl
+++ b/internal/js_library/js_library.bzl
@@ -98,8 +98,8 @@ _ATTRS = {
     ),
     "package_name": attr.string(),
     "srcs": attr.label_list(allow_files = True),
-    "strip_path": attr.string(
-        doc = "Path components to strip from the package import path",
+    "strip_prefix": attr.string(
+        doc = "Path components to strip from the start of the package import path",
         default = "",
     ),
 }
@@ -228,7 +228,7 @@ def _impl(ctx):
 
     if ctx.attr.package_name:
         path = "/".join([
-            p for p in [ctx.bin_dir.path, ctx.label.workspace_root, ctx.label.package, ctx.attr.strip_path] if p
+            p for p in [ctx.bin_dir.path, ctx.label.workspace_root, ctx.label.package, ctx.attr.strip_prefix] if p
         ])
         providers.append(LinkablePackageInfo(
             package_name = ctx.attr.package_name,
@@ -345,7 +345,7 @@ def js_library(
         srcs: the list of files that comprise the package
         package_name: the name it will be imported by. Should match the "name" field in the package.json file.
         deps: other targets that provide JavaScript code
-        strip_path: path components to strip from the package import path
+        strip_prefix: path components to strip from the start of the package import path
         **kwargs: used for undocumented legacy features
     """
 

--- a/internal/js_library/js_library.bzl
+++ b/internal/js_library/js_library.bzl
@@ -98,6 +98,10 @@ _ATTRS = {
     ),
     "package_name": attr.string(),
     "srcs": attr.label_list(allow_files = True),
+    "strip_path": attr.string(
+        doc = "Path components to strip from the package import path",
+        default = "",
+    ),
 }
 
 AmdNamesInfo = provider(
@@ -223,7 +227,9 @@ def _impl(ctx):
     ]
 
     if ctx.attr.package_name:
-        path = "/".join([p for p in [ctx.bin_dir.path, ctx.label.workspace_root, ctx.label.package] if p])
+        path = "/".join([
+            p for p in [ctx.bin_dir.path, ctx.label.workspace_root, ctx.label.package, ctx.attr.strip_path] if p
+        ])
         providers.append(LinkablePackageInfo(
             package_name = ctx.attr.package_name,
             path = path,
@@ -339,6 +345,7 @@ def js_library(
         srcs: the list of files that comprise the package
         package_name: the name it will be imported by. Should match the "name" field in the package.json file.
         deps: other targets that provide JavaScript code
+        strip_path: path components to strip from the package import path
         **kwargs: used for undocumented legacy features
     """
 

--- a/internal/js_library/test/strip_prefix/BUILD.bazel
+++ b/internal/js_library/test/strip_prefix/BUILD.bazel
@@ -2,13 +2,16 @@ load("//:index.bzl", "js_library", "nodejs_test")
 
 js_library(
     name = "stripped_library",
-    srcs = ["library/file.js"],
     package_name = "stripped_library",
+    srcs = ["library/file.js"],
     strip_prefix = "library",
 )
 
 nodejs_test(
     name = "test",
+    data = [
+        "test.js",
+        ":stripped_library",
+    ],
     entry_point = "test.js",
-    data = ["test.js", ":stripped_library"],
 )

--- a/internal/js_library/test/strip_prefix/BUILD.bazel
+++ b/internal/js_library/test/strip_prefix/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//:index.bzl", "js_library", "nodejs_test")
+
+js_library(
+    name = "stripped_library",
+    srcs = ["library/file.js"],
+    package_name = "stripped_library",
+    strip_prefix = "library",
+)
+
+nodejs_test(
+    name = "test",
+    entry_point = "test.js",
+    data = ["test.js", ":stripped_library"],
+)

--- a/internal/js_library/test/strip_prefix/test.js
+++ b/internal/js_library/test/strip_prefix/test.js
@@ -1,0 +1,9 @@
+// Try to load on unstripped path, this should fail
+try {
+    require("stripped_library/library/file");
+} catch (exc) {
+    if (exc.code !== 'MODULE_NOT_FOUND') throw exc;
+}
+
+// Load with the stripped path, this should succeed
+require("stripped_library/file");


### PR DESCRIPTION
Solution to #2482

Open questions:
- What is the preferred name for this attr? I have called it `strip_path` but perhaps you have a preference for a different name.
- How would you like this tested? A new directory in `/e2e` or is there an existing one that it is suitable to add to?

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features): Docstrings and attr doc have been updated


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

See issue Number: #2482

## What is the new behavior?

The `LinkablePackageInfo` provider can now point into a subdirectory without that subdirectory being present in the import, as detailed in the issue above.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A
