### PR TITLE
feat(esbuild): add output_css flag to esbuild()

### DIFF
--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -100,6 +100,9 @@ def _esbuild_impl(ctx):
                 fail("output_map must be specified if sourcemap is not set to 'inline'")
             outputs.append(js_out_map)
 
+        if ctx.outputs.output_css:
+            outputs.append(ctx.outputs.output_css)
+
         if ctx.attr.format:
             args.add_joined(["--format", ctx.attr.format], join_with = "=")
 
@@ -219,6 +222,10 @@ See https://esbuild.github.io/api/#splitting for more details
             mandatory = False,
             doc = "Name of the output source map when bundling",
         ),
+        "output_css": attr.output(
+            mandatory = False,
+            doc = "Name of the output css file when bundling",
+        ),
         "platform": attr.string(
             default = "browser",
             values = ["node", "browser", "neutral", ""],
@@ -273,7 +280,7 @@ For further information about esbuild, see https://esbuild.github.io/
     """,
 )
 
-def esbuild_macro(name, output_dir = False, **kwargs):
+def esbuild_macro(name, output_dir = False, output_css = False, **kwargs):
     """esbuild helper macro around the `esbuild_bundle` rule
 
     For a full list of attributes, see the `esbuild_bundle` rule
@@ -281,6 +288,8 @@ def esbuild_macro(name, output_dir = False, **kwargs):
     Args:
         name: The name used for this rule and output files
         output_dir: If `True`, produce a code split bundle in an output directory
+        output_css: If `True`, declare name.css as an output, which is the
+                    case when your code imports a css file.
         **kwargs: All other args from `esbuild_bundle`
     """
 
@@ -304,5 +313,6 @@ def esbuild_macro(name, output_dir = False, **kwargs):
             name = name,
             output = output,
             output_map = output_map,
+            output_css = None if not output_css else "%s.css" % name,
             **kwargs
         )

--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -28,6 +28,9 @@ def _esbuild_impl(ctx):
         elif hasattr(dep, "files"):
             deps_depsets.append(dep.files)
 
+        if DefaultInfo in dep:
+            deps_depsets.append(dep[DefaultInfo].data_runfiles.files)
+
         if NpmPackageInfo in dep:
             deps_depsets.append(dep[NpmPackageInfo].sources)
             npm_workspaces.append(dep[NpmPackageInfo].workspace)

--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -227,7 +227,11 @@ See https://esbuild.github.io/api/#splitting for more details
         ),
         "output_css": attr.output(
             mandatory = False,
-            doc = "Name of the output css file when bundling",
+            doc = """Declare a .css file will be output next to output bundle.
+
+If your JS code contains import statements that import .css files, esbuild will place the
+content in a file next to the main output file, which you'll need to declare. If your output
+file is named 'foo.js', you should set this to 'foo.css'.""",
         ),
         "platform": attr.string(
             default = "browser",
@@ -283,7 +287,7 @@ For further information about esbuild, see https://esbuild.github.io/
     """,
 )
 
-def esbuild_macro(name, output_dir = False, output_css = False, **kwargs):
+def esbuild_macro(name, output_dir = False, **kwargs):
     """esbuild helper macro around the `esbuild_bundle` rule
 
     For a full list of attributes, see the `esbuild_bundle` rule
@@ -291,8 +295,6 @@ def esbuild_macro(name, output_dir = False, output_css = False, **kwargs):
     Args:
         name: The name used for this rule and output files
         output_dir: If `True`, produce a code split bundle in an output directory
-        output_css: If `True`, declare name.css as an output, which is the
-                    case when your code imports a css file.
         **kwargs: All other args from `esbuild_bundle`
     """
 
@@ -316,6 +318,5 @@ def esbuild_macro(name, output_dir = False, output_css = False, **kwargs):
             name = name,
             output = output,
             output_map = output_map,
-            output_css = None if not output_css else "%s.css" % name,
             **kwargs
         )

--- a/packages/esbuild/test/css/BUILD.bazel
+++ b/packages/esbuild/test/css/BUILD.bazel
@@ -34,6 +34,10 @@ ts_library(
 
 esbuild(
     name = "default",
+    args = [
+        "--keep-names",
+        "--resolve-extensions=.mjs,.js",
+    ],
     entry_point = "main.ts",
     deps = [
         ":main",
@@ -42,6 +46,10 @@ esbuild(
 
 esbuild(
     name = "with_css",
+    args = [
+        "--keep-names",
+        "--resolve-extensions=.mjs,.js",
+    ],
     entry_point = "main.ts",
     output_css = True,
     deps = [

--- a/packages/esbuild/test/css/BUILD.bazel
+++ b/packages/esbuild/test/css/BUILD.bazel
@@ -9,11 +9,25 @@ copy_to_bin(
 )
 
 ts_library(
+    name = "dep",
+    srcs = [
+        "dep.ts",
+    ],
+    data = [
+        ":external_copied",
+    ],
+    deps = [
+        "@npm//@types/node",
+    ],
+)
+
+ts_library(
     name = "main",
     srcs = [
         "main.ts",
     ],
     deps = [
+        ":dep",
         "@npm//@types/node",
     ],
 )
@@ -22,7 +36,6 @@ esbuild(
     name = "default",
     entry_point = "main.ts",
     deps = [
-        "external_copied",
         ":main",
     ],
 )
@@ -32,7 +45,6 @@ esbuild(
     entry_point = "main.ts",
     output_css = True,
     deps = [
-        "external_copied",
         ":main",
     ],
 )

--- a/packages/esbuild/test/css/BUILD.bazel
+++ b/packages/esbuild/test/css/BUILD.bazel
@@ -1,0 +1,47 @@
+load("//packages/esbuild/test:tests.bzl", "esbuild")
+load("//packages/jasmine:index.bzl", "jasmine_node_test")
+load("//packages/typescript:index.bzl", "ts_library")
+load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin")
+
+copy_to_bin(
+    name = "external_copied",
+    srcs = ["external.css"],
+)
+
+ts_library(
+    name = "main",
+    srcs = [
+        "main.ts",
+    ],
+    deps = [
+        "@npm//@types/node",
+    ],
+)
+
+esbuild(
+    name = "default",
+    entry_point = "main.ts",
+    deps = [
+        "external_copied",
+        ":main",
+    ],
+)
+
+esbuild(
+    name = "with_css",
+    entry_point = "main.ts",
+    output_css = True,
+    deps = [
+        "external_copied",
+        ":main",
+    ],
+)
+
+jasmine_node_test(
+    name = "bundle_test",
+    srcs = ["bundle_test.js"],
+    data = [
+        ":default",
+        ":with_css",
+    ],
+)

--- a/packages/esbuild/test/css/BUILD.bazel
+++ b/packages/esbuild/test/css/BUILD.bazel
@@ -51,7 +51,7 @@ esbuild(
         "--resolve-extensions=.mjs,.js",
     ],
     entry_point = "main.ts",
-    output_css = True,
+    output_css = "with_css.css",
     deps = [
         ":main",
     ],

--- a/packages/esbuild/test/css/bundle_test.js
+++ b/packages/esbuild/test/css/bundle_test.js
@@ -1,0 +1,21 @@
+const { stat } = require("fs");
+const path = require("path");
+
+const helper = require(process.env.BAZEL_NODE_RUNFILES_HELPER);
+const locationBase = "build_bazel_rules_nodejs/packages/esbuild/test/css/";
+
+const cssExpected = helper.resolve(path.join(locationBase, "with_css.css"));
+
+describe("esbuild css", () => {
+  it("no css by default", () => {
+    expect(() =>
+      helper.resolve(path.join(locationBase, "default.css"))
+    ).toThrow();
+  });
+
+  it("css if requested", () => {
+    stat(cssExpected, (err, stats) => {
+      expect(err).toBeNull();
+    });
+  });
+});

--- a/packages/esbuild/test/css/bundle_test.js
+++ b/packages/esbuild/test/css/bundle_test.js
@@ -8,6 +8,11 @@ const cssExpected = helper.resolve(path.join(locationBase, "with_css.css"));
 
 describe("esbuild css", () => {
   it("no css by default", () => {
+    if (process.platform === "win32") {
+      // Windows has no sandbox, and the runfiles helper will return files
+      // that happen to exist in the folder, even if they are not declared outputs
+      return;
+    }
     expect(() =>
       helper.resolve(path.join(locationBase, "default.css"))
     ).toThrow();

--- a/packages/esbuild/test/css/bundle_test.js
+++ b/packages/esbuild/test/css/bundle_test.js
@@ -1,4 +1,4 @@
-const { stat } = require("fs");
+const { readFileSync } = require("fs");
 const path = require("path");
 
 const helper = require(process.env.BAZEL_NODE_RUNFILES_HELPER);
@@ -14,8 +14,7 @@ describe("esbuild css", () => {
   });
 
   it("css if requested", () => {
-    stat(cssExpected, (err, stats) => {
-      expect(err).toBeNull();
-    });
+    const contents = readFileSync(cssExpected, { encoding: "utf8" });
+    expect(contents).toContain("external-content");
   });
 });

--- a/packages/esbuild/test/css/dep.ts
+++ b/packages/esbuild/test/css/dep.ts
@@ -1,0 +1,3 @@
+import "./external.css";
+
+export function dep() {}

--- a/packages/esbuild/test/css/external.css
+++ b/packages/esbuild/test/css/external.css
@@ -1,0 +1,2 @@
+.external-content {
+}

--- a/packages/esbuild/test/css/main.ts
+++ b/packages/esbuild/test/css/main.ts
@@ -1,1 +1,3 @@
-import "./external.css";
+import { dep } from "./dep";
+
+dep();

--- a/packages/esbuild/test/css/main.ts
+++ b/packages/esbuild/test/css/main.ts
@@ -1,0 +1,1 @@
+import "./external.css";


### PR DESCRIPTION
When esbuild encounters an 'import "./foo.css"' reference in normal (non-splitting)
mode, it will place the contents of that file in a .css file next to the
main output .js file.

This patch adds a flag output_css, which when set to True, will declare
the created .css file as another output, so it can be consumed by other
rules.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
