### PR TITLE
feat(esbuild): allow ts / tsx files in esbuilds srcs

### DIFF
--- a/packages/esbuild/test/typescript/ts_as_srcs/BUILD.bazel
+++ b/packages/esbuild/test/typescript/ts_as_srcs/BUILD.bazel
@@ -1,0 +1,35 @@
+load("//:index.bzl", "generated_file_test", "nodejs_binary", "npm_package_bin")
+load("//packages/esbuild/test:tests.bzl", "esbuild")
+
+esbuild(
+    name = "lib",
+    srcs = [
+        "main.ts",
+        "service/index.ts",
+        "service/service.ts",
+    ],
+    entry_point = "main.ts",
+    minify = True,
+    platform = "node",
+    deps = [
+        "//packages/esbuild/test/typescript/ts_as_srcs/questions",
+    ],
+)
+
+nodejs_binary(
+    name = "bin",
+    data = [":lib"],
+    entry_point = ":lib.js",
+)
+
+npm_package_bin(
+    name = "runner",
+    stdout = "output.txt",
+    tool = ":bin",
+)
+
+generated_file_test(
+    name = "ts_srcs_test",
+    src = "output.golden.txt",
+    generated = ":output.txt",
+)

--- a/packages/esbuild/test/typescript/ts_as_srcs/main.ts
+++ b/packages/esbuild/test/typescript/ts_as_srcs/main.ts
@@ -1,0 +1,8 @@
+import {QUESTION} from '@rnj/questions';
+
+import {UnhelpfulService} from './service';
+
+const service = new UnhelpfulService();
+const answer = service.question(QUESTION);
+
+console.log(answer);

--- a/packages/esbuild/test/typescript/ts_as_srcs/output.golden.txt
+++ b/packages/esbuild/test/typescript/ts_as_srcs/output.golden.txt
@@ -1,0 +1,1 @@
+Don't know

--- a/packages/esbuild/test/typescript/ts_as_srcs/questions/BUILD.bazel
+++ b/packages/esbuild/test/typescript/ts_as_srcs/questions/BUILD.bazel
@@ -1,0 +1,23 @@
+load("//internal/js_library:js_library.bzl", "js_library")
+load("//packages/typescript:index.bzl", "ts_project")
+
+ts_project(
+    name = "lib",
+    srcs = [
+        "index.ts",
+        "wood-chuck.ts",
+    ],
+    tsconfig = {
+        "compilerOptions": {
+            "declaration": True,
+            "types": [],
+        },
+    },
+)
+
+js_library(
+    name = "questions",
+    package_name = "@rnj/questions",
+    visibility = ["//packages/esbuild/test/typescript/ts_as_srcs:__pkg__"],
+    deps = [":lib"],
+)

--- a/packages/esbuild/test/typescript/ts_as_srcs/questions/index.ts
+++ b/packages/esbuild/test/typescript/ts_as_srcs/questions/index.ts
@@ -1,0 +1,1 @@
+export * from './wood-chuck';

--- a/packages/esbuild/test/typescript/ts_as_srcs/questions/wood-chuck.ts
+++ b/packages/esbuild/test/typescript/ts_as_srcs/questions/wood-chuck.ts
@@ -1,0 +1,1 @@
+export const QUESTION = `How much wood could a woodchuck chuck, if a woodchuck could chuck wood?`;

--- a/packages/esbuild/test/typescript/ts_as_srcs/service/index.ts
+++ b/packages/esbuild/test/typescript/ts_as_srcs/service/index.ts
@@ -1,0 +1,1 @@
+export * from './service';

--- a/packages/esbuild/test/typescript/ts_as_srcs/service/service.ts
+++ b/packages/esbuild/test/typescript/ts_as_srcs/service/service.ts
@@ -1,0 +1,15 @@
+abstract class Service {
+  abstract question(q: string): string;
+}
+
+export class UnhelpfulService extends Service {
+  public question(q: string): string {
+    return `Don't know`;
+  }
+}
+
+export class HelpfulService extends Service {
+  public question(q: string): string {
+    return `42`;
+  }
+}

--- a/packages/esbuild/test/vanilla_js/BUILD.bazel
+++ b/packages/esbuild/test/vanilla_js/BUILD.bazel
@@ -1,0 +1,29 @@
+load("//:index.bzl", "generated_file_test", "nodejs_binary", "npm_package_bin")
+load("//packages/esbuild/test:tests.bzl", "esbuild")
+
+esbuild(
+    name = "lib",
+    srcs = [
+        "main.js",
+        "name.js",
+    ],
+    entry_point = "main.js",
+)
+
+nodejs_binary(
+    name = "bin",
+    data = [":lib"],
+    entry_point = ":lib.js",
+)
+
+npm_package_bin(
+    name = "runner",
+    stdout = "output.txt",
+    tool = ":bin",
+)
+
+generated_file_test(
+    name = "vanilla_js_test",
+    src = "output.golden.txt",
+    generated = ":output.txt",
+)

--- a/packages/esbuild/test/vanilla_js/main.js
+++ b/packages/esbuild/test/vanilla_js/main.js
@@ -1,0 +1,2 @@
+const NAME = require('./name').NAME;
+console.log(NAME);

--- a/packages/esbuild/test/vanilla_js/name.js
+++ b/packages/esbuild/test/vanilla_js/name.js
@@ -1,0 +1,1 @@
+exports.NAME = 'rules_nodejs'

--- a/packages/esbuild/test/vanilla_js/output.golden.txt
+++ b/packages/esbuild/test/vanilla_js/output.golden.txt
@@ -1,0 +1,1 @@
+rules_nodejs


### PR DESCRIPTION
Esbuild can take `.ts` files as an input and compile to js, this change allows that, and shows that you can plumb together both `esbuild`, `ts_project` and `js_library` in novel ways to compile Typescript and bundle it.

It's a little tricky to handle the `entry_point`, as we resolve a `.ts` entrypoint to its js for the user. This change means that if a `.ts` file is passed to `entry_point` then it's expected to be in `srcs`, rather than `deps`.

As a breaking change in 4.0.0, I'd like to propose that we _don't_ automagically resolve to a `.js` input, and the user has to specify the correct extension, or at least provide a flag to flip to the new behaviour, or back to the `legacy_resolve_ts_entry_points` (I like verbose names). 

closes #2594