### PR TITLE
feat(esbuild): add support for multiple entry points

### DIFF
--- a/packages/esbuild/helpers.bzl
+++ b/packages/esbuild/helpers.bzl
@@ -40,6 +40,28 @@ def resolve_entry_point(f, inputs, srcs):
 
     fail("Could not find corresponding entry point for %s. Add the %s.js to your deps or %s.ts to your srcs" % (f.path, no_ext, no_ext))
 
+def desugar_entry_point_names(entry_point, entry_points):
+    """Users can specify entry_point (sugar) or entry_points (long form).
+
+    This function allows our code to treat it like they always used the long form.
+
+    It also validates that exactly one of these attributes should be specified.
+
+    Args:
+        entry_point: the simple argument for specifying a single entry
+        entry_points: the long form argument for specifing one or more entry points
+
+    Returns:
+        the array of entry poitns
+    """
+    if entry_point and entry_points:
+        fail("Cannot specify both entry_point and entry_points")
+    if not entry_point and not entry_points:
+        fail("One of entry_point or entry_points must be specified")
+    if entry_point:
+        return [entry_point]
+    return entry_points
+
 def filter_files(input, endings = ALLOWED_EXTENSIONS):
     """Filters a list of files for specific endings
 

--- a/packages/esbuild/test/entries/BUILD.bazel
+++ b/packages/esbuild/test/entries/BUILD.bazel
@@ -1,0 +1,36 @@
+load("//:index.bzl", "nodejs_test")
+load("//packages/esbuild/test:tests.bzl", "esbuild")
+load("//packages/typescript:index.bzl", "ts_library")
+
+ts_library(
+    name = "index",
+    srcs = ["index.ts"],
+    module_name = "lib",
+)
+
+ts_library(
+    name = "lib",
+    srcs = [
+        "a.ts",
+        "b.ts",
+    ],
+    deps = [":index"],
+)
+
+esbuild(
+    name = "bundle",
+    entry_points = [
+        "a.ts",
+        "b.ts",
+    ],
+    deps = [":lib"],
+)
+
+nodejs_test(
+    name = "bundle_test",
+    data = [
+        "bundle.spec.js",
+        ":bundle",
+    ],
+    entry_point = ":bundle.spec.js",
+)

--- a/packages/esbuild/test/entries/a.ts
+++ b/packages/esbuild/test/entries/a.ts
@@ -1,0 +1,3 @@
+import {NAME} from 'lib';
+
+console.log(`Hello ${NAME}`);

--- a/packages/esbuild/test/entries/b.ts
+++ b/packages/esbuild/test/entries/b.ts
@@ -1,0 +1,3 @@
+import {NAME} from 'lib';
+
+console.log(`Hello ${NAME} from b.ts`);

--- a/packages/esbuild/test/entries/bundle.spec.js
+++ b/packages/esbuild/test/entries/bundle.spec.js
@@ -1,0 +1,25 @@
+const {join} = require('path');
+const {readFileSync, lstatSync} = require('fs');
+
+const helper = require(process.env.BAZEL_NODE_RUNFILES_HELPER);
+const location = helper.resolve('build_bazel_rules_nodejs/packages/esbuild/test/entries/bundle/');
+
+const a = readFileSync(join(location, 'a.js'), {encoding: 'utf8'});
+const b = readFileSync(join(location, 'b.js'), {encoding: 'utf8'});
+const aHasImportOfChunk = a.match(/\/(chunk-[a-zA-Z0-9]+\.js)";/);
+const bHasImportOfChunk = b.match(/\/(chunk-[a-zA-Z0-9]+\.js)";/);
+
+if (!aHasImportOfChunk || !bHasImportOfChunk) {
+  console.error(`Expected entry_points 'a.js' and 'b.js' to have an import of './chunk-[hash].js'`);
+}
+
+if (aHasImportOfChunk[1] !== bHasImportOfChunk[1]) {
+  console.error(`Expected entry_points 'a.js' and 'b.js' to the same shared chunk`);
+}
+
+// throws if file does not exist
+lstatSync(join(location, aHasImportOfChunk && aHasImportOfChunk[1]));
+
+process.exit(
+    (aHasImportOfChunk && bHasImportOfChunk && aHasImportOfChunk[1] === bHasImportOfChunk[1]) ? 0 :
+                                                                                                1);

--- a/packages/esbuild/test/entries/index.ts
+++ b/packages/esbuild/test/entries/index.ts
@@ -1,0 +1,1 @@
+export const NAME = 'bazel';


### PR DESCRIPTION
Very similar to the rollup one, including copying (almost identically) the `_desugar_entry_point_names` util. The main difference is that rollup allows each entry point to have its own output file specified (see "Chunks can be named by adding an = to the provided value:" under https://rollupjs.org/guide/en/#input), where in esbuild it seems that you specify a output filename pattern which all outputted files follow: https://esbuild.github.io/api/#entry-names

In the future we can potentially add support for that `--entry-names` param, but I guess that can always be done manually today with the arbitrary `args`.

Note that the `output_dir` is now defaulted to `True` in the macro if `entry_points` is used. I'm not 100% sure if that is correct or the best way to do it? Are code splitting and `entry_points` starting to overlap a bit too much?