### PR TITLE
fix(esbuild): provide JSModuleInfo of output bundle

### DIFF
--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -149,8 +149,14 @@ def _esbuild_impl(ctx):
         tools = [ctx.executable.tool],
     )
 
+    outputs_depset = depset(outputs)
+
     return [
-        DefaultInfo(files = depset(outputs)),
+        DefaultInfo(files = outputs_depset),
+        JSModuleInfo(
+            direct_sources = outputs_depset,
+            sources = outputs_depset,
+        ),
     ]
 
 esbuild = rule(


### PR DESCRIPTION
Seems like other rules such as rollup and terser provide this, and it makes sense. I'm not sure of the greatest way to test it though? All 3 could probably use such a test...