### PR TITLE
refactor: use ts_project for webapp example

### DIFF
--- a/examples/webapp/differential_loading.bzl
+++ b/examples/webapp/differential_loading.bzl
@@ -4,14 +4,15 @@ load("@build_bazel_rules_nodejs//:index.bzl", "pkg_web")
 load("@npm_deps//@babel/cli:index.bzl", "babel")
 load("@npm_deps//@bazel/rollup:index.bzl", "rollup_bundle")
 load("@npm_deps//@bazel/terser:index.bzl", "terser_minified")
-load("@npm_deps//@bazel/typescript:index.bzl", "ts_library")
+load("@npm_deps//@bazel/typescript:index.bzl", "ts_project")
 
 def differential_loading(name, entry_point, srcs):
     "Common workflow to serve TypeScript to modern browsers"
 
-    ts_library(
+    ts_project(
         name = name + "_lib",
         srcs = srcs,
+        tsconfig = "tsconfig.json",
     )
 
     rollup_bundle(

--- a/examples/webapp/sourcemaps.spec.js
+++ b/examples/webapp/sourcemaps.spec.js
@@ -37,9 +37,9 @@ function find(text, s = 'ts1') {
 function asserts(pos) {
   // This doesn't work because the output dir is different from input
   // so it actually starts with a bunch of '/../..'
-  // expect(pos.source).toBe('index.mjs');
+  // expect(pos.source).toBe('index.js');
 
-  assert(pos.source.endsWith('index.mjs'));
+  assert(pos.source.endsWith('index.js'));
   assert(pos.line == 7);     // one-based
   assert(pos.column == 20);  // zero-based
 }

--- a/examples/webapp/tsconfig.json
+++ b/examples/webapp/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
     "strict": true,
-    "lib": ["es2015.promise", "dom", "es5"],
-    // Explicitly set types settings so typescript doesn't auto-discover types.
-    // If all types are discovered then all types need to be included as deps
-    // or typescript may error out with TS2688: Cannot find type definition file for 'foo'.
-    "types": []
- }
+    "lib": ["es2015", "dom"],
+    "target": "esnext",
+    "module": "esnext",
+    "inlineSourceMap": true
+ },
+ "exclude": ["external"]
 }
 


### PR DESCRIPTION
We no longer recommend ts_library, so our examples should reflect that