### PR TITLE
feat: add manual_package_build_file_contents attr to npm_install/yarn_install

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -282,6 +282,15 @@ filegroup(
     "//zone.js:BUILD.bazel",
   ],
 )""",
+    manual_package_build_file_contents = {
+        "@gregmagolan/test-a": """
+filegroup(
+    name = "golden_files",
+    srcs = [
+        "//:BUILD.bazel",
+    ],
+)""",
+    },
     package_json = "//:tools/fine_grained_goldens/package.json",
     symlink_node_modules = False,
     yarn_lock = "//:tools/fine_grained_goldens/yarn.lock",

--- a/docs/Built-ins.md
+++ b/docs/Built-ins.md
@@ -735,7 +735,7 @@ Defaults to `[]`
 
 <pre>
 npm_install(<a href="#npm_install-name">name</a>, <a href="#npm_install-args">args</a>, <a href="#npm_install-data">data</a>, <a href="#npm_install-environment">environment</a>, <a href="#npm_install-generate_local_modules_build_files">generate_local_modules_build_files</a>, <a href="#npm_install-included_files">included_files</a>,
-            <a href="#npm_install-manual_build_file_contents">manual_build_file_contents</a>, <a href="#npm_install-npm_command">npm_command</a>, <a href="#npm_install-package_json">package_json</a>, <a href="#npm_install-package_lock_json">package_lock_json</a>, <a href="#npm_install-package_path">package_path</a>,
+            <a href="#npm_install-manual_build_file_contents">manual_build_file_contents</a>, <a href="#npm_install-manual_package_build_file_contents">manual_package_build_file_contents</a>,<a href="#npm_install-npm_command">npm_command</a>, <a href="#npm_install-package_json">package_json</a>, <a href="#npm_install-package_lock_json">package_lock_json</a>, <a href="#npm_install-package_path">package_path</a>,
             <a href="#npm_install-quiet">quiet</a>, <a href="#npm_install-repo_mapping">repo_mapping</a>, <a href="#npm_install-strict_visibility">strict_visibility</a>, <a href="#npm_install-symlink_node_modules">symlink_node_modules</a>, <a href="#npm_install-timeout">timeout</a>)
 </pre>
 
@@ -839,6 +839,24 @@ node_modules target it is recommended to switch to using
 fine grained npm dependencies.
 
 Defaults to `""`
+
+<h4 id="npm_install-manual_package_build_file_contents">manual_package_build_file_contents</h4>
+
+(*dict*): Experimental attribute that can be used to append to the end of the generated BUILD.bazel file for each package.
+
+This can be used to add `filegroup` to access assets from certain npm packages (e.g CSS/fonts/imgs...). Example:
+```
+{
+    "package-1": \"\"\"
+filegroup(
+    name = "css",
+    srcs = glob(["**/*.css"]),
+)
+\"\"\",
+}
+```
+
+Defaults to `{}`
 
 <h4 id="npm_install-npm_command">npm_command</h4>
 
@@ -1143,7 +1161,7 @@ Defaults to `{}`
 
 <pre>
 yarn_install(<a href="#yarn_install-name">name</a>, <a href="#yarn_install-args">args</a>, <a href="#yarn_install-data">data</a>, <a href="#yarn_install-environment">environment</a>, <a href="#yarn_install-frozen_lockfile">frozen_lockfile</a>, <a href="#yarn_install-generate_local_modules_build_files">generate_local_modules_build_files</a>,
-             <a href="#yarn_install-included_files">included_files</a>, <a href="#yarn_install-manual_build_file_contents">manual_build_file_contents</a>, <a href="#yarn_install-package_json">package_json</a>, <a href="#yarn_install-package_path">package_path</a>, <a href="#yarn_install-quiet">quiet</a>,
+             <a href="#yarn_install-included_files">included_files</a>, <a href="#yarn_install-manual_build_file_contents">manual_build_file_contents</a>, <a href="#yarn_install-manual_package_build_file_contents">manual_package_build_file_contents</a>,<a href="#yarn_install-package_json">package_json</a>, <a href="#yarn_install-package_path">package_path</a>, <a href="#yarn_install-quiet">quiet</a>,
              <a href="#yarn_install-repo_mapping">repo_mapping</a>, <a href="#yarn_install-strict_visibility">strict_visibility</a>, <a href="#yarn_install-symlink_node_modules">symlink_node_modules</a>, <a href="#yarn_install-timeout">timeout</a>, <a href="#yarn_install-use_global_yarn_cache">use_global_yarn_cache</a>,
              <a href="#yarn_install-yarn_lock">yarn_lock</a>)
 </pre>
@@ -1263,6 +1281,24 @@ node_modules target it is recommended to switch to using
 fine grained npm dependencies.
 
 Defaults to `""`
+
+<h4 id="yarn_install-manual_package_build_file_contents">manual_package_build_file_contents</h4>
+
+(*dict*): Experimental attribute that can be used to append to the end of the generated BUILD.bazel file for each package.
+
+This can be used to add `filegroup` to access assets from certain npm packages (e.g CSS/fonts/imgs...). Example:
+```
+{
+    "package-1": \"\"\"
+filegroup(
+    name = "css",
+    srcs = glob(["**/*.css"]),
+)
+\"\"\",
+}
+```
+
+Defaults to `{}`
 
 <h4 id="yarn_install-package_json">package_json</h4>
 

--- a/internal/npm_install/generate_build_file.ts
+++ b/internal/npm_install/generate_build_file.ts
@@ -209,6 +209,13 @@ js_library(
  * Generates all BUILD & bzl files for a package.
  */
 function generatePackageBuildFiles(pkg: Dep) {
+  let customPackageBuildFileContent = ''
+  try {
+    customPackageBuildFileContent =
+        fs.readFileSync(`manual_package_build_file_contents/${pkg._dir}`, 'utf-8')
+  } catch (e) {
+    // Ignore
+  }
   // If a BUILD file was shipped with the package we should symlink the generated BUILD file
   // instead of append its contents to the end of the one we were going to generate.
   // https://github.com/bazelbuild/rules_nodejs/issues/2131
@@ -235,6 +242,9 @@ function generatePackageBuildFiles(pkg: Dep) {
 
   // The following won't be used in a symlink build file case
   let buildFile = printPackage(pkg);
+  if (customPackageBuildFileContent) {
+    buildFile += `\n${customPackageBuildFileContent}`
+  }
   if (buildFilePath) {
     buildFile = buildFile + '\n' +
         fs.readFileSync(path.join('node_modules', pkg._dir, buildFilePath), 'utf-8');

--- a/internal/npm_install/index.js
+++ b/internal/npm_install/index.js
@@ -117,6 +117,13 @@ js_library(
     writeFileSync('BUILD.bazel', buildFile);
 }
 function generatePackageBuildFiles(pkg) {
+    let customPackageBuildFileContent = '';
+    try {
+        customPackageBuildFileContent =
+            fs.readFileSync(`manual_package_build_file_contents/${pkg._dir}`, 'utf-8');
+    }
+    catch (e) {
+    }
     let buildFilePath;
     if (pkg._files.includes('BUILD'))
         buildFilePath = 'BUILD';
@@ -129,6 +136,9 @@ function generatePackageBuildFiles(pkg) {
         console.log(`[yarn_install/npm_install]: package ${nodeModulesPkgDir} is local symlink and as such a BUILD file for it is expected but none was found. Please add one at ${fs.realpathSync(nodeModulesPkgDir)}`);
     }
     let buildFile = printPackage(pkg);
+    if (customPackageBuildFileContent) {
+        buildFile += `\n${customPackageBuildFileContent}`;
+    }
     if (buildFilePath) {
         buildFile = buildFile + '\n' +
             fs.readFileSync(path.join('node_modules', pkg._dir, buildFilePath), 'utf-8');

--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -98,6 +98,22 @@ node_modules target it is recommended to switch to using
 fine grained npm dependencies.
 """,
     ),
+    "manual_package_build_file_contents": attr.string_dict(
+        doc = """Experimental attribute that can be used to append to the end of the generated BUILD.bazel file for each package.
+
+This can be used to add `filegroup` to access assets from certain npm packages (e.g CSS/fonts/imgs...). Example:
+```
+{
+    "package-1": \"\"\"
+filegroup(
+    name = "css",
+    srcs = glob(["**/*.css"]),
+)
+\"\"\",
+}
+```
+""",
+    ),
     "package_json": attr.label(
         mandatory = True,
         allow_single_file = True,
@@ -150,6 +166,8 @@ def _create_build_files(repository_ctx, rule_type, node, lock_file, generate_loc
     repository_ctx.report_progress("Processing node_modules: installing Bazel packages and generating BUILD files")
     if repository_ctx.attr.manual_build_file_contents:
         repository_ctx.file("manual_build_file_contents", repository_ctx.attr.manual_build_file_contents)
+    for pkg, content in repository_ctx.attr.manual_package_build_file_contents.items():
+        repository_ctx.file("manual_package_build_file_contents/%s" % pkg, content)
     result = repository_ctx.execute([
         node,
         "index.js",

--- a/internal/npm_install/test/golden/@gregmagolan/test-a/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/@gregmagolan/test-a/BUILD.bazel.golden
@@ -53,4 +53,10 @@ npm_umd_bundle(
     entry_point = "//:node_modules/@gregmagolan/test-a/main.js",
     package = ":test-a",
 )
+filegroup(
+    name = "golden_files",
+    srcs = [
+        "//:BUILD.bazel",
+    ],
+)
 exports_files(["index.bzl"])


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the new behavior?

Add `manual_package_build_file_contents` to `npm_install`/`yarn_install`.

(*dict*): Experimental attribute that can be used to append to the end of the generated BUILD.bazel file for each package.

This can be used to add `filegroup` to access assets from certain npm packages (e.g CSS/fonts/imgs...). Example:
```python
{
    "package-1": """
filegroup(
    name = "css",
    srcs = glob(["**/*.css"]),
)
""",
}
```

Defaults to `{}`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
