### PR TITLE
fix: fetch node toolchain based on exec platform, not target platform

### DIFF
--- a/toolchains/node/BUILD.bazel
+++ b/toolchains/node/BUILD.bazel
@@ -103,7 +103,7 @@ alias(
 
 toolchain(
     name = "node_linux_amd64_toolchain",
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],
@@ -113,7 +113,7 @@ toolchain(
 
 toolchain(
     name = "node_linux_arm64_toolchain",
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:aarch64",
     ],
@@ -123,7 +123,7 @@ toolchain(
 
 toolchain(
     name = "node_darwin_amd64_toolchain",
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:osx",
         "@platforms//cpu:x86_64",
     ],
@@ -133,7 +133,7 @@ toolchain(
 
 toolchain(
     name = "node_windows_amd64_toolchain",
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:windows",
         "@platforms//cpu:x86_64",
     ],
@@ -143,7 +143,7 @@ toolchain(
 
 toolchain(
     name = "node_linux_s390x_toolchain",
-    target_compatible_with = [
+    exec_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:s390x",
     ],


### PR DESCRIPTION
Currently rules_nodejs can't be used when cross-compiling to a different
platform, if that platform does not have a node toolchain available.
This means if you want to cross-compile a project that includes JS
files, you need to do it in multiple steps:

- build the JS files with the default host platform
- build the other products with a target platform specified, copying
the generated JS files in

The fact that it's currently set to target makes me wonder if this
use case was just not considered at the time, or whether there's some
other workflow that changing to exec will break. Thoughts?

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
