### PR TITLE
fix(esbuild): 'output' is passed twice when used

### DIFF
--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -291,13 +291,18 @@ def esbuild_macro(name, output_dir = False, **kwargs):
             **kwargs
         )
     else:
+        output = "%s.js" % name
+        if "output" in kwargs:
+            output = kwargs.pop("output")
+
         output_map = None
         sourcemap = kwargs.get("sourcemap", None)
         if sourcemap != "inline":
-            output_map = "%s.js.map" % name
+            output_map = "%s.map" % output
+
         esbuild(
             name = name,
-            output = "%s.js" % name,
+            output = output,
             output_map = output_map,
             **kwargs
         )

--- a/packages/esbuild/test/output/BUILD.bazel
+++ b/packages/esbuild/test/output/BUILD.bazel
@@ -1,0 +1,29 @@
+load("//packages/esbuild/test:tests.bzl", "esbuild")
+load("//packages/jasmine:index.bzl", "jasmine_node_test")
+load("//packages/typescript:index.bzl", "ts_library")
+
+ts_library(
+    name = "main",
+    srcs = [
+        "main.ts",
+    ],
+    deps = [
+        "@npm//@types/node",
+    ],
+)
+
+esbuild(
+    name = "bundle_different_output",
+    args = ["--keep-names"],
+    entry_point = "main.ts",
+    output = "different_output.js",
+    deps = [":main"],
+)
+
+jasmine_node_test(
+    name = "bundle_test",
+    srcs = ["bundle_test.js"],
+    data = [
+        ":bundle_different_output",
+    ],
+)

--- a/packages/esbuild/test/output/bundle_test.js
+++ b/packages/esbuild/test/output/bundle_test.js
@@ -1,0 +1,25 @@
+const {readFileSync} = require('fs');
+const path = require('path');
+
+const helper = require(process.env.BAZEL_NODE_RUNFILES_HELPER);
+const locationBase = 'build_bazel_rules_nodejs/packages/esbuild/test/output/';
+
+// Location for :bundle_output
+const bundleOutputLocation = helper.resolve(path.join(locationBase, 'different_output.js'));
+const bundleOutputSourcemapLocation =
+    helper.resolve(path.join(locationBase, 'different_output.js.map'));
+
+describe('esbuild sourcemap', () => {
+  it('writes the bundle with name specified by \'output\'', () => {
+    const bundle = readFileSync(bundleOutputLocation, {encoding: 'utf8'});
+    expect(bundle).toContain('foo = {');
+    // Sourcemaps should point to the right file
+    expect(bundle).toContain('//# sourceMappingURL=different_output.js.map');
+  });
+
+  it('writes the sourcemap with name specified by \'output\'', () => {
+    const sourcemap = readFileSync(bundleOutputSourcemapLocation, {encoding: 'utf8'});
+    expect(sourcemap).toContain('"sources":');
+    expect(sourcemap).toContain('"mappings":');
+  });
+})

--- a/packages/esbuild/test/output/main.ts
+++ b/packages/esbuild/test/output/main.ts
@@ -1,0 +1,8 @@
+export interface Foo {
+  x: number, y: string,
+}
+
+export const foo: Foo = {
+  x: 123,
+  y: 'hello',
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features): N/A


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
When passing 'output', esbuild throws `Error in esbuild: rule(...) got multiple values for parameter 'output'`

Issue Number: N/A


## What is the new behavior?
Fix esbuild_macro always passing the 'output' argument as generated by the rule's name even when the user provides their own 'output' argument.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I think there may also be a bug with 'output_map' since as far as I can tell, esbuild doesn't let you specify the output file for the sourcemap and always bases it off of the output file's name. Perhaps it shouldn't be an argument to the rule.

