### PR TITLE
Added mechanism to support labels as an input to ts_project

### DIFF
--- a/packages/typescript/internal/ts_config.bzl
+++ b/packages/typescript/internal/ts_config.bzl
@@ -120,10 +120,14 @@ def write_tsconfig(name, config, files, out, extends = None):
     if extends:
         config["extends"] = "__extends__"
 
-    amended_config = struct(
-        files = "__files__",
-        **config
-    )
+    if len(files):
+        amended_config = struct(
+            files = "__files__",
+            **config
+        )
+    else:
+        amended_config = struct(**config)
+
     write_tsconfig_rule(
         name = name,
         files = files,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?
Allows the use of labels OR files in order to populate ts_project sources (not both)
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Current behavior only allows files to be specified into ts_project.  Generated files are allowed, but must be named.  This causes some bazel lifecycle challenges where ts_project is being created by a macro (which itself is a macro)
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Labels can now be specified, which are auto-expanded into the appropriate sources.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

