### PR TITLE
fix(jasmine): transitive specs are no longer added to the test suite

### DIFF
--- a/packages/jasmine/test/BUILD.bazel
+++ b/packages/jasmine/test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//:index.bzl", "js_library")
 load("//internal/common:copy_to_bin.bzl", "copy_to_bin")
 load("//packages/jasmine:index.bzl", "jasmine_node_test")
 load("//packages/typescript:index.bzl", "ts_library")
@@ -208,4 +209,18 @@ jasmine_node_test(
 jasmine_node_test(
     name = "stack_test",
     srcs = ["stack.spec.js"],
+    deps = [":fail_test"],
+)
+
+# Verify that transitive specs are not added to the execution
+js_library(
+    name = "lib_with_fail_spec",
+    srcs = ["fail.spec.js"],
+)
+
+jasmine_node_test(
+    name = "transitive_spec_test",
+    srcs = ["foo.spec.js"],
+    use_direct_specs = True,
+    deps = [":lib_with_fail_spec"],
 )

--- a/packages/rollup/rollup_bundle.bzl
+++ b/packages/rollup/rollup_bundle.bzl
@@ -352,7 +352,10 @@ def _rollup_bundle(ctx):
 
     return [
         DefaultInfo(files = outputs_depset),
-        JSModuleInfo(sources = outputs_depset),
+        JSModuleInfo(
+            direct_sources = outputs_depset,
+            sources = outputs_depset,
+        ),
     ]
 
 rollup_bundle = rule(

--- a/packages/terser/terser_minified.bzl
+++ b/packages/terser/terser_minified.bzl
@@ -185,9 +185,14 @@ def _terser(ctx):
         progress_message = "Minifying JavaScript %s [terser]" % (outputs[0].short_path),
     )
 
+    outputs_depset = depset(outputs)
+
     return [
-        DefaultInfo(files = depset(outputs)),
-        JSModuleInfo(sources = depset(outputs)),
+        DefaultInfo(files = outputs_depset),
+        JSModuleInfo(
+            direct_sources = outputs_depset,
+            sources = outputs_depset,
+        ),
     ]
 
 terser_minified = rule(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Jasmine runner adds all transitive specs to active execution, which results in some specs running multiple times. 

This can be especially problematic when there are multiple `ts_projects` with test specs that depend on each other. For example:

```
ts_project(name="proj_a") → jasmine_node_test(name="test_a") // will run specs from proj_a
↓
ts_project(name="proj_b") → jasmine_node_test(name="test_b") // will run specs from proj_a and proj_b
↓
ts_project(name="proj_c") → jasmine_node_test(name="test_c") // will run specs from proj_a, proj_b and proj_c
```

Issue Number: N/A


## What is the new behavior?

Only specs from direct deps are added to active execution


## Does this PR introduce a breaking change?

- [x] Yes, with opt-in flag
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

