### PR TITLE
refactor: make our full set of typings mutually compatible

### DIFF
--- a/internal/linker/test/local/fit/tsconfig.json
+++ b/internal/linker/test/local/fit/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
-    "types": []
+    "declaration": true
   }
 }

--- a/internal/linker/test/multi_linker/BUILD.bazel
+++ b/internal/linker/test/multi_linker/BUILD.bazel
@@ -6,7 +6,7 @@ checked_in_ts_project(
     src = "test.ts",
     checked_in_js = "checked_in_test.js",
     deps = [
-        "@npm//@types/jest",
+        "@npm//@types/jasmine",
         "@npm//@types/node",
     ],
 )

--- a/internal/linker/test/multi_linker/tsconfig.json
+++ b/internal/linker/test/multi_linker/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "compilerOptions": {
-    "types": ["node", "jest"]
+    "types": ["node", "jasmine"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
         "@gregmagolan/test-a": "0.0.5",
         "@types/hammerjs": "2.0.35",
         "@types/jasmine": "~3.3.13",
-        "@types/jest": "24.9.0",
         "@types/node": "^12.0.0",
         "@types/semver": "6.2.0",
         "babel-jest": "^25.5.1",

--- a/packages/typescript/test/ts_library_esm_with_jest/ts_jest_test.bzl
+++ b/packages/typescript/test/ts_library_esm_with_jest/ts_jest_test.bzl
@@ -12,7 +12,10 @@ Uses ts_library prodmode esm output"""
         name = "%s_ts" % name,
         srcs = srcs,
         data = data,
-        deps = deps + ["@npm//@types/jest"],
+        # Ideally we'd use @types/jest, but it causes typings conflicts
+        # if installed together with @types/jasmine and they both end up
+        # ambiently included in a TS compile
+        deps = deps + ["@npm//@types/jasmine"],
         # NB: hacky hidden configuration setting so that es6_sources does not include tsickle
         #     .externs.js outputs
         runtime = "nodejs",

--- a/packages/typescript/test/ts_project/allow_js/tsconfig.json
+++ b/packages/typescript/test/ts_project/allow_js/tsconfig.json
@@ -4,6 +4,5 @@
       "sourceMap": true,
       "declaration": true,
       "declarationMap": true,
-      "types": []
   }
 }

--- a/packages/typescript/test/ts_project/declaration_only/tsconfig.json
+++ b/packages/typescript/test/ts_project/declaration_only/tsconfig.json
@@ -2,6 +2,5 @@
     "compilerOptions": {
         "declaration": true,
         "emitDeclarationOnly": true,
-        "types": []
     }
 }

--- a/packages/typescript/test/ts_project/declarationdir/tsconfig.json
+++ b/packages/typescript/test/ts_project/declarationdir/tsconfig.json
@@ -3,6 +3,5 @@
         "sourceMap": true,
         "declaration": true,
         "declarationMap": true,
-        "types": []
     }
 }

--- a/packages/typescript/test/ts_project/declarationdir_with_value/tsconfig.json
+++ b/packages/typescript/test/ts_project/declarationdir_with_value/tsconfig.json
@@ -3,6 +3,5 @@
         "sourceMap": true,
         "declaration": true,
         "declarationMap": true,
-        "types": []
     }
 }

--- a/packages/typescript/test/ts_project/empty_intermediate/tsconfig-a.json
+++ b/packages/typescript/test/ts_project/empty_intermediate/tsconfig-a.json
@@ -1,6 +1,5 @@
 {
     "files": ["a.d.ts"],
     "compilerOptions": {
-        "types": []
     }
 }

--- a/packages/typescript/test/ts_project/empty_intermediate/tsconfig-b.json
+++ b/packages/typescript/test/ts_project/empty_intermediate/tsconfig-b.json
@@ -1,6 +1,5 @@
 {
     "files": [],
     "compilerOptions": {
-        "types": []
     }
 }

--- a/packages/typescript/test/ts_project/empty_intermediate/tsconfig-c.json
+++ b/packages/typescript/test/ts_project/empty_intermediate/tsconfig-c.json
@@ -11,6 +11,5 @@
             "../../../../../bazel-out/k8-dbg/bin/packages/typescript/test/ts_project/empty_intermediate",
             "../../../../../bazel-out/x64_windows-dbg/bin/packages/typescript/test/ts_project/empty_intermediate",
         ],
-        "types": []
     }
 }

--- a/packages/typescript/test/ts_project/extends_chain/tsconfig.base.json
+++ b/packages/typescript/test/ts_project/extends_chain/tsconfig.base.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
     "noImplicitAny": true,
-    "types": []
   }
 }

--- a/packages/typescript/test/ts_project/generated_tsconfig/config/BUILD.bazel
+++ b/packages/typescript/test/ts_project/generated_tsconfig/config/BUILD.bazel
@@ -10,10 +10,10 @@ ts_project(
             "declarationDir": "types",
             "declarationMap": True,
             "module": "esnext",
+            "moduleResolution": "node",
             "outDir": "out",
             "rootDir": "src",
             "sourceMap": True,
-            "types": [],
         },
     },
 )

--- a/packages/typescript/test/ts_project/generated_tsconfig/config_attrs/BUILD.bazel
+++ b/packages/typescript/test/ts_project/generated_tsconfig/config_attrs/BUILD.bazel
@@ -13,7 +13,7 @@ ts_project(
     tsconfig = {
         "compilerOptions": {
             "module": "esnext",
-            "types": [],
+            "moduleResolution": "node",
         },
     },
 )

--- a/packages/typescript/test/ts_project/generated_tsconfig/decl_only/BUILD.bazel
+++ b/packages/typescript/test/ts_project/generated_tsconfig/decl_only/BUILD.bazel
@@ -7,7 +7,6 @@ ts_project(
         "compilerOptions": {
             "declaration": True,
             "emitDeclarationOnly": True,
-            "types": [],
         },
     },
 )

--- a/packages/typescript/test/ts_project/generated_tsconfig/default/BUILD.bazel
+++ b/packages/typescript/test/ts_project/generated_tsconfig/default/BUILD.bazel
@@ -4,7 +4,6 @@ load("//packages/typescript:index.bzl", "ts_project")
 ts_project(
     tsconfig = {
         "compilerOptions": {
-            "types": [],
         },
     },
 )

--- a/packages/typescript/test/ts_project/generated_tsconfig/extends/BUILD.bazel
+++ b/packages/typescript/test/ts_project/generated_tsconfig/extends/BUILD.bazel
@@ -9,7 +9,6 @@ ts_project(
         "compilerOptions": {
             "declaration": True,
             "outDir": "case_one",
-            "types": [],
         },
     },
 )
@@ -30,7 +29,6 @@ ts_project(
         "compilerOptions": {
             "declaration": True,
             "outDir": "case_two",
-            "types": [],
         },
     },
 )

--- a/packages/typescript/test/ts_project/generated_tsconfig/gen_src/BUILD.bazel
+++ b/packages/typescript/test/ts_project/generated_tsconfig/gen_src/BUILD.bazel
@@ -13,7 +13,6 @@ ts_project(
     tsconfig = {
         "compilerOptions": {
             "rootDir": "subdir",
-            "types": [],
         },
     },
 )

--- a/packages/typescript/test/ts_project/import_package_by_name/app/BUILD.bazel
+++ b/packages/typescript/test/ts_project/import_package_by_name/app/BUILD.bazel
@@ -4,7 +4,6 @@ ts_project(
     tsconfig = {
         "compilerOptions": {
             "moduleResolution": "Node",
-            "types": [],
         },
     },
     deps = ["//packages/typescript/test/ts_project/import_package_by_name/lib"],

--- a/packages/typescript/test/ts_project/import_package_by_name/lib/BUILD.bazel
+++ b/packages/typescript/test/ts_project/import_package_by_name/lib/BUILD.bazel
@@ -5,7 +5,6 @@ ts_project(
     tsconfig = {
         "compilerOptions": {
             "declaration": True,
-            "types": [],
         },
     },
 )

--- a/packages/typescript/test/ts_project/js_library/tsconfig.json
+++ b/packages/typescript/test/ts_project/js_library/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "files": ["b.ts"],
     "compilerOptions": {
-        "types": [],
         // Help TypeScript locate the a.d.ts file from dep.
         // Note that it comes from a js_library which means the .d.ts file is copied to the bazel-out folder.
         // Needed when running in a sandbox or remote.

--- a/packages/typescript/test/ts_project/json/BUILD.bazel
+++ b/packages/typescript/test/ts_project/json/BUILD.bazel
@@ -30,7 +30,6 @@ ts_project(
             "declaration": True,
             "emitDeclarationOnly": True,
             "resolveJsonModule": True,
-            "types": [],
         },
     },
 )

--- a/packages/typescript/test/ts_project/json/tsconfig.json
+++ b/packages/typescript/test/ts_project/json/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-        "types": [],
         "resolveJsonModule": true
     }
 }

--- a/packages/typescript/test/ts_project/jsx/tsconfig.json
+++ b/packages/typescript/test/ts_project/jsx/tsconfig.json
@@ -4,7 +4,6 @@
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
-    "jsx": "preserve",
-    "types": []
+    "jsx": "preserve"
   }
 }

--- a/packages/typescript/test/ts_project/outdir/BUILD.bazel
+++ b/packages/typescript/test/ts_project/outdir/BUILD.bazel
@@ -8,6 +8,8 @@ load("//packages/typescript:index.bzl", "ts_project")
         args = [
             "--module",
             format,
+            "--moduleResolution",
+            "node",
         ],
         # Write the output files to an extra nested directory
         out_dir = format,

--- a/packages/typescript/test/ts_project/outdir/tsconfig.json
+++ b/packages/typescript/test/ts_project/outdir/tsconfig.json
@@ -1,5 +1,4 @@
 {
     "compilerOptions": {
-        "types": []
     }
 }

--- a/packages/typescript/test/ts_project/output_group/tsconfig.json
+++ b/packages/typescript/test/ts_project/output_group/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-        "types": [],
         "declaration": true
     }
 }

--- a/packages/typescript/test/ts_project/rootdir/tsconfig.json
+++ b/packages/typescript/test/ts_project/rootdir/tsconfig.json
@@ -1,5 +1,4 @@
 {
     "compilerOptions": {
-        "types": []
     }
 }

--- a/packages/typescript/test/ts_project/rootdir_with_value/tsconfig.json
+++ b/packages/typescript/test/ts_project/rootdir_with_value/tsconfig.json
@@ -1,5 +1,4 @@
 {
     "compilerOptions": {
-        "types": []
     }
 }

--- a/packages/typescript/test/ts_project/simple/tsconfig.json
+++ b/packages/typescript/test/ts_project/simple/tsconfig.json
@@ -1,5 +1,4 @@
 {
     "compilerOptions": {
-        "types": []
     }
 }

--- a/packages/typescript/test/ts_project/ts_config/tsconfig.json
+++ b/packages/typescript/test/ts_project/ts_config/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "extends": "./tsconfig-extended.json",
     "compilerOptions": {
-        "types": []
     }
 }

--- a/packages/typescript/test/ts_project/tsbuildinfofile/tsconfig.json
+++ b/packages/typescript/test/ts_project/tsbuildinfofile/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
         "composite": true,
-        "tsBuildInfoFile": "my.tsbuildinfo",
-        "types": []
+        "tsBuildInfoFile": "my.tsbuildinfo"
     }
 }

--- a/packages/typescript/test/ts_project/tsconfig-base.json
+++ b/packages/typescript/test/ts_project/tsconfig-base.json
@@ -18,6 +18,5 @@
             "../../../../bazel-out/k8-dbg/bin/packages/typescript/test/ts_project",
             "../../../../bazel-out/x64_windows-dbg/bin/packages/typescript/test/ts_project",
         ],
-        "types": []
     }
 }

--- a/packages/typescript/test/ts_project/validation/tsconfig.json
+++ b/packages/typescript/test/ts_project/validation/tsconfig.json
@@ -4,7 +4,6 @@
         "composite": true,
         "declarationMap": true,
         "declaration": true,
-        "sourceMap": true,
-        "types": []
+        "sourceMap": true
     }
 }

--- a/packages/typescript/test/ts_project/worker/BUILD.bazel
+++ b/packages/typescript/test/ts_project/worker/BUILD.bazel
@@ -5,7 +5,6 @@ ts_project(
     tsconfig = {
         "compilerOptions": {
             "declaration": True,
-            "types": [],
         },
     },
 )


### PR DESCRIPTION
By not installing @types/jest and @types/jasmine together, we avoid TS having type conflicts when running outside the sandbox.
This makes it a lot easier to make compiles succeed on windows for example, which trips a lot of first-time contributors
