### PR TITLE
fix(typescript): fixed "output was not created" error for ts_project with supports_workers

### DIFF
--- a/packages/typescript/internal/worker/index.js
+++ b/packages/typescript/internal/worker/index.js
@@ -26,7 +26,7 @@ const reportWatchStatusChanged = (diagnostic) => {
     worker.debug(ts.formatDiagnostic(diagnostic, formatHost));
 };
 function createWatchProgram(options, tsconfigPath, setTimeout) {
-    const host = createWatchCompilerHost(tsconfigPath, options, Object.assign(Object.assign({}, ts.sys), { setTimeout }), ts.createEmitAndSemanticDiagnosticsBuilderProgram, reportDiagnostic, reportWatchStatusChanged);
+    const host = createWatchCompilerHost(tsconfigPath, options, Object.assign(Object.assign({}, ts.sys), { setTimeout }), ts.createSemanticDiagnosticsBuilderProgram, reportDiagnostic, reportWatchStatusChanged);
     return ts.createWatchProgram(host);
 }
 let workerRequestTimestamp;

--- a/packages/typescript/internal/worker/worker_adapter.ts
+++ b/packages/typescript/internal/worker/worker_adapter.ts
@@ -42,7 +42,7 @@ function createWatchProgram(
     options: ts.CompilerOptions, tsconfigPath: string, setTimeout: ts.System['setTimeout']) {
   const host = createWatchCompilerHost(
       tsconfigPath, options, {...ts.sys, setTimeout},
-      ts.createEmitAndSemanticDiagnosticsBuilderProgram, reportDiagnostic,
+      ts.createSemanticDiagnosticsBuilderProgram, reportDiagnostic,
       reportWatchStatusChanged);
 
   // `createWatchProgram` creates an initial program, watches files, and updates
@@ -57,7 +57,7 @@ let workerRequestTimestamp: number|undefined;
 /**
  * The typescript compiler in watch mode.
  */
-let cachedWatchedProgram:|ts.WatchOfConfigFile<ts.EmitAndSemanticDiagnosticsBuilderProgram>|
+let cachedWatchedProgram:|ts.WatchOfConfigFile<ts.SemanticDiagnosticsBuilderProgram>|
     undefined;
 /**
  * Callback provided by ts.System which should be called at the point at which
@@ -68,7 +68,7 @@ let consolidateChangesCallback: ((...args: any[]) => void)|undefined;
 let cachedWatchProgramArgs: string|undefined;
 
 function getWatchProgram(args: string[]):
-    ts.WatchOfConfigFile<ts.EmitAndSemanticDiagnosticsBuilderProgram> {
+    ts.WatchOfConfigFile<ts.SemanticDiagnosticsBuilderProgram> {
   const newWatchArgs = args.join(' ');
 
   // Check to see if the watch program needs to be updated or if we can re-use the old one.

--- a/packages/typescript/test/ts_project/worker/second.ts
+++ b/packages/typescript/test/ts_project/worker/second.ts
@@ -1,0 +1,1 @@
+export const second: string = 'second';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, if a `ts_project` with `supports_workers = True` contains more than one file, recompilation will fail with the error `output 'xxx' was not created` for files that have not been modified. This is due to the use of the `ts.createEmitAndSemanticDiagnosticsBuilderProgram` program creation strategy, which only emits modified files, but bazel expects all defined outputs.

Initial build:
```
» bazel build //packages/typescript/test/ts_project/worker/...
INFO: Invocation ID: 3e38759e-f7b4-4f96-9194-ce8fff759c32
INFO: Analyzed 3 targets (0 packages loaded, 0 targets configured).
INFO: Found 3 targets...
INFO: Elapsed time: 0.414s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
```

Changing `packages/typescript/test/ts_project/worker/big.ts` and starting another build

```
» bazel build //packages/typescript/test/ts_project/worker/...
INFO: Invocation ID: 8bf18f6a-e0f3-433d-878e-22d404d984a8
INFO: Analyzed 3 targets (0 packages loaded, 0 targets configured).
INFO: Found 3 targets...
ERROR: /Users/antonignatov/Sites/rules_nodejs/packages/typescript/test/ts_project/worker/BUILD.bazel:3:11: output 'packages/typescript/test/ts_project/worker/second.js' was not created
ERROR: /Users/antonignatov/Sites/rules_nodejs/packages/typescript/test/ts_project/worker/BUILD.bazel:3:11: output 'packages/typescript/test/ts_project/worker/second.d.ts' was not created
ERROR: /Users/antonignatov/Sites/rules_nodejs/packages/typescript/test/ts_project/worker/BUILD.bazel:3:11: Compiling TypeScript project (worker mode) //packages/typescript/test/ts_project/worker:tsconfig [tsc -p packages/typescript/test/ts_project/worker/tsconfig_tsconfig.json] failed: not all outputs were created or valid
INFO: Elapsed time: 0.470s, Critical Path: 0.06s
INFO: 2 processes: 1 internal, 1 worker.
FAILED: Build did NOT complete successfully
```

Issue Number: N/A


## What is the new behavior?

The program creation strategy switched to `ts.createSemanticDiagnosticsBuilderProgram`, which always emits all outputs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

