### PR TITLE
feat(typescript): produce JSNamedModuleInfo

### DIFF
--- a/examples/web_testing/BUILD.bazel
+++ b/examples/web_testing/BUILD.bazel
@@ -1,22 +1,42 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
 load("@npm//@bazel/concatjs:index.bzl", "karma_web_test_suite")
-load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_library")
+load("@npm//@bazel/typescript:index.bzl", "ts_project")
 
-ts_library(
-    name = "lib",
+ts_project(
+    name = "compile",
     srcs = ["decrement.ts"],
+    extends = "tsconfig.json",
+    produces_named_modules = True,
+    tsconfig = {
+        "compilerOptions": {
+            "declaration": True,
+        },
+    },
 )
 
-ts_config(
-    name = "tsconfig-test",
-    src = "tsconfig-test.json",
-    deps = [":tsconfig.json"],
+# workaround https://github.com/microsoft/TypeScript/issues/22208
+# on Windows, we can't use a relative import "./decrement" from the spec file
+# or else TypeScript will try to emit decrement.js on top of a read-only file.
+js_library(
+    name = "lib",
+    package_name = "decrement-lib",
+    deps = [":compile"],
 )
 
-ts_library(
+ts_project(
     name = "tests",
     testonly = 1,
     srcs = glob(["*.spec.ts"]),
-    tsconfig = ":tsconfig-test",
+    extends = "tsconfig.json",
+    produces_named_modules = True,
+    tsconfig = {
+        "compilerOptions": {
+            "types": [
+                "jasmine",
+                "node",
+            ],
+        },
+    },
     deps = [
         ":lib",
         "@npm//@types/jasmine",
@@ -24,11 +44,13 @@ ts_library(
     ],
 )
 
-ts_library(
+ts_project(
     name = "tests_setup",
     testonly = 1,
     srcs = ["setup_script.ts"],
-    tsconfig = ":tsconfig-test",
+    extends = "tsconfig.json",
+    produces_named_modules = True,
+    tsconfig = {},
     deps = [
         "@npm//@types/jasmine",
         "@npm//@types/node",

--- a/examples/web_testing/decrement.spec.ts
+++ b/examples/web_testing/decrement.spec.ts
@@ -1,4 +1,5 @@
-import {decrement} from './decrement';
+/// <amd-module name="examples_webtesting/decrement.spec"/>
+import {decrement} from 'decrement-lib/decrement';
 
 describe('decrementing', () => {
   it('should do that', () => {

--- a/examples/web_testing/decrement.ts
+++ b/examples/web_testing/decrement.ts
@@ -1,3 +1,4 @@
+/// <amd-module name="decrement"/>
 export function decrement(n: number) {
   return n - 1;
 }

--- a/examples/web_testing/setup_script.spec.ts
+++ b/examples/web_testing/setup_script.spec.ts
@@ -1,3 +1,4 @@
+/// <amd-module name="examples_webtesting/setup_script.spec"/>
 describe('setup script', () => {
   it('should load before the spec', async () => {
     expect((window as any).setupGlobal).toBe('setupGlobalValue');

--- a/examples/web_testing/setup_script.ts
+++ b/examples/web_testing/setup_script.ts
@@ -1,3 +1,5 @@
+/// <amd-module name="examples_webtesting/setup_script"/>
+
 // Setup global value that the test expect to be present.
 (window as any).setupGlobal = 'setupGlobalValue';
 

--- a/examples/web_testing/static_script.spec.ts
+++ b/examples/web_testing/static_script.spec.ts
@@ -1,3 +1,4 @@
+/// <amd-module name="examples_webtesting/static_script.spec"/>
 const someGlobal = new Promise<string>((resolve, reject) => {
   const script = document.createElement('script');
   script.src = `base/examples_webtesting/static_script.js`;

--- a/examples/web_testing/tsconfig-test.json
+++ b/examples/web_testing/tsconfig-test.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-
-  "compilerOptions": {
-    "types": ["jasmine", "node"]
-  }
-}

--- a/examples/web_testing/tsconfig.json
+++ b/examples/web_testing/tsconfig.json
@@ -2,6 +2,11 @@
   "compilerOptions": {
     "strict": true,
     "lib": ["es2015.promise", "dom", "es5"],
-  }
+    "declaration": true,
+    "rootDirs": [".", "bazel-out/k8-fastbuild/bin", "bazel-out/darwin-fastbuild/bin", "bazel-out/x64_windows-fastbuild/bin"],
+    "module": "umd",
+    "moduleResolution": "node"
+  },
+  "exclude": ["external"]
 }
 


### PR DESCRIPTION
This allows concatjs use cases to depend on ts_project targets rather than ts_library.
Update one example to illustrate
