### PR TITLE
fix(esbuild): use run_node to call esbuild via a launcher rather than invoking directly

### DIFF
--- a/examples/esbuild/WORKSPACE
+++ b/examples/esbuild/WORKSPACE
@@ -25,12 +25,12 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/3.3.0/rules_nodejs-3.3.0.tar.gz"],
 )
 
-_ESBUILD_VERSION = "0.11.5"
+_ESBUILD_VERSION = "0.11.6"
 
 http_archive(
     name = "esbuild_darwin",
     build_file_content = """exports_files(["bin/esbuild"])""",
-    sha256 = "98436890727bdb0d4beddd9c9e07d0aeff0e8dfe0169f85e568eca0dd43f665e",
+    sha256 = "2b06365b075b854654fc9ed26fcd48a0c38947e1c8d5151ce400cd1e173bb138",
     strip_prefix = "package",
     urls = [
         "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-%s.tgz" % _ESBUILD_VERSION,
@@ -40,7 +40,7 @@ http_archive(
 http_archive(
     name = "esbuild_windows",
     build_file_content = """exports_files(["esbuild.exe"])""",
-    sha256 = "589c8ff97210bd41de106e6317ce88f9e88d2cacfd8178ae1217f2b857ff6c3a",
+    sha256 = "ddab1121833f0a12ca4fb3e288231e058f5526310671e84c0a9aa575340bb20b",
     strip_prefix = "package",
     urls = [
         "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-%s.tgz" % _ESBUILD_VERSION,
@@ -50,7 +50,7 @@ http_archive(
 http_archive(
     name = "esbuild_linux",
     build_file_content = """exports_files(["bin/esbuild"])""",
-    sha256 = "113c2e84895f4422a3676db4e15d9f01b2b4fac041edab25284fdb9574ba58a0",
+    sha256 = "34612e3e15e6c31d9d742d3fd677bd5208b7e5c0ee9c93809999138c6c5c1039",
     strip_prefix = "package",
     urls = [
         "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-%s.tgz" % _ESBUILD_VERSION,

--- a/packages/esbuild/BUILD.bazel
+++ b/packages/esbuild/BUILD.bazel
@@ -19,6 +19,8 @@ load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "co
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["launcher.js"])
+
 codeowners(
     teams = ["@mattem"],
 )
@@ -67,11 +69,14 @@ pkg_npm(
         "esbuild.bzl",
         "helpers.bzl",
         "index.bzl",
+        "launcher.js",
         "package.json",
     ],
-    build_file_content = " ",
+    build_file_content = """exports_files(["launcher.js"])
+    """,
     substitutions = dict({
         "@build_bazel_rules_nodejs//packages/esbuild:esbuild.bzl": "//@bazel/esbuild:esbuild.bzl",
+        "@build_bazel_rules_nodejs//packages/esbuild:launcher.js": "//@bazel/esbuild:launcher.js",
     }),
     deps = [
         ":npm_version_check",

--- a/packages/esbuild/_README.md
+++ b/packages/esbuild/_README.md
@@ -18,7 +18,7 @@ yarn add -D @bazel/esbuild
 Add an `http_archive` fetching the esbuild binary for each platform that you need to support. 
 
 ```python
-_ESBUILD_VERSION = "0.11.5"  # reminder: update SHAs below when changing this value
+_ESBUILD_VERSION = "0.11.6"  # reminder: update SHAs below when changing this value
 http_archive(
     name = "esbuild_darwin",
     urls = [
@@ -26,7 +26,7 @@ http_archive(
     ],
     strip_prefix = "package",
     build_file_content = """exports_files(["bin/esbuild"])""",
-    sha256 = "98436890727bdb0d4beddd9c9e07d0aeff0e8dfe0169f85e568eca0dd43f665e",
+    sha256 = "2b06365b075b854654fc9ed26fcd48a0c38947e1c8d5151ce400cd1e173bb138",
 )
 
 http_archive(
@@ -36,7 +36,7 @@ http_archive(
     ],
     strip_prefix = "package",
     build_file_content = """exports_files(["esbuild.exe"])""",
-    sha256 = "589c8ff97210bd41de106e6317ce88f9e88d2cacfd8178ae1217f2b857ff6c3a",
+    sha256 = "ddab1121833f0a12ca4fb3e288231e058f5526310671e84c0a9aa575340bb20b",
 )
 
 http_archive(
@@ -46,7 +46,7 @@ http_archive(
     ],
     strip_prefix = "package",
     build_file_content = """exports_files(["bin/esbuild"])""",
-    sha256 = "113c2e84895f4422a3676db4e15d9f01b2b4fac041edab25284fdb9574ba58a0",
+    sha256 = "34612e3e15e6c31d9d742d3fd677bd5208b7e5c0ee9c93809999138c6c5c1039",
 )
 ```
 

--- a/packages/esbuild/esbuild_repo.bzl
+++ b/packages/esbuild/esbuild_repo.bzl
@@ -6,7 +6,7 @@ Helper macro for fetching esbuild versions for internal tests and examples in ru
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-_VERSION = "0.11.5"
+_VERSION = "0.11.6"
 
 def esbuild_dependencies():
     """Helper to install required dependencies for the esbuild rules"""
@@ -20,7 +20,7 @@ def esbuild_dependencies():
         ],
         strip_prefix = "package",
         build_file_content = """exports_files(["bin/esbuild"])""",
-        sha256 = "98436890727bdb0d4beddd9c9e07d0aeff0e8dfe0169f85e568eca0dd43f665e",
+        sha256 = "2b06365b075b854654fc9ed26fcd48a0c38947e1c8d5151ce400cd1e173bb138",
     )
     http_archive(
         name = "esbuild_windows",
@@ -29,7 +29,7 @@ def esbuild_dependencies():
         ],
         strip_prefix = "package",
         build_file_content = """exports_files(["esbuild.exe"])""",
-        sha256 = "589c8ff97210bd41de106e6317ce88f9e88d2cacfd8178ae1217f2b857ff6c3a",
+        sha256 = "ddab1121833f0a12ca4fb3e288231e058f5526310671e84c0a9aa575340bb20b",
     )
     http_archive(
         name = "esbuild_linux",
@@ -38,5 +38,5 @@ def esbuild_dependencies():
         ],
         strip_prefix = "package",
         build_file_content = """exports_files(["bin/esbuild"])""",
-        sha256 = "113c2e84895f4422a3676db4e15d9f01b2b4fac041edab25284fdb9574ba58a0",
+        sha256 = "34612e3e15e6c31d9d742d3fd677bd5208b7e5c0ee9c93809999138c6c5c1039",
     )

--- a/packages/esbuild/launcher.js
+++ b/packages/esbuild/launcher.js
@@ -1,0 +1,25 @@
+const {spawn} = require('child_process');
+const {readFileSync} = require('fs');
+
+function getFlag(flag, required = true) {
+  const argvFlag = process.argv.find(arg => arg.startsWith(`${flag}=`));
+  if (required && !argvFlag) {
+    console.error(`Expected flag '${flag}' passed to launcher, but not found`);
+    process.exit(1);
+  }
+
+  return argvFlag.split('=')[1];
+}
+
+const esbuild = getFlag('--esbuild');
+const params_file_path = getFlag('--esbuild_flags');
+
+let flags = [];
+try {
+  flags = readFileSync(params_file_path, {encoding: 'utf8'}).trim().replace(/'/gm, '').split('\n');
+} catch (e) {
+  console.error('Error while reading esbuild flags param file', e);
+  process.exit(1);
+}
+
+spawn(esbuild, flags, {detached: true, stdio: 'inherit'});

--- a/packages/esbuild/test/vanilla_js/BUILD.bazel
+++ b/packages/esbuild/test/vanilla_js/BUILD.bazel
@@ -8,6 +8,9 @@ esbuild(
         "name.js",
     ],
     entry_point = "main.js",
+    deps = [
+        "@npm//date-fns",
+    ],
 )
 
 nodejs_binary(

--- a/packages/esbuild/test/vanilla_js/main.js
+++ b/packages/esbuild/test/vanilla_js/main.js
@@ -1,2 +1,5 @@
 const NAME = require('./name').NAME;
+const {isDate} = require('date-fns');
+
+console.log(isDate(NAME));
 console.log(NAME);

--- a/packages/esbuild/test/vanilla_js/output.golden.txt
+++ b/packages/esbuild/test/vanilla_js/output.golden.txt
@@ -1,1 +1,2 @@
+false
 rules_nodejs


### PR DESCRIPTION
Use `run_node` to call esbuild via a launcher rather than invoking directly. This addresses two issues:

* using `run_node` allows us to invoke the linker fist. We no longer have to teach esbuild how to resolve `node_modules`, fixing https://github.com/bazelbuild/rules_nodejs/issues/2586
* Opens up the possibility of using esbuild via an API rather than directly, allowing us to add support for plugins if needed

Currently 1st party sources are still resolved though the `jsconfig.json` file, as this does change the bundle output slightly. 

closes https://github.com/bazelbuild/rules_nodejs/issues/2586