### PR TITLE
Add darwin_arm64 (Apple Silicon) toolchain

### DIFF
--- a/internal/node/launcher.sh
+++ b/internal/node/launcher.sh
@@ -125,8 +125,13 @@ else
 
   case "${machine}" in
     # The following paths must match up with _download_node in node_repositories
-    darwin) readonly node_toolchain="nodejs_darwin_amd64/bin/nodejs/bin/node" ;;
     windows) readonly node_toolchain="nodejs_windows_amd64/bin/nodejs/node.exe" ;;
+    darwin)
+      case "${unameArch}" in
+        x86_64*) readonly node_toolchain="nodejs_darwin_amd64/bin/nodejs/bin/node" ;;
+        *) readonly node_toolchain="nodejs_darwin_arm64/bin/nodejs/bin/node" ;;
+      esac
+      ;;
     *)
       case "${unameArch}" in
         aarch64*) readonly node_toolchain="nodejs_linux_arm64/bin/nodejs/bin/node" ;;

--- a/internal/node/test/nodejs_toolchain_test.bzl
+++ b/internal/node/test/nodejs_toolchain_test.bzl
@@ -32,7 +32,7 @@ fi
 
 _ATTRS = {
     "platform": attr.string(
-        values = ["linux_amd64", "linux_arm64", "linux_s390x", "darwin_amd64", "windows_amd64"],
+        values = ["linux_amd64", "linux_arm64", "linux_s390x", "darwin_amd64", "darwin_arm64", "windows_amd64"],
     ),
 }
 

--- a/toolchains/node/BUILD.bazel
+++ b/toolchains/node/BUILD.bazel
@@ -26,6 +26,14 @@ platform(
 )
 
 platform(
+    name = "darwin_arm64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+platform(
     name = "linux_amd64",
     constraint_values = [
         "@platforms//os:linux",
@@ -80,7 +88,8 @@ toolchain_type(
 alias(
     name = "toolchain",
     actual = select({
-        "@bazel_tools//src/conditions:darwin": "@nodejs_darwin_amd64_config//:toolchain",
+        "@bazel_tools//src/conditions:darwin_arm64": "@nodejs_darwin_arm64_config//:toolchain",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@nodejs_darwin_amd64_config//:toolchain",
         "@bazel_tools//src/conditions:linux_aarch64": "@nodejs_linux_arm64_config//:toolchain",
         "@bazel_tools//src/conditions:linux_s390x": "@nodejs_linux_s390x_config//:toolchain",
         "@bazel_tools//src/conditions:linux_x86_64": "@nodejs_linux_amd64_config//:toolchain",
@@ -94,7 +103,8 @@ alias(
 alias(
     name = "node_bin",
     actual = select({
-        "@bazel_tools//src/conditions:darwin": "@nodejs_darwin_amd64//:node_bin",
+        "@bazel_tools//src/conditions:darwin_arm64": "@nodejs_darwin_arm64//:node_bin",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@nodejs_darwin_amd64//:node_bin",
         "@bazel_tools//src/conditions:linux_aarch64": "@nodejs_linux_arm64//:node_bin",
         "@bazel_tools//src/conditions:linux_s390x": "@nodejs_linux_s390x//:node_bin",
         "@bazel_tools//src/conditions:linux_x86_64": "@nodejs_linux_amd64//:node_bin",
@@ -131,6 +141,16 @@ toolchain(
         "@platforms//cpu:x86_64",
     ],
     toolchain = "@nodejs_darwin_amd64_config//:toolchain",
+    toolchain_type = ":toolchain_type",
+)
+
+toolchain(
+    name = "node_darwin_arm64_toolchain",
+    target_compatible_with = [
+        "@platforms//os:osx",
+        "@platforms//cpu:aarch64",
+    ],
+    toolchain = "@nodejs_darwin_arm64_config//:toolchain",
     toolchain_type = ":toolchain_type",
 )
 


### PR DESCRIPTION
Fixes #2699 

Note this doesn't include updating our list of nodejs mirror download locations, so you'll still have to specify that manually in your `node_repositories` call in `WORKSPACE`