### PR TITLE
feat(esbuild): support location expansion in esbuild args

### DIFF
--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -109,7 +109,7 @@ def _esbuild_impl(ctx):
     args.add_joined(["--tsconfig", jsconfig_file.path], join_with = "=")
     inputs.append(jsconfig_file)
 
-    args.add_all(ctx.attr.args)
+    args.add_all([ctx.expand_location(arg) for arg in ctx.attr.args])
 
     env = {}
     if ctx.attr.max_threads > 0:
@@ -136,7 +136,8 @@ esbuild = rule(
     attrs = {
         "args": attr.string_list(
             default = [],
-            doc = "A list of extra arguments that are included in the call to esbuild",
+            doc = """A list of extra arguments that are included in the call to esbuild.
+    $(location ...) can be used to resolve the path to a Bazel target.""",
         ),
         "define": attr.string_list(
             default = [],


### PR DESCRIPTION
When an esbuild rule is passed an argument like "--inject:path/in/repo.js",
this works when building in the local workspace, as esbuild is invoked
with the correct working directory. But if the esbuild rule is in
a remote workspace (eg bazel build @other_workspace//path/in:esbuild_rule),
then the path is no longer valid.

By expanding $(location ...) references in provided arguments, it allows
callers of the rule to pass arguments like the following, which work
in both local and remote repo cases:

esbuild(args = ["--inject:$(location //path/in:repo.js)"], ...)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
