### PR TITLE
fix(typescript): repair error reporting when a ts_project is missing …

### DIFF
--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -233,10 +233,11 @@ def _ts_project_impl(ctx):
         ])),
     ]
 
-    # Don't provide DeclarationInfo if there are no typings to provide.
+    # Only provide DeclarationInfo if there are some typings.
     # Improves error messaging if a ts_project needs declaration = True
-    if len(typings_outputs) or len(ctx.attr.deps):
-        providers.append(declaration_info(depset(typings_outputs), ctx.attr.deps))
+    typings_in_deps = [d for d in ctx.attr.deps if DeclarationInfo in d]
+    if len(typings_outputs) or len(typings_in_deps):
+        providers.append(declaration_info(depset(typings_outputs), typings_in_deps))
         providers.append(OutputGroupInfo(types = depset(typings_outputs)))
 
     return providers


### PR DESCRIPTION
…declaration=True

Now prints this like it should:
```
ERROR: /home/alexeagle/Projects/rules_nodejs/examples/web_testing/BUILD.bazel:16:11: in deps attribute of ts_project rule //:tests: '//:lib' does not have mandatory providers: 'DeclarationInfo' or '_ValidOptionsInfo'. Since this rule was created by the macro 'ts_project_macro', the error might have been caused by the macro implementation
```
