### PR TITLE
Update jasmine-reporters to fix xmldom vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "is-builtin-module": "3.0.0",
         "jasmine": "~3.4.0",
         "jasmine-core": "~3.4.0",
-        "jasmine-reporters": "~2.3.2",
+        "jasmine-reporters": "~2.4.0",
         "jest": "~25.3.0",
         "jest-cli": "~25.3.0",
         "jest-websocket-mock": "~2.0.2",

--- a/packages/jasmine/package.json
+++ b/packages/jasmine/package.json
@@ -17,7 +17,7 @@
     ],
     "main": "index.js",
     "dependencies": {
-        "jasmine-reporters": "~2.3.2",
+        "jasmine-reporters": "~2.4.0",
         "c8": "~7.5.0"
     },
     "//1": "jasmine depends on jasmine-core, however since we require() it we need it hoisted to the top",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5472,13 +5472,13 @@ jasmine-core@~3.4.0:
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.4.0.tgz#2a74618e966026530c3518f03e9f845d26473ce3"
   integrity sha512-HU/YxV4i6GcmiH4duATwAbJQMlE0MsDIR5XmSVxURxKHn3aGAdbY1/ZJFmVRbKtnLwIxxMJD7gYaPsypcbYimg==
 
-jasmine-reporters@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/jasmine-reporters/-/jasmine-reporters-2.3.2.tgz#898818ffc234eb8b3f635d693de4586f95548d43"
-  integrity sha512-u/7AT9SkuZsUfFBLLzbErohTGNsEUCKaQbsVYnLFW1gEuL2DzmBL4n8v90uZsqIqlWvWUgian8J6yOt5Fyk/+A==
+jasmine-reporters@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jasmine-reporters/-/jasmine-reporters-2.4.0.tgz#708c17ae70ba6671e3a930bb1b202aab80a31409"
+  integrity sha512-jxONSrBLN1vz/8zCx5YNWQSS8iyDAlXQ5yk1LuqITe4C6iXCDx5u6Q0jfNtkKhL4qLZPe69fL+AWvXFt9/x38w==
   dependencies:
     mkdirp "^0.5.1"
-    xmldom "^0.1.22"
+    xmldom "^0.5.0"
 
 jasmine@2.8.0:
   version "2.8.0"
@@ -10357,10 +10357,10 @@ xmlchars@^2.1.1:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmldom@^0.1.22:
-  version "0.1.31"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
-  integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
+xmldom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
+  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
 
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"


### PR DESCRIPTION
https://github.com/larrymyers/jasmine-reporters/pull/202 updated the xlmdom dependency to a version that doesn't have the security vulnerability https://github.com/advisories/GHSA-h6q6-9hqw-rwfv -- bumping the version here to pull in that dep.