### PR TITLE
fix(protractor): unable to specify `server` as configurable attribute

### DIFF
--- a/packages/protractor/test/protractor-2/BUILD.bazel
+++ b/packages/protractor/test/protractor-2/BUILD.bazel
@@ -82,3 +82,13 @@ protractor_web_test_suite(
         ":ts_spec",
     ],
 )
+
+protractor_web_test_suite(
+    name = "test_suite_with_configured_server",
+    configuration = ":conf.js",
+    on_prepare = ":on-prepare.js",
+    server = select({
+        "//conditions:default": ":devserver",
+    }),
+    deps = [":ts_spec"],
+)


### PR DESCRIPTION
Currently it is not possible to specify the `protractor_web_test`
server using a configurable attribute. i.e. using `select`.

This happens because the `server` attribute is accessed directly
in the macro so that Bazel is unable to respect the `select`. We
fix this by no longer accessing the server in the macro.