### PR TITLE
fix(concatjs): devserver not passing through tags to all targets

### DIFF
--- a/packages/concatjs/devserver/concatjs_devserver.bzl
+++ b/packages/concatjs/devserver/concatjs_devserver.bzl
@@ -235,6 +235,7 @@ def concatjs_devserver_macro(name, args = [], visibility = None, tags = [], test
     native.alias(
         name = "%s.MF" % name,
         actual = "%s_launcher.MF" % name,
+        tags = tags,
         visibility = visibility,
     )
 


### PR DESCRIPTION
If a devserver target is currently testonly and marked with the
`manual` tag (e.g. if used for e2e testing), then the `manual`
tag is not passed to all targets exposed by the ConcatJS devserver
macro. i.e. the manifest alias is exposed and results in the
manifest to be built -> which inherently means that the actual
devserver target is built even though it has the `manual` tag.