### PR TITLE
feat(esbuild): default log-level flag to warning, unless overridden

### DIFF
--- a/packages/esbuild/test/splitting/BUILD.bazel
+++ b/packages/esbuild/test/splitting/BUILD.bazel
@@ -16,7 +16,12 @@ ts_library(
 
 esbuild(
     name = "bundle",
-    args = ["--keep-names"],
+    args = [
+        # info log level may be helpful when splitting as esbuild will show each file emitted
+        # where as bazel will only list the output directory
+        "--log-level=info",
+        "--keep-names",
+    ],
     entry_point = "main.ts",
     output_dir = True,
     deps = [":main"],


### PR DESCRIPTION
esbuild defaults the `--log-level` flag to `info` which includes an output file summary (I think this used to be a separate flag 🤷). This can lead to spammy build logs and redundant output under bazel as output file paths will be duplicated.

Unless overridden by the user with the `args` attribute, default the `--log-level` flag to `warning` which only includes erorrs and warnings about the build, and not the output file summary.