### PR TITLE
feat(esbuild): tool resolution via toolchain (for discussion)

### DIFF
--- a/examples/esbuild/src/BUILD.bazel
+++ b/examples/esbuild/src/BUILD.bazel
@@ -26,11 +26,6 @@ esbuild(
     minify = True,
     # setting node as the platform will default us to CJS
     platform = "node",
-    tool = select({
-        "@bazel_tools//src/conditions:darwin": "@esbuild_darwin//:bin/esbuild",
-        "@bazel_tools//src/conditions:linux_x86_64": "@esbuild_linux//:bin/esbuild",
-        "@bazel_tools//src/conditions:windows": "@esbuild_windows//:esbuild.exe",
-    }),
     deps = [
         ":lib",
     ],

--- a/packages/esbuild/BUILD.bazel
+++ b/packages/esbuild/BUILD.bazel
@@ -16,6 +16,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@build_bazel_rules_nodejs//:tools/defaults.bzl", "codeowners", "pkg_npm")
 load("@build_bazel_rules_nodejs//tools/stardoc:index.bzl", "stardoc")
 load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "copy_file")
+load("//packages/esbuild:toolchain.bzl", "define_default_toolchains")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -61,17 +62,34 @@ copy_file(
     out = ":npm_version_check.js",
 )
 
+toolchain_type(
+    name = "toolchain_type",
+)
+
+define_default_toolchains()
+
 pkg_npm(
     name = "npm_package",
     srcs = [
         "esbuild.bzl",
+        "esbuild_repo.bzl",
         "helpers.bzl",
         "index.bzl",
         "package.json",
+        "toolchain.bzl",
     ],
-    build_file_content = " ",
+    build_file_content = """\
+load(":toolchain.bzl", "define_default_toolchains")
+
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"]
+)
+
+define_default_toolchains()
+""",
     substitutions = dict({
-        "@build_bazel_rules_nodejs//packages/esbuild:esbuild.bzl": "//@bazel/esbuild:esbuild.bzl",
+        "@build_bazel_rules_nodejs//packages/esbuild": "//@bazel/esbuild",
     }),
     deps = [
         ":npm_version_check",

--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -5,6 +5,7 @@ esbuild rule
 load("@build_bazel_rules_nodejs//:providers.bzl", "JSEcmaScriptModuleInfo", "JSModuleInfo", "NpmPackageInfo", "node_modules_aspect")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "MODULE_MAPPINGS_ASPECT_RESULTS_NAME", "module_mappings_aspect")
 load(":helpers.bzl", "filter_files", "generate_path_mapping", "resolve_js_input", "write_jsconfig_file")
+load(":toolchain.bzl", "TOOLCHAIN")
 
 def _esbuild_impl(ctx):
     # For each dep, JSEcmaScriptModuleInfo is used if found, then JSModuleInfo and finally
@@ -122,7 +123,7 @@ def _esbuild_impl(ctx):
     ctx.actions.run(
         inputs = inputs,
         outputs = outputs,
-        executable = ctx.executable.tool,
+        executable = ctx.toolchains[TOOLCHAIN].binary,
         arguments = [args],
         progress_message = "%s Javascript %s [esbuild]" % ("Bundling" if not ctx.attr.output_dir else "Splitting", entry_point.short_path),
         execution_requirements = execution_requirements,
@@ -258,19 +259,15 @@ edge16, node10, default esnext)
 See https://esbuild.github.io/api/#target for more details
             """,
         ),
-        "tool": attr.label(
-            allow_single_file = True,
-            mandatory = True,
-            executable = True,
-            cfg = "exec",
-            doc = "An executable for the esbuild binary",
-        ),
     },
     implementation = _esbuild_impl,
     doc = """Runs the esbuild bundler under Bazel
 
 For further information about esbuild, see https://esbuild.github.io/
     """,
+    toolchains = [
+        TOOLCHAIN,
+    ],
 )
 
 def esbuild_macro(name, output_dir = False, **kwargs):

--- a/packages/esbuild/esbuild_repo.bzl
+++ b/packages/esbuild/esbuild_repo.bzl
@@ -1,10 +1,12 @@
 """ Generated code; do not edit
 Update by running yarn update-esbuild-versions
 
-Helper macro for fetching esbuild versions for internal tests and examples in rules_nodejs
+Helper macro for fetching esbuild binaries
 """
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@build_bazel_rules_nodejs//packages/esbuild:toolchain.bzl", "register_default_toolchains")
 
 _VERSION = "0.11.5"
 
@@ -13,7 +15,8 @@ def esbuild_dependencies():
 
     version = _VERSION
 
-    http_archive(
+    maybe(
+        http_archive,
         name = "esbuild_darwin",
         urls = [
             "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-%s.tgz" % version,
@@ -22,7 +25,8 @@ def esbuild_dependencies():
         build_file_content = """exports_files(["bin/esbuild"])""",
         sha256 = "98436890727bdb0d4beddd9c9e07d0aeff0e8dfe0169f85e568eca0dd43f665e",
     )
-    http_archive(
+    maybe(
+        http_archive,
         name = "esbuild_windows",
         urls = [
             "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-%s.tgz" % version,
@@ -31,7 +35,8 @@ def esbuild_dependencies():
         build_file_content = """exports_files(["esbuild.exe"])""",
         sha256 = "589c8ff97210bd41de106e6317ce88f9e88d2cacfd8178ae1217f2b857ff6c3a",
     )
-    http_archive(
+    maybe(
+        http_archive,
         name = "esbuild_linux",
         urls = [
             "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-%s.tgz" % version,
@@ -40,3 +45,5 @@ def esbuild_dependencies():
         build_file_content = """exports_files(["bin/esbuild"])""",
         sha256 = "113c2e84895f4422a3676db4e15d9f01b2b4fac041edab25284fdb9574ba58a0",
     )
+
+    register_default_toolchains()

--- a/packages/esbuild/index.bzl
+++ b/packages/esbuild/index.bzl
@@ -19,8 +19,13 @@ load(
     "@build_bazel_rules_nodejs//packages/esbuild:esbuild.bzl",
     _esbuild_macro = "esbuild_macro",
 )
+load(
+    "@build_bazel_rules_nodejs//packages/esbuild:esbuild_repo.bzl",
+    _esbuild_dependencies = "esbuild_dependencies",
+)
 
 esbuild = _esbuild_macro
+esbuild_dependencies = _esbuild_dependencies
 
 # DO NOT ADD MORE rules here unless they appear in the generated docsite.
 # Run yarn stardoc to re-generate the docsite.

--- a/packages/esbuild/test/tests.bzl
+++ b/packages/esbuild/test/tests.bzl
@@ -2,12 +2,4 @@
 
 load("//packages/esbuild:index.bzl", _esbuild = "esbuild")
 
-def esbuild(**kwargs):
-    _esbuild(
-        tool = select({
-            "@bazel_tools//src/conditions:darwin": "@esbuild_darwin//:bin/esbuild",
-            "@bazel_tools//src/conditions:linux_x86_64": "@esbuild_linux//:bin/esbuild",
-            "@bazel_tools//src/conditions:windows": "@esbuild_windows//:esbuild.exe",
-        }),
-        **kwargs
-    )
+esbuild = _esbuild

--- a/packages/esbuild/toolchain.bzl
+++ b/packages/esbuild/toolchain.bzl
@@ -1,0 +1,42 @@
+def _esbuild_toolchain_impl(ctx):
+    return [platform_common.ToolchainInfo(
+        binary = ctx.executable.binary,
+    )]
+
+esbuild_toolchain = rule(
+    implementation = _esbuild_toolchain_impl,
+    attrs = {
+        "binary": attr.label(allow_single_file = True, executable = True, cfg = "exec"),
+    },
+)
+
+_package_path = "@build_bazel_rules_nodejs//packages/esbuild"
+
+TOOLCHAIN = _package_path + ":toolchain_type"
+
+_default_toolchains = [
+    ["@esbuild_darwin//:bin/esbuild", "macos"],
+    ["@esbuild_linux//:bin/esbuild", "linux"],
+    ["@esbuild_windows//:esbuild.exe", "windows"],
+]
+
+def define_default_toolchains():
+    for repo_path, platform in _default_toolchains:
+        esbuild_toolchain(
+            name = "esbuild_" + platform,
+            binary = repo_path,
+        )
+
+        native.toolchain(
+            name = "esbuild_{}_toolchain".format(platform),
+            exec_compatible_with = [
+                "@platforms//os:" + platform,
+                "@platforms//cpu:x86_64",
+            ],
+            toolchain = ":esbuild_" + platform,
+            toolchain_type = TOOLCHAIN,
+        )
+
+def register_default_toolchains():
+    for _, platform in _default_toolchains:
+        native.register_toolchains(_package_path + ":esbuild_{}_toolchain".format(platform))

--- a/scripts/update-esbuild-versions.js
+++ b/scripts/update-esbuild-versions.js
@@ -58,8 +58,11 @@ async function main() {
   const content = [];
   const fileReplacements = [];
 
-  content.push('""" Generated code; do not edit\nUpdate by running yarn update-esbuild-versions\n\nHelper macro for fetching esbuild versions for internal tests and examples in rules_nodejs\n"""\n');
-  content.push('load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")\n');
+  content.push('""" Generated code; do not edit\nUpdate by running yarn update-esbuild-versions\n\nHelper macro for fetching esbuild binaries\n"""\n');
+  content.push('load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")');
+  content.push('load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")');
+  content.push('load("@build_bazel_rules_nodejs//packages/esbuild:toolchain.bzl", "register_default_toolchains")');
+  content.push('');
 
   if(process.argv.length !== 2 && process.argv.length !== 3) {
     console.log("Expected number of arguments is 0 or 1");
@@ -93,7 +96,8 @@ async function main() {
 
     fileReplacements.push([new RegExp(`"${platform}",.+?sha256 = "(.+?)"`, 's'), shasum]);
 
-    content.push('    http_archive(');
+    content.push('    maybe(');
+    content.push('        http_archive,')
     content.push(`        name = "${platform}",`);
     content.push('        urls = [');
     content.push(`            "https://registry.npmjs.org/${PLATFORMS[platform]}/-/${PLATFORMS[platform]}-%s.tgz" % version,`);
@@ -103,6 +107,9 @@ async function main() {
     content.push(`        sha256 = "${shasum}",`);
     content.push('    )');
   }
+
+  content.push('');
+  content.push('    register_default_toolchains()');
 
 
   rmdirSync(tmpDir, {recursive: true});


### PR DESCRIPTION
This currently works when testing packages/esbuild/test, but not when
used via a built package, and I wanted to get an idea of if this is
a desired change before proceeding further.

The current recommended way to pass the esbuild binary to the rule
is to use a select() statement, but that makes a decision based on
the target architecture, not the host architecture, and causes builds
to fail when a target platform has been set with --platforms that is
not one of Mac/Windows/Linux (related: #2591)

By switching to a toolchain, we can specify that each platform's binary
requires a given host platform, so if building on a Mac for example,
it will invoke the esbuild Mac binary even if a build is targeting
another architecture, eg building a native Android/iOS library that
needs to bundle esbuild output products.

I made some other changes in this PR for discussion - they are not
required for toolchain support, but IMHO would be nice to have:

- Bundle esbuild_repo.bzl, so users can get easy access to the same
esbuild version that the tests are run against. Currently, if you update
rules_nodejs after a change like the move to esbuild 0.11, your build
will break until you update the local esbuild binaries in your repo
to match. The change also makes esbuild behave more like the core
nodejs toolchain, which includes some default binary URLs.
- Change the script that generates esbuild_repo.bzl to use maybe(),
so that users can override the default URLs if they wish. This is not
strictly necessary, as the user could define and register their own
toolchains instead, but it just makes it a bit easier to override the
default values.

If there is interest in the toolchain change (and possibly the repo change),
I'd appreciate some advice on how to proceed. A toolchains= argument to
a rule seems to require an absolute label, so I can't use ":toolchain_type" -
it needs to be "//packages/esbuild:toolchain_type" in local development, and
something like "@npm//@bazel/esbuild:toolchain_type" when installed via
npm.

The package.json in examples/esbuild appears to reference npm packages
directly, so presumably the examples can't be updated until a new release
is made. Is there some trick I can use to replace the npm reference
with the files in dist/bin/packages/esbuild/npm_package? I tried updating
the package.json file to reference
"file:../../dist/bin/packages/esbuild/npm_package", but the build fails,
and I'm not sure if that's because it's creating a symlink in the file:
case. Is there a recommended way I can test out the changes without having
to upload packages to npm?

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

