### PR TITLE
chore: change clang-format hook to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,29 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: local
+  - repo: local
     hooks:
+      - id: bazel-format
+        name: bazel format
+        description: Auto-formats starlark code
+        entry: buildifier --lint=off --mode=fix
+        files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE)$|\.BUILD$|\.bzl$'
+        # Ideally we'd exclude third_party, but the CI enforcement doesn't support it, see
+        # https://github.com/bazelbuild/continuous-integration/issues/1162
+        # exclude: '^third_party/'
+        language: system
 
-      -   id: bazel-format
-          name: bazel format
-          description: Auto-formats starlark code
-          entry: buildifier --lint=off --mode=fix
-          files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE)$|\.BUILD$|\.bzl$'
-          # Ideally we'd exclude third_party, but the CI enforcement doesn't support it, see
-          # https://github.com/bazelbuild/continuous-integration/issues/1162
-          # exclude: '^third_party/'
-          language: system
+      - id: bazel-lint
+        name: bazel lint
+        description: Checks for code style violations in starlark code
+        # Keep this list in sync with .bazelci/presubmit.yml
+        entry: buildifier --lint=warn --mode=fix -v --warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,confusing-name,constant-glob,ctx-actions,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,function-docstring,git-repository,http-archive,integer-division,load,load-on-top,module-docstring,name-conventions,native-build,native-package,out-of-order-load,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,return-value,same-origin-load,string-iteration,unreachable,unsorted-dict-items,unused-variable
+        files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE)$|\.BUILD$|\.bzl$'
+        language: system
 
-      -   id: bazel-lint
-          name: bazel lint
-          description: Checks for code style violations in starlark code
-          # Keep this list in sync with .bazelci/presubmit.yml
-          entry: buildifier --lint=warn --mode=fix -v --warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,confusing-name,constant-glob,ctx-actions,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,function-docstring,git-repository,http-archive,integer-division,load,load-on-top,module-docstring,name-conventions,native-build,native-package,out-of-order-load,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,return-value,same-origin-load,string-iteration,unreachable,unsorted-dict-items,unused-variable
-          files: '^(.*/)?(BUILD\.bazel|BUILD|WORKSPACE)$|\.BUILD$|\.bzl$'
-          language: system
+  - repo: https://github.com/jlebar/pre-commit-hooks.git
+    rev: 07a539b8db43298f124ace23c90b4b871911b8c4
+    hooks:
+      - id: clang-format-diff
+        files: \.(js|ts)x?$
+

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -89,11 +89,6 @@ rules](./docs/changing-rules.md) instead of building your own release products.
 
 Start from a clean checkout at master/HEAD.
 
-Note: if you are using a new clone, you'll need to configure `git-clang-format` to be able to commit the release:
-
-1. `git config clangFormat.binary node_modules/.bin/clang-format`
-1. `git config clangFormat.style file`
-
 Googlers: you should npm login using the go/npm-publish service: `$ npm login --registry https://wombat-dressing-room.appspot.com`
 
 Check if there are any breaking changes since the last tag - if so, this will be a major. Check if there were new features added since the last tag - if so, this will be a minor.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
         "@types/semver": "6.2.0",
         "babel-jest": "^25.5.1",
         "bazel_workspaces_consistent": "file:./tools/npm_packages/bazel_workspaces_consistent",
-        "clang-format": "1.5.0",
         "conventional-changelog-cli": "^2.0.21",
         "core-util-is": "^1.0.2",
         "date-fns": "1.30.1",
@@ -125,15 +124,12 @@
         "update-codeowners": "./scripts/update_codeowners.sh",
         "update-nodejs-versions": "node ./scripts/update-nodejs-versions.js > internal/node/node_versions.bzl",
         "update-esbuild-versions": "node ./scripts/update-esbuild-versions.js > packages/esbuild/esbuild_repo.bzl",
-        "format": "git-clang-format",
-        "format-all": "clang-format --glob='{internal/**/,examples/**/}*.{js,ts}' -i",
         "stardoc": "bazel build --noincompatible_strict_action_env //docs && cp -f dist/bin/docs/*.md ./docs && cp -f dist/bin/docs/docs-out/*.html ./docs && cp -f dist/bin/docs/docs-out/css/*.css ./docs/css",
         "version": "conventional-changelog -p angular -i CHANGELOG.md -s && node ./scripts/on-version.js && bazel build //:release && node ./scripts/on-release.js && git stage version.bzl docs/install.md packages/create/index.js README.md CHANGELOG.md e2e/*/WORKSPACE examples/*/WORKSPACE",
         "postinstall": "patch-package && node internal/npm_install/test/postinstall.js"
     },
     "husky": {
         "hooks": {
-            "pre-push": "check-clang-format \"yarn format\"",
             "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2869,15 +2869,6 @@ cidr-regex@^2.0.10:
   dependencies:
     ip-regex "^2.1.0"
 
-clang-format@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.5.0.tgz#1bd4c47b66a1a02556b192b93f5505e7ccec84fb"
-  integrity sha512-C1LucFX7E+ABVYcPEbBHM4PYQ2+WInXsqsLpFlQ9cmRfSbk7A7b1I06h/nE4bQ3MsyEkb31jY2gC0Dtc76b4IA==
-  dependencies:
-    async "^1.5.2"
-    glob "^7.0.0"
-    resolve "^1.1.6"
-
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"


### PR DESCRIPTION
No longer stitches it with npm ecosystem or with husky. We continue to have no CI verification either, formatting isn't that consequential
