### PR TITLE
Propagate esbuild `no-remote-exec` from tags

### DIFF
--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -115,15 +115,17 @@ def _esbuild_impl(ctx):
     if ctx.attr.max_threads > 0:
         env["GOMAXPROCS"] = str(ctx.attr.max_threads)
 
+    execution_requirements = {}
+    if "no-remote-exec" in ctx.attr.tags:
+        execution_requirements = {"no-remote-exec": "1"}
+
     ctx.actions.run(
         inputs = inputs,
         outputs = outputs,
         executable = ctx.executable.tool,
         arguments = [args],
         progress_message = "%s Javascript %s [esbuild]" % ("Bundling" if not ctx.attr.output_dir else "Splitting", entry_point.short_path),
-        execution_requirements = {
-            "no-remote-exec": "1",
-        },
+        execution_requirements = execution_requirements,
         mnemonic = "esbuild",
         env = env,
     )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

I've tested this change with a local patch, and it works great with or without RBE enabled. Happy to add tests if it makes sense for a change like this.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently esbuild `execution_requirements` are hardcoded to disable remote execution. When running a build with remote execution enabled, the esbuild action will always run locally.

If running with `--spawn_strategy=remote`, you get the following error:
```
ERROR: /Users/siggi/Code/buildbuddy/app/BUILD.bazel:13:8: Bundling Javascript app/app.mjs [esbuild] failed: No usable spawn strategy found for spawn with mnemonic Action.  Your --spawn_strategy, --genrule_strategy and/or --strategy flags are probably too strict. Visit https://github.com/bazelbuild/bazel/issues/7480 for migration advice
```

Issue Number: N/A


## What is the new behavior?
If the `no-remote-exec` tag is set on the esbuild rule, that value is propagated down to the action's `execution_requirements`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

