### PR TITLE
fix(esbuild): prefer finding entry_point files in deps rather than srcs

### DIFF
--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -41,7 +41,9 @@ def _esbuild_impl(ctx):
     entry_points = desugar_entry_point_names(ctx.file.entry_point, ctx.files.entry_points)
 
     deps_inputs = depset(transitive = deps_depsets).to_list()
-    inputs = filter_files(entry_points) + ctx.files.srcs + deps_inputs
+
+    # TODO(mattem): 4.0.0 breaking change, entry_points must exist in deps, and are not considered additional srcs
+    inputs = deps_inputs + ctx.files.srcs + filter_files(entry_points)
 
     metafile = ctx.actions.declare_file("%s_metadata.json" % ctx.attr.name)
     outputs = [metafile]

--- a/packages/esbuild/test/js-library/BUILD.bazel
+++ b/packages/esbuild/test/js-library/BUILD.bazel
@@ -1,0 +1,41 @@
+load("//:index.bzl", "generated_file_test", "js_library", "nodejs_binary", "npm_package_bin")
+load("//packages/esbuild/test:tests.bzl", "esbuild")
+
+js_library(
+    name = "lib",
+    srcs = ["lib.jsx"],
+)
+
+js_library(
+    name = "main",
+    srcs = ["main.js"],
+    deps = [":lib"],
+)
+
+esbuild(
+    name = "bundle",
+    entry_point = "main.js",
+    deps = [
+        ":main",
+    ],
+)
+
+nodejs_binary(
+    name = "bin",
+    data = [
+        ":bundle",
+    ],
+    entry_point = "bundle.js",
+)
+
+npm_package_bin(
+    name = "runner",
+    stdout = "out.txt",
+    tool = ":bin",
+)
+
+generated_file_test(
+    name = "test",
+    src = "out.golden.txt",
+    generated = "out.txt",
+)

--- a/packages/esbuild/test/js-library/lib.jsx
+++ b/packages/esbuild/test/js-library/lib.jsx
@@ -1,0 +1,1 @@
+export const NAME = 'rules_nodejs';

--- a/packages/esbuild/test/js-library/main.js
+++ b/packages/esbuild/test/js-library/main.js
@@ -1,0 +1,3 @@
+import {NAME as name} from './lib';
+
+console.log(name);

--- a/packages/esbuild/test/js-library/out.golden.txt
+++ b/packages/esbuild/test/js-library/out.golden.txt
@@ -1,0 +1,1 @@
+rules_nodejs


### PR DESCRIPTION
When using esbuild with `js_library`, the entry_point may be part of the deps, therefore the path will end up in `bazel-out/` inside the sandbox where esbuild is running, however the entrypoint path will be in the sources path, leaving any relative path inputs to no longer be relative to the entrypoint file.

The reordering here forces the `resolve_entry_point` method to prefer the file that resides in the `bazel-out/` path in the sandbox.

A possible future breaking change would be to force users to list the entrypoint file(s) in either srcs or deps for the correct pathing, or remove `srcs` from esbuild, meaning all input files must be in the output tree.