### PR TITLE
feat(typescript): add support for "jsx: preserve" compiler option

### DIFF
--- a/packages/typescript/internal/ts_project_options_validator.ts
+++ b/packages/typescript/internal/ts_project_options_validator.ts
@@ -64,6 +64,25 @@ function main([tsconfigPath, output, target, attrsStr]: string[]): 0|1 {
     }
   }
 
+  const jsxEmit: Record<ts.JsxEmit, string|undefined> =
+      {
+        [ts.JsxEmit.None]: 'none',
+        [ts.JsxEmit.Preserve]: 'preserve',
+        [ts.JsxEmit.React]: 'react',
+        [ts.JsxEmit.ReactNative]: 'react-native',
+      }
+
+  function
+  check_preserve_jsx() {
+    const attr = 'preserve_jsx'
+    const jsxVal = options['jsx'] as ts.JsxEmit
+    if ((jsxVal === ts.JsxEmit.Preserve) !== Boolean(attrs[attr])) {
+      failures.push(
+          `attribute ${attr}=${attrs[attr]} does not match compilerOptions.jsx=${jsxEmit[jsxVal]}`);
+      buildozerCmds.push(`set ${attr} ${jsxVal === ts.JsxEmit.Preserve ? 'True' : 'False'}`);
+    }
+  }
+
   check('allowJs', 'allow_js');
   check('declarationMap', 'declaration_map');
   check('emitDeclarationOnly', 'emit_declaration_only');
@@ -72,6 +91,7 @@ function main([tsconfigPath, output, target, attrsStr]: string[]): 0|1 {
   check('declaration');
   check('incremental');
   check('tsBuildInfoFile', 'ts_build_info_file');
+  check_preserve_jsx();
 
   if (failures.length > 0) {
     console.error(`ERROR: ts_project rule ${
@@ -98,6 +118,7 @@ function main([tsconfigPath, output, target, attrsStr]: string[]): 0|1 {
 // source_map:            ${attrs.source_map}
 // emit_declaration_only: ${attrs.emit_declaration_only}
 // ts_build_info_file:    ${attrs.ts_build_info_file}
+// preserve_jsx:          ${attrs.preserve_jsx}
 `,
       'utf-8');
   return 0;

--- a/packages/typescript/test/ts_project/jsx/BUILD.bazel
+++ b/packages/typescript/test/ts_project/jsx/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
+load("//packages/typescript:index.bzl", "ts_project")
+
+# Ensure that jsx inputs result in jsx outputs with preserve_jsx = True
+SRCS = [
+    "a.tsx",
+    "b.jsx",
+]
+
+ts_project(
+    name = "tsconfig",
+    srcs = SRCS,
+    allow_js = True,
+    declaration = True,
+    declaration_map = True,
+    out_dir = "out",
+    preserve_jsx = True,
+    source_map = True,
+)
+
+filegroup(
+    name = "types",
+    srcs = [":tsconfig"],
+    output_group = "types",
+)
+
+nodejs_test(
+    name = "test",
+    data = [
+        ":tsconfig",
+        ":types",
+    ],
+    entry_point = "verify-preserve.js",
+    templated_args = [
+        "$(locations :types)",
+        "$(locations :tsconfig)",
+    ],
+)

--- a/packages/typescript/test/ts_project/jsx/a.tsx
+++ b/packages/typescript/test/ts_project/jsx/a.tsx
@@ -1,0 +1,1 @@
+export const A = <div>a</div>

--- a/packages/typescript/test/ts_project/jsx/b.jsx
+++ b/packages/typescript/test/ts_project/jsx/b.jsx
@@ -1,0 +1,1 @@
+export const B = <div>b</div>

--- a/packages/typescript/test/ts_project/jsx/tsconfig.json
+++ b/packages/typescript/test/ts_project/jsx/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "jsx": "preserve",
+    "types": []
+  }
+}

--- a/packages/typescript/test/ts_project/jsx/verify-preserve.js
+++ b/packages/typescript/test/ts_project/jsx/verify-preserve.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+
+const files = process.argv.slice(2);
+assert.ok(files.some(f => f.endsWith('out/a.d.ts')), 'Missing a.d.ts');
+assert.ok(files.some(f => f.endsWith('out/a.d.ts.map')), 'Missing a.d.ts.map');
+assert.ok(files.some(f => f.endsWith('out/a.jsx.map'), 'Missing a.jsx.map'));
+assert.ok(files.some(f => f.endsWith('out/a.jsx'), 'Missing a.jsx'));
+assert.ok(files.some(f => f.endsWith('out/b.jsx'), 'Missing b.jsx'));


### PR DESCRIPTION
When tsc is instructed to preserve jsx, the emitted files have a .jsx
extension for .tsx and .jsx inputs, which means ts_project needs to be
aware of the option to properly define outputs.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current behavior causes the `ts_project` rule to fail as it is expecting different outputs.

Issue Number: N/A


## What is the new behavior?

In the new behavior, `ts_project` is aware of the `jsx` compiler option and sets output files accordingly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

