### PR TITLE
feat: allow esbuild cwd for subprocess to be set

### DIFF
--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -135,6 +135,9 @@ def _esbuild_impl(ctx):
     launcher_args = ctx.actions.args()
     launcher_args.add("--esbuild=%s" % ctx.executable.tool.path)
 
+    if ctx.attr.cwd:
+        launcher_args.add("--cwd=%s" % ctx.attr.cwd)
+
     run_node(
         ctx = ctx,
         inputs = depset(inputs),
@@ -174,6 +177,16 @@ esbuild(
 ```
 
 See https://esbuild.github.io/api/#define for more details
+            """,
+        ),
+        "cwd": attr.string(
+            default = ".",
+            doc = """The working directory to spawn.
+            That path is assumed to be relative to the root of the repository.
+            The path will be used by the subprocess to spawn the process at the path instead of at the root of the
+            repository.
+            
+            This is use by ESBuild to resolve files relative to the current working directory.
             """,
         ),
         "deps": attr.label_list(

--- a/packages/esbuild/launcher.js
+++ b/packages/esbuild/launcher.js
@@ -12,6 +12,7 @@ function getFlag(flag, required = true) {
 }
 
 const esbuild = getFlag('--esbuild');
+const cwd = getFlag('--cwd');
 const params_file_path = getFlag('--esbuild_flags');
 
 let flags = [];
@@ -22,4 +23,4 @@ try {
   process.exit(1);
 }
 
-spawn(esbuild, flags, {detached: true, stdio: 'inherit'});
+spawn(esbuild, flags, {cwd, detached: true, stdio: 'inherit'});


### PR DESCRIPTION
This change is to allow users to set where the esbuild process is
invoked relative to the root of the repo. This is useful in the case
of monorepos in which packages may be nested and not invoked from
root. This is important to have as it helps with relative path resolution
when an entry_point is passed ot ESBuild. Without this, ESBuild will fail
to resolve relative imports.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Allow ESBuild rule to set the CWD of the `spawn` subprocess it invokes to allow ESBuild to run from non repo root locations.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

