### PR TITLE
refactor(typescript): tsconfig default to tsconfig.json

### DIFF
--- a/examples/app/BUILD.bazel
+++ b/examples/app/BUILD.bazel
@@ -67,6 +67,7 @@ ts_project(
     testonly = 1,
     srcs = ["app.e2e-spec.ts"],
     extends = "tsconfig.json",
+    tsconfig = "tsconfig-test.json",
     deps = [
         "@npm//@types/jasmine",
         "@npm//@types/node",

--- a/examples/webapp/differential_loading.bzl
+++ b/examples/webapp/differential_loading.bzl
@@ -12,7 +12,6 @@ def differential_loading(name, entry_point, srcs):
     ts_project(
         name = name + "_lib",
         srcs = srcs,
-        tsconfig = "tsconfig.json",
     )
 
     rollup_bundle(

--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -477,7 +477,7 @@ def ts_project_macro(
             To support "chaining" of more than one extended config, this label could be a target that
             provdes `TsConfigInfo` such as `ts_config`.
 
-            By default, we assume the tsconfig file is named by adding `.json` to the `name` attribute.
+            By default, we assume the tsconfig file is "tsconfig.json" in the same folder as the ts_project rule.
 
             EXPERIMENTAL: generated tsconfig
 
@@ -641,7 +641,7 @@ def ts_project_macro(
 
     else:
         if tsconfig == None:
-            tsconfig = name + ".json"
+            tsconfig = "tsconfig.json"
 
         if validate:
             validate_options(

--- a/packages/typescript/test/ts_project/a/BUILD.bazel
+++ b/packages/typescript/test/ts_project/a/BUILD.bazel
@@ -10,6 +10,7 @@ ts_config(
 )
 
 ts_project(
+    name = "a",
     composite = True,
     tsconfig = "config",
     # Intentionally not syncing this option from tsconfig, to test validator suppression

--- a/packages/typescript/test/ts_project/allow_js/BUILD.bazel
+++ b/packages/typescript/test/ts_project/allow_js/BUILD.bazel
@@ -7,7 +7,7 @@ SRCS = [
 ]
 
 ts_project(
-    name = "tsconfig",
+    name = "transpile",
     srcs = SRCS,
     allow_js = True,
     declaration = True,
@@ -18,19 +18,19 @@ ts_project(
 
 filegroup(
     name = "types",
-    srcs = [":tsconfig"],
+    srcs = [":transpile"],
     output_group = "types",
 )
 
 nodejs_test(
     name = "test",
     data = [
-        ":tsconfig",
+        ":transpile",
         ":types",
     ],
     entry_point = "verify.js",
     templated_args = [
         "$(locations :types)",
-        "$(locations :tsconfig)",
+        "$(locations :transpile)",
     ],
 )

--- a/packages/typescript/test/ts_project/b/BUILD.bazel
+++ b/packages/typescript/test/ts_project/b/BUILD.bazel
@@ -4,23 +4,24 @@ load("//packages/typescript:index.bzl", "ts_project")
 package(default_visibility = ["//packages/typescript/test:__subpackages__"])
 
 ts_project(
-    name = "tsconfig",  # This will use ./tsconfig.json
+    name = "b",
     srcs = [":b.ts"],
     # just a test for the pass-through args attribute
     args = ["--emitBOM"],
     composite = True,
     extends = "//packages/typescript/test/ts_project:tsconfig-base.json",
-    deps = ["//packages/typescript/test/ts_project/a:tsconfig"],
+    deps = ["//packages/typescript/test/ts_project/a"],
 )
 
 ts_project(
-    name = "tsconfig-test",  # This will use ./tsconfig-test.json
+    name = "transpile_test",
     testonly = True,
     srcs = [":b.spec.ts"],
     composite = True,
     extends = "//packages/typescript/test/ts_project:tsconfig-base.json",
+    tsconfig = "tsconfig-test.json",
     deps = [
-        ":tsconfig",
+        ":b",
         "@npm//@types/jasmine",
         "@npm//@types/node",
     ],
@@ -29,5 +30,5 @@ ts_project(
 jasmine_node_test(
     name = "test",
     srcs = ["b.spec.js"],
-    data = [":tsconfig"],
+    data = [":b"],
 )

--- a/packages/typescript/test/ts_project/c/BUILD.bazel
+++ b/packages/typescript/test/ts_project/c/BUILD.bazel
@@ -6,5 +6,5 @@ ts_project(
     composite = True,
     extends = "//packages/typescript/test/ts_project:tsconfig-base.json",
     tsconfig = "tsconfig.json",
-    deps = ["//packages/typescript/test/ts_project/b:tsconfig"],
+    deps = ["//packages/typescript/test/ts_project/b"],
 )

--- a/packages/typescript/test/ts_project/declarationdir/BUILD.bazel
+++ b/packages/typescript/test/ts_project/declarationdir/BUILD.bazel
@@ -7,7 +7,7 @@ SRCS = [
 ]
 
 ts_project(
-    name = "tsconfig",
+    name = "transpile",
     srcs = SRCS,
     declaration = True,
     declaration_map = True,
@@ -18,19 +18,19 @@ ts_project(
 
 filegroup(
     name = "types",
-    srcs = [":tsconfig"],
+    srcs = [":transpile"],
     output_group = "types",
 )
 
 nodejs_test(
     name = "test",
     data = [
-        ":tsconfig",
+        ":transpile",
         ":types",
     ],
     entry_point = "verify.js",
     templated_args = [
         "$(locations :types)",
-        "$(locations :tsconfig)",
+        "$(locations :transpile)",
     ],
 )

--- a/packages/typescript/test/ts_project/declarationdir_with_value/BUILD.bazel
+++ b/packages/typescript/test/ts_project/declarationdir_with_value/BUILD.bazel
@@ -7,7 +7,7 @@ SRCS = [
 ]
 
 ts_project(
-    name = "tsconfig",
+    name = "transpile",
     srcs = SRCS,
     declaration = True,
     declaration_dir = "out/types",
@@ -19,19 +19,19 @@ ts_project(
 
 filegroup(
     name = "types",
-    srcs = [":tsconfig"],
+    srcs = [":transpile"],
     output_group = "types",
 )
 
 nodejs_test(
     name = "test",
     data = [
-        ":tsconfig",
+        ":transpile",
         ":types",
     ],
     entry_point = "verify.js",
     templated_args = [
         "$(locations :types)",
-        "$(locations :tsconfig)",
+        "$(locations :transpile)",
     ],
 )

--- a/packages/typescript/test/ts_project/js_library/BUILD.bazel
+++ b/packages/typescript/test/ts_project/js_library/BUILD.bazel
@@ -10,7 +10,7 @@ js_library(
 )
 
 ts_project(
-    name = "tsconfig",
+    name = "transpile",
     srcs = ["b.ts"],
     deps = ["lib_a"],
 )

--- a/packages/typescript/test/ts_project/json/BUILD.bazel
+++ b/packages/typescript/test/ts_project/json/BUILD.bazel
@@ -10,20 +10,19 @@ SRCS = [
 ]
 
 ts_project(
-    name = "tsconfig",
+    name = "transpile",
     srcs = SRCS,
     out_dir = "foobar",
 )
 
 ts_project(
-    name = "tsconfig-no-outdir",
+    name = "transpile-no-outdir",
     srcs = SRCS,
-    tsconfig = "tsconfig.json",
 )
 
 # Test that we don't try to declare .json outputs when tsc isn't producing any JS
 ts_project(
-    name = "tsconfig-decl-only",
+    name = "transpile-decl-only",
     srcs = SRCS,
     tsconfig = {
         "compilerOptions": {
@@ -37,13 +36,13 @@ ts_project(
 nodejs_test(
     name = "test",
     data = [
-        ":tsconfig",
-        ":tsconfig-decl-only",
-        ":tsconfig-no-outdir",
+        ":transpile",
+        ":transpile-decl-only",
+        ":transpile-no-outdir",
     ],
     entry_point = "verify.js",
     templated_args = [
-        "$(locations :tsconfig)",
-        "$(locations :tsconfig-no-outdir)",
+        "$(locations :transpile)",
+        "$(locations :transpile-no-outdir)",
     ],
 )

--- a/packages/typescript/test/ts_project/jsx/BUILD.bazel
+++ b/packages/typescript/test/ts_project/jsx/BUILD.bazel
@@ -8,7 +8,7 @@ SRCS = [
 ]
 
 ts_project(
-    name = "tsconfig",
+    name = "transpile",
     srcs = SRCS,
     allow_js = True,
     declaration = True,
@@ -20,19 +20,19 @@ ts_project(
 
 filegroup(
     name = "types",
-    srcs = [":tsconfig"],
+    srcs = [":transpile"],
     output_group = "types",
 )
 
 nodejs_test(
     name = "test",
     data = [
-        ":tsconfig",
+        ":transpile",
         ":types",
     ],
     entry_point = "verify-preserve.js",
     templated_args = [
         "$(locations :types)",
-        "$(locations :tsconfig)",
+        "$(locations :transpile)",
     ],
 )

--- a/packages/typescript/test/ts_project/output_group/BUILD.bazel
+++ b/packages/typescript/test/ts_project/output_group/BUILD.bazel
@@ -4,14 +4,14 @@ load("//packages/typescript:index.bzl", "ts_project")
 # This uses defaults for all attributes.
 # It will find `index.ts` and produce `index.js` & `index.d.ts`
 ts_project(
-    name = "tsconfig",
+    name = "transpile",
     srcs = ["index.ts"],
     declaration = True,
 )
 
 filegroup(
     name = "types",
-    srcs = [":tsconfig"],
+    srcs = [":transpile"],
     output_group = "types",
 )
 

--- a/packages/typescript/test/ts_project/rootdir_with_value/BUILD.bazel
+++ b/packages/typescript/test/ts_project/rootdir_with_value/BUILD.bazel
@@ -7,18 +7,14 @@ SRCS = [
 ]
 
 ts_project(
-    name = "tsconfig",
+    name = "transpile",
     srcs = SRCS,
     root_dir = "subdir",
 )
 
 nodejs_test(
     name = "test",
-    data = [
-        ":tsconfig",
-    ],
+    data = [":transpile"],
     entry_point = "verify.js",
-    templated_args = [
-        "$(locations :tsconfig)",
-    ],
+    templated_args = ["$(locations :transpile)"],
 )

--- a/packages/typescript/test/ts_project/ts_config/BUILD.bazel
+++ b/packages/typescript/test/ts_project/ts_config/BUILD.bazel
@@ -17,5 +17,5 @@ ts_project(
     name = "compile_ts",
     composite = True,
     declaration = True,
-    tsconfig = "tsconfig",
+    tsconfig = ":tsconfig",
 )

--- a/packages/typescript/test/ts_project/tsbuildinfofile/BUILD.bazel
+++ b/packages/typescript/test/ts_project/tsbuildinfofile/BUILD.bazel
@@ -1,7 +1,7 @@
 load("//packages/typescript:index.bzl", "ts_project")
 
 ts_project(
-    name = "tsconfig",
+    name = "transpile",
     composite = True,
     ts_build_info_file = "my.tsbuildinfo",
 )


### PR DESCRIPTION
The previous way was kinda dumb, that targets got named 'tsconfig' just so they could have the right default value.
It also forces users to use a tsconfig attribute in *more* cases than they should, because they don't want to name their target that thing.

BREAKING CHANGE:
ts_project tsconfig attribute now defaults to just 'tsconfig.json' rather than '[name].json'
