### PR TITLE
fix(esbuild): files not being found when building external repo

### DIFF
--- a/packages/esbuild/helpers.bzl
+++ b/packages/esbuild/helpers.bzl
@@ -86,8 +86,9 @@ def write_jsconfig_file(ctx, path_alias_mappings):
         File object reference for the jsconfig file
     """
 
-    # The package path
-    rule_path = paths.dirname(ctx.build_file_path)
+    # The package path, including an "external/repo_name/" prefix if the package is in
+    # an external repo.
+    rule_path = paths.join(ctx.label.workspace_root, paths.dirname(ctx.build_file_path))
 
     # Replace all segments in the path with .. join them with "/" and postfix
     # it with another / to get a relative path from the build file dir


### PR DESCRIPTION
An esbuild rule that ran fine in a local repo (eg bazel build //:my_esbuild_rule)
fails when built externally (eg bazel build @other_workspace//:my_esbuild_rule).
By prepending the workspace root to the bin path, the resulting base
URL works correctly in both local and remote repo invocations, allowing
esbuild output to be consumed by a different repo.

This change fixes remote repos in Bazel 4.0.0. 3.7.0 seems to require a
workspace_root.replace("external/", "") call first in order
to get the correct location. So while this patch should not break anything
that was not already broken, it only fixes/adds support for remote repos
in 4.0+.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
