### PR TITLE
Reduce ci load

### DIFF
--- a/index.bzl
+++ b/index.bzl
@@ -88,11 +88,7 @@ BAZEL_VERSION = "4.0.0"
 # accidentally forcing users to update their LTS-supported bazel.
 # These are the versions used when testing nested workspaces with
 # bazel_integration_test.
-SUPPORTED_BAZEL_VERSIONS = [
-    BAZEL_VERSION,
-    "3.6.0",
-    "2.2.0",
-]
+SUPPORTED_BAZEL_VERSIONS = [BAZEL_VERSION]
 
 def check_rules_nodejs_version(minimum_version_string):
     """


### PR DESCRIPTION
It makes our CI slower to run all examples against all Bazel versions. Other rulesets don't seem to test backcompat at all, so it's hard to imagine anyone is actually running on Bazel 2 and using recent rules releases
