### PR TITLE
fix(examples): remove relativeLinkResolution

### DIFF
--- a/examples/angular_bazel_architect/src/app/app-routing.module.ts
+++ b/examples/angular_bazel_architect/src/app/app-routing.module.ts
@@ -4,5 +4,5 @@ import {RouterModule, Routes} from '@angular/router';
 
 const routes: Routes = [];
 
-@NgModule({imports: [RouterModule.forRoot(routes, { relativeLinkResolution: 'legacy' })], exports: [RouterModule]})
+@NgModule({imports: [RouterModule.forRoot(routes)], exports: [RouterModule]})
 export class AppRoutingModule {}


### PR DESCRIPTION
Relative routing is not used in the angular_bazel_architect example.
Parameter `relativeLinkResolution` introduced by Angular migration is
not required.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
PR for change as asked in https://github.com/bazelbuild/rules_nodejs/pull/2495#discussion_r592991820
