### PR TITLE
fix: remove current directory prefix when running from execroot

### DIFF
--- a/internal/node/launcher.sh
+++ b/internal/node/launcher.sh
@@ -353,7 +353,7 @@ else
   # TODO: after we link-all-bins we should not need this extra lookup
   if [[ ! -f "$MAIN" ]]; then
     if [ "$FROM_EXECROOT" = true ]; then
-      MAIN="$EXECROOT/$MAIN"
+      MAIN="$EXECROOT/"TEMPLATED_entry_point_execroot_path
     else
       MAIN=TEMPLATED_entry_point_manifest_path
     fi


### PR DESCRIPTION
Fixes a regression where $PWD was included in the MAIN variable when
FROM_EXECROOT is defined.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

