### PR TITLE
chore(builtin): add yarn v1.22.10 to known yarn versions

### DIFF
--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -36,6 +36,7 @@ _YARN_VERSIONS = {
     "1.13.0": ("yarn-v1.13.0.tar.gz", "yarn-v1.13.0", "125d40ebf621ebb08e3f66a618bd2cc5cd77fa317a312900a1ab4360ed38bf14"),
     "1.19.1": ("yarn-v1.19.1.tar.gz", "yarn-v1.19.1", "34293da6266f2aae9690d59c2d764056053ff7eebc56b80b8df05010c3da9343"),
     "1.22.4": ("yarn-v1.22.4.tar.gz", "yarn-v1.22.4", "bc5316aa110b2f564a71a3d6e235be55b98714660870c5b6b2d2d3f12587fb58"),
+    "1.22.10": ("yarn-v1.22.10.tar.gz", "yarn-v1.22.10", "7e433d4a77e2c79e6a7ae4866782608a8e8bcad3ec6783580577c59538381a6e"),
     # When adding a new version. please update /docs/install.md
 }
 


### PR DESCRIPTION
This is the version debian sid currently has (https://packages.debian.org/sid/yarnpkg)