### PR TITLE
fix(builtin): include optionalDependencies in strictly visible packages

### DIFF
--- a/internal/npm_install/generate_build_file.ts
+++ b/internal/npm_install/generate_build_file.ts
@@ -526,10 +526,11 @@ export function getDirectDependencySet(pkgJsonPath: string): Set<string> {
     stripBom(fs.readFileSync(pkgJsonPath, {encoding: 'utf8'}))
   );
 
-  const dependencies: string[] = Object.keys(pkgJson.dependencies || {});
-  const devDependencies: string[] = Object.keys(pkgJson.devDependencies || {});
-
-  return new Set([...dependencies, ...devDependencies]);
+  return new Set([
+    ...Object.keys(pkgJson.dependencies || {}),
+    ...Object.keys(pkgJson.devDependencies || {}),
+    ...Object.keys(pkgJson.optionalDependencies || {}),
+  ]);
 }
 
 /**

--- a/internal/npm_install/index.js
+++ b/internal/npm_install/index.js
@@ -317,9 +317,11 @@ function hasRootBuildFile(pkg, rootPath) {
 }
 function getDirectDependencySet(pkgJsonPath) {
     const pkgJson = JSON.parse(stripBom(fs.readFileSync(pkgJsonPath, { encoding: 'utf8' })));
-    const dependencies = Object.keys(pkgJson.dependencies || {});
-    const devDependencies = Object.keys(pkgJson.devDependencies || {});
-    return new Set([...dependencies, ...devDependencies]);
+    return new Set([
+        ...Object.keys(pkgJson.dependencies || {}),
+        ...Object.keys(pkgJson.devDependencies || {}),
+        ...Object.keys(pkgJson.optionalDependencies || {}),
+    ]);
 }
 exports.getDirectDependencySet = getDirectDependencySet;
 function findPackages(p, dependencies) {

--- a/internal/npm_install/test/package.spec.json
+++ b/internal/npm_install/test/package.spec.json
@@ -4,7 +4,9 @@
     "@angular/core": "9.1.0"
   },
   "devDependencies": {
-    "@angular/common": "9.1.0",
+    "@angular/common": "9.1.0"
+  },
+  "optionalDependencies": {
     "zone.js": "0.8.29"
   }
 }


### PR DESCRIPTION
These are identical to regular dependencies except that a failure to install them is non-fatal.
They should be visible as Bazel dependencies.

Note I didn't include peerDependencies here still. These are an indication that some consumer should install the package, and that results in a bazel-visible dependency, so I think that's working correctly
