### PR TITLE
fix(builtin): add transitive typings to runfiles provider produced by js_library

### DIFF
--- a/internal/js_library/js_library.bzl
+++ b/internal/js_library/js_library.bzl
@@ -212,7 +212,9 @@ def _impl(ctx):
             files = depset(transitive = files_depsets),
             runfiles = ctx.runfiles(
                 files = all_files,
-                transitive_files = depset(transitive = files_depsets),
+                transitive_files = depset(
+                    transitive = files_depsets + typings_depsets,
+                ),
             ),
         ),
         AmdNamesInfo(names = ctx.attr.amd_names),


### PR DESCRIPTION
Add transitive typings to runfiles provider produced by `js_library`. Allows downstream consumers that require the `.d.ts` files at runtime (eg typechecking) to access the files via the runfiles tree.