### PR TITLE
refactor: convert nestjs example to ts_project

### DIFF
--- a/examples/nestjs/src/BUILD.bazel
+++ b/examples/nestjs/src/BUILD.bazel
@@ -15,17 +15,18 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("@io_bazel_rules_docker//nodejs:image.bzl", "nodejs_image")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("@npm//@bazel/typescript:index.bzl", "ts_library")
+load("@npm//@bazel/typescript:index.bzl", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
-ts_library(
+ts_project(
     name = "app",
     srcs = glob(
         ["*.ts"],
         exclude = ["*.spec.ts"],
     ),
-    module_name = "examples_nestjs",
+    declaration = True,
+    tsconfig = "//:tsconfig.json",
     deps = [
         "@npm//@nestjs/common",
         "@npm//@nestjs/core",
@@ -35,9 +36,11 @@ ts_library(
     ],
 )
 
-ts_library(
+ts_project(
     name = "test_lib",
     srcs = glob(["*.spec.ts"]),
+    declaration = True,
+    tsconfig = "//:tsconfig.json",
     deps = [
         ":app",
         "@npm//@nestjs/common",

--- a/examples/nestjs/tsconfig.json
+++ b/examples/nestjs/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "experimentalDecorators": true,
+        "target": "ES2015",
+        "module": "commonjs",
+        "rootDirs": [".", "bazel-out/k8-fastbuild/bin", "bazel-out/darwin-fastbuild/bin"],
+        "declaration": true
+    },
+    "exclude": ["external"]
+}


### PR DESCRIPTION
We no longer recommend ts_library so our examples shouldn't use it
