### PR TITLE
feat(concatjs): enable junit report for karma_web_test

### DIFF
--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -59,6 +59,7 @@
         "karma-chrome-launcher": "2.2.0",
         "karma-firefox-launcher": "1.1.0",
         "karma-jasmine": "2.0.1",
+        "karma-junit-reporter": "2.0.1",
         "karma-requirejs": "1.1.0",
         "karma-sourcemap-loader": "0.3.7",
         "protractor": "^5.4.2",

--- a/examples/angular/yarn.lock
+++ b/examples/angular/yarn.lock
@@ -4298,6 +4298,14 @@ karma-jasmine@2.0.1:
   dependencies:
     jasmine-core "^3.3"
 
+karma-junit-reporter@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/karma-junit-reporter/-/karma-junit-reporter-2.0.1.tgz#d34eef7f0b2fd064e0896954e8851a90cf14c8f3"
+  integrity sha512-VtcGfE0JE4OE1wn0LK8xxDKaTP7slN8DO3I+4xg6gAi1IoAHAXOJ1V9G/y45Xg6sxdxPOR3THCFtDlAfBo9Afw==
+  dependencies:
+    path-is-absolute "^1.0.0"
+    xmlbuilder "12.0.0"
+
 karma-requirejs@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/karma-requirejs/-/karma-requirejs-1.1.0.tgz#fddae2cb87d7ebc16fb0222893564d7fee578798"
@@ -7349,6 +7357,11 @@ xml2js@^0.4.17:
     sax ">=0.6.0"
     util.promisify "~1.0.0"
     xmlbuilder "~11.0.0"
+
+xmlbuilder@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-12.0.0.tgz#e2ed675e06834a089ddfb84db96e2c2b03f78c1a"
+  integrity sha512-lMo8DJ8u6JRWp0/Y4XLa/atVDr75H9litKlb2E5j3V3MesoL50EBgZDWoLT3F/LztVnG67GjPXLZpqcky/UMnQ==
 
 xmlbuilder@~11.0.0:
   version "11.0.1"

--- a/examples/web_testing/package.json
+++ b/examples/web_testing/package.json
@@ -8,6 +8,7 @@
     "karma-chrome-launcher": "2.2.0",
     "karma-firefox-launcher": "1.1.0",
     "karma-jasmine": "2.0.1",
+    "karma-junit-reporter": "2.0.1",
     "karma-json-result-reporter": "1.0.0",
     "karma-requirejs": "1.1.0",
     "karma-sourcemap-loader": "0.3.7",

--- a/examples/web_testing/yarn.lock
+++ b/examples/web_testing/yarn.lock
@@ -1100,6 +1100,14 @@ karma-json-result-reporter@1.0.0:
   dependencies:
     fun-map "^3.3.1"
 
+karma-junit-reporter@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/karma-junit-reporter/-/karma-junit-reporter-2.0.1.tgz#d34eef7f0b2fd064e0896954e8851a90cf14c8f3"
+  integrity sha512-VtcGfE0JE4OE1wn0LK8xxDKaTP7slN8DO3I+4xg6gAi1IoAHAXOJ1V9G/y45Xg6sxdxPOR3THCFtDlAfBo9Afw==
+  dependencies:
+    path-is-absolute "^1.0.0"
+    xmlbuilder "12.0.0"
+
 karma-requirejs@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/karma-requirejs/-/karma-requirejs-1.1.0.tgz#fddae2cb87d7ebc16fb0222893564d7fee578798"
@@ -2100,6 +2108,11 @@ ws@~3.3.1:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
+
+xmlbuilder@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-12.0.0.tgz#e2ed675e06834a089ddfb84db96e2c2b03f78c1a"
+  integrity sha512-lMo8DJ8u6JRWp0/Y4XLa/atVDr75H9litKlb2E5j3V3MesoL50EBgZDWoLT3F/LztVnG67GjPXLZpqcky/UMnQ==
 
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "karma-chrome-launcher": "3.1.0",
         "karma-firefox-launcher": "2.1.0",
         "karma-jasmine": "4.0.1",
+        "karma-junit-reporter": "^2.0.1",
         "karma-requirejs": "1.1.0",
         "karma-sourcemap-loader": "0.3.8",
         "lit-element": "^2.2.1",

--- a/packages/concatjs/package.json
+++ b/packages/concatjs/package.json
@@ -26,6 +26,7 @@
         "karma-chrome-launcher": ">=2.0.0",
         "karma-firefox-launcher": ">=1.0.0",
         "karma-jasmine": ">=2.0.0",
+        "karma-junit-reporter": ">=2.0.0",
         "karma-requirejs": ">=1.0.0",
         "karma-sourcemap-loader": ">=0.3.0"
     },

--- a/packages/concatjs/web_test/BUILD.bazel
+++ b/packages/concatjs/web_test/BUILD.bazel
@@ -28,6 +28,7 @@ nodejs_binary(
         "@npm//karma-chrome-launcher",
         "@npm//karma-firefox-launcher",
         "@npm//karma-jasmine",
+        "@npm//karma-junit-reporter",
         "@npm//karma-requirejs",
         "@npm//karma-sourcemap-loader",
         "@npm//requirejs",

--- a/packages/concatjs/web_test/test/karma/BUILD.bazel
+++ b/packages/concatjs/web_test/test/karma/BUILD.bazel
@@ -21,6 +21,9 @@ karma_web_test_suite(
     srcs = glob(
         ["*.js"],
         exclude = [
+            "coverage_source_uncovered.js",
+            "coverage_source.js",
+            "coverage.spec.js",
             "unnamed-amd-module.js",
             "init-test.js",
         ],
@@ -43,6 +46,20 @@ karma_web_test_suite(
         "init-test.js",
         "requirejs-config.js",
     ],
+)
+
+karma_web_test_suite(
+    name = "coverage_test",
+    srcs = [
+        "coverage.spec.js",
+        "coverage_source.js",
+        "coverage_source_uncovered.js",
+    ],
+    browsers = [
+        "@io_bazel_rules_webtesting//browsers:chromium-local",
+        "@io_bazel_rules_webtesting//browsers:firefox-local",
+    ],
+    tags = ["native"],
 )
 
 custom_browser(

--- a/packages/concatjs/web_test/test/karma/coverage.spec.js
+++ b/packages/concatjs/web_test/test/karma/coverage.spec.js
@@ -1,0 +1,27 @@
+(function(factory) {
+if (typeof module === 'object' && typeof module.exports === 'object') {
+  var v = factory(require, exports);
+  if (v !== undefined) module.exports = v;
+} else if (typeof define === 'function' && define.amd) {
+  define(
+      'build_bazel_rules_nodejs/packages/concatjs/web_test/test/karma/coverage.spec',
+      [
+        'require', 'exports',
+        'build_bazel_rules_nodejs/packages/concatjs/web_test/test/karma/coverage_source'
+      ],
+      factory);
+}
+})(function(require, exports) {
+'use strict';
+Object.defineProperty(exports, '__esModule', {value: true});
+var coverage_source_1 =
+    require('build_bazel_rules_nodejs/packages/concatjs/web_test/test/karma/coverage_source');
+describe('coverage function', () => {
+  it('should cover one branch', () => {
+    expect(coverage_source_1.isString(2)).toBe(false);
+  });
+  it('should cover the other branch', () => {
+    expect(coverage_source_1.isString('some string')).toBe(true);
+  });
+});
+});

--- a/packages/concatjs/web_test/test/karma/coverage_source.js
+++ b/packages/concatjs/web_test/test/karma/coverage_source.js
@@ -1,0 +1,21 @@
+(function(factory) {
+if (typeof module === 'object' && typeof module.exports === 'object') {
+  var v = factory(require, exports);
+  if (v !== undefined) module.exports = v;
+} else if (typeof define === 'function' && define.amd) {
+  define(
+      'build_bazel_rules_nodejs/packages/concatjs/web_test/test/karma/coverage_source',
+      ['require', 'exports'], factory);
+}
+})(function(require, exports) {
+'use strict';
+Object.defineProperty(exports, '__esModule', {value: true});
+function isString(input) {
+  if (typeof input === 'string') {
+    return true;
+  } else {
+    return false;
+  }
+}
+exports.isString = isString;
+});

--- a/packages/concatjs/web_test/test/karma/coverage_source_uncovered.js
+++ b/packages/concatjs/web_test/test/karma/coverage_source_uncovered.js
@@ -1,0 +1,20 @@
+(function(factory) {
+if (typeof module === 'object' && typeof module.exports === 'object') {
+  var v = factory(require, exports);
+  if (v !== undefined) module.exports = v;
+} else if (typeof define === 'function' && define.amd) {
+  define(
+      'build_bazel_rules_nodejs/packages/concatjs/web_test/test/karma/coverage_source_uncovered',
+      ['require', 'exports'], factory);
+}
+})(function(require, exports) {
+'use strict';
+Object.defineProperty(exports, '__esModule', {value: true});
+// noting in  this file should be required, so we can test the c8 feature all: true
+// which will pick up files that aren't directly referenced by test files
+// but are added to coverage as empty coverage
+function notCalled(input) {
+  return input * 13;
+}
+exports.notCalled = notCalled;
+});

--- a/packages/concatjs/web_test/test/karma_typescript/BUILD.bazel
+++ b/packages/concatjs/web_test/test/karma_typescript/BUILD.bazel
@@ -78,6 +78,36 @@ filegroup(
     ],
 )
 
+ts_library(
+    name = "coverage_test_srcs",
+    srcs = [
+        "coverage_source.ts",
+        "coverage_source_uncovered.ts",
+    ],
+)
+
+ts_library(
+    name = "coverage_test_spec_srcs",
+    srcs = ["coverage.spec.ts"],
+    deps = [
+        ":coverage_test_srcs",
+        "@npm//@types/jasmine",
+    ],
+)
+
+karma_web_test_suite(
+    name = "coverage_test",
+    browsers = [
+        "@io_bazel_rules_webtesting//browsers:chromium-local",
+        "@io_bazel_rules_webtesting//browsers:firefox-local",
+    ],
+    tags = ["native"],
+    deps = [
+        # ts_library target, must be TS module
+        ":coverage_test_spec_srcs",
+    ],
+)
+
 jasmine_node_test(
     name = "user_files_test",
     srcs = [

--- a/packages/concatjs/web_test/test/karma_typescript/coverage.spec.ts
+++ b/packages/concatjs/web_test/test/karma_typescript/coverage.spec.ts
@@ -1,0 +1,10 @@
+import {isString} from './coverage_source';
+
+describe('coverage function', () => {
+  it('should cover one branch', () => {
+    expect(isString(2 as any)).toBe(false);
+  });
+  it('should cover the other branch', () => {
+    expect(isString('some string')).toBe(true);
+  });
+});

--- a/packages/concatjs/web_test/test/karma_typescript/coverage_source.ts
+++ b/packages/concatjs/web_test/test/karma_typescript/coverage_source.ts
@@ -1,0 +1,7 @@
+export function isString(input: string) {
+  if (typeof input === 'string') {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/packages/concatjs/web_test/test/karma_typescript/coverage_source_uncovered.ts
+++ b/packages/concatjs/web_test/test/karma_typescript/coverage_source_uncovered.ts
@@ -1,0 +1,6 @@
+// noting in  this file should be required, so we can test the c8 feature all: true
+// which will pick up files that aren't directly referenced by test files
+// but are added to coverage as empty coverage
+export function notCalled(input: number) {
+  return input * 13;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1314,15 +1314,6 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
-"@jest/types@^24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.9.0.tgz#63cb26cb7500d069e5a389441a7c6ab5e909fc59"
-  integrity sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^13.0.0"
-
 "@jest/types@^25.3.0":
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.3.0.tgz#88f94b277a1d028fd7117bc1f74451e0fc2131e7"
@@ -1622,13 +1613,6 @@
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.3.16.tgz#7c84074f5d7f84da9a14f816ccfb9aeb4da13f27"
   integrity sha512-Nveep4zKGby8uIvG2AEUyYOwZS8uVeHK9TgbuWYSawUDDdIgfhCKz28QzamTo//Jk7Ztt9PO3f+vzlB6a4GV1Q==
 
-"@types/jest@24.9.0":
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.0.tgz#78c6991cd1734cf0d390be24875e310bb0a9fb74"
-  integrity sha512-dXvuABY9nM1xgsXlOtLQXJKdacxZJd7AtvLsKZ/0b57ruMXDKCOXAC/M75GbllQX6o1pcZ5hAG4JzYy7Z/wM2w==
-  dependencies:
-    jest-diff "^24.3.0"
-
 "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
@@ -1695,13 +1679,6 @@
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
-
-"@types/yargs@^13.0.0":
-  version "13.0.8"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.8.tgz#a38c22def2f1c2068f8971acb3ea734eb3c64a99"
-  integrity sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0":
   version "15.0.4"
@@ -1844,7 +1821,7 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.0.0, ansi-regex@^4.1.0:
+ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
@@ -3519,11 +3496,6 @@ didyoumean2@2.0.4:
     leven "^2.0.0"
     lodash.deburr "^4.1.0"
     ramda "^0.26.1"
-
-diff-sequences@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
-  integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
 
 diff-sequences@^25.2.6:
   version "25.2.6"
@@ -5517,16 +5489,6 @@ jest-config@^25.3.0:
     pretty-format "^25.3.0"
     realpath-native "^2.0.0"
 
-jest-diff@^24.3.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
-  integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
-  dependencies:
-    chalk "^2.0.1"
-    diff-sequences "^24.9.0"
-    jest-get-type "^24.9.0"
-    pretty-format "^24.9.0"
-
 jest-diff@^25.3.0:
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.3.0.tgz#0d7d6f5d6171e5dacde9e05be47b3615e147c26f"
@@ -5578,11 +5540,6 @@ jest-environment-node@^25.3.0:
     jest-mock "^25.3.0"
     jest-util "^25.3.0"
     semver "^6.3.0"
-
-jest-get-type@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
-  integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
 
 jest-get-type@^25.2.6:
   version "25.2.6"
@@ -6033,6 +5990,14 @@ karma-jasmine@4.0.1:
   integrity sha512-h8XDAhTiZjJKzfkoO1laMH+zfNlra+dEQHUAjpn5JV1zCPtOIVWGQjLBrqhnzQa/hrU2XrZwSyBa6XjEBzfXzw==
   dependencies:
     jasmine-core "^3.6.0"
+
+karma-junit-reporter@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/karma-junit-reporter/-/karma-junit-reporter-2.0.1.tgz#d34eef7f0b2fd064e0896954e8851a90cf14c8f3"
+  integrity sha512-VtcGfE0JE4OE1wn0LK8xxDKaTP7slN8DO3I+4xg6gAi1IoAHAXOJ1V9G/y45Xg6sxdxPOR3THCFtDlAfBo9Afw==
+  dependencies:
+    path-is-absolute "^1.0.0"
+    xmlbuilder "12.0.0"
 
 karma-requirejs@1.1.0:
   version "1.1.0"
@@ -7863,16 +7828,6 @@ prettier@^1.15.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-pretty-format@^24.9.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
-  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-regex "^4.0.0"
-    ansi-styles "^3.2.0"
-    react-is "^16.8.4"
-
 pretty-format@^25.3.0:
   version "25.3.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.3.0.tgz#d0a4f988ff4a6cd350342fdabbb809aeb4d49ad5"
@@ -8130,7 +8085,7 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-is@^16.12.0, react-is@^16.8.4:
+react-is@^16.12.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -10259,6 +10214,11 @@ xml2js@^0.4.17:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xmlbuilder@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-12.0.0.tgz#e2ed675e06834a089ddfb84db96e2c2b03f78c1a"
+  integrity sha512-lMo8DJ8u6JRWp0/Y4XLa/atVDr75H9litKlb2E5j3V3MesoL50EBgZDWoLT3F/LztVnG67GjPXLZpqcky/UMnQ==
 
 xmlbuilder@~9.0.1:
   version "9.0.7"


### PR DESCRIPTION
This PR enables junit reports for karma_web_test, by adding karma-junit-reporter as a
peer dependency and adding an appropriate configuration that works with bazel.

BREAKING CHANGE: karma-junit-reporter is now a peer dependency of @bazel/concatjs

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
       **It's unclear to me if this is required or if this is part of base expectation**


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #983


## What is the new behavior?

Junit Report is created at path specified via the XML_OUTPUT_FILE environment variable.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

karma-junit-reporter is now a peer dependency of @bazel/concatjs. Add the `karma-junit-reporter` package as a dev dependency to your project (`yarn add karma-junit-reporter --dev` or `npm install karma-junit-reporter --save-dev`).

## Other information

