### PR TITLE
feat: make node toolchain_type public so new toolchains can be added

### DIFF
--- a/toolchains/node/BUILD.bazel
+++ b/toolchains/node/BUILD.bazel
@@ -70,7 +70,10 @@ filegroup(
 )
 
 # node toolchain type
-toolchain_type(name = "toolchain_type")
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
 
 # Allow targets to use a toolchains attribute, such as sh_binary and genrule
 # This way they can reference the NODE_PATH make variable.


### PR DESCRIPTION
Enables rules_nodejs to be used in cross-compilation contexts, where
the target architecture is not supported by rules_nodejs.

rules_nodejs's default toolchains are limited via target_compatible_with,
which means they will not work when cross-compiling to Android or iOS
with --platforms for example. With this change, users can define their
own toolchain that is limited by execution platform instead of target
platform.

For example, if you're targeting an unsupported platform, but building
on a Mac, you can place the following in the local WORKSPACE:

    register_toolchains("//ts/node_toolchain")

And the following in ts/node_toolchain/BUILD.bazel:

    toolchain(
        name = "node_toolchain",
        exec_compatible_with = [
            "@platforms//os:osx",
            "@platforms//cpu:x86_64",
        ],
        toolchain = "@nodejs_darwin_amd64_config//:toolchain",
        toolchain_type = "@build_bazel_rules_nodejs//toolchains/node:toolchain_type",
    )

Closes #2565

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

