### PR TITLE
refactor: convert from_source example to ts_project

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -110,6 +110,7 @@ example_integration_test(
 
 example_integration_test(
     name = "examples_cypress",
+    bazel_commands = ["test --sandbox_debug //..."],
     npm_packages = {
         "//packages/cypress:npm_package": "@bazel/cypress",
         "//packages/typescript:npm_package": "@bazel/typescript",

--- a/examples/from_source/BUILD
+++ b/examples/from_source/BUILD
@@ -1,12 +1,12 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test", "nodejs_binary", "npm_package_bin")
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
-load("//:index.bzl", "custom_ts_library")
+load("//:index.bzl", "custom_ts_project")
 
-# thin macro around ts_library that sets some implicit dependencies
+# thin macro around ts_project that sets some implicit dependencies
 # while passing though all other attributes
 # is used here to show how to generate stardoc for rules that consume rules_nodejs from source
-custom_ts_library(
+custom_ts_project(
     name = "main",
     srcs = ["main.ts"],
 )
@@ -30,7 +30,7 @@ bzl_library(
     ],
 )
 
-# generation of the docs for the custom_ts_library macro used above
+# generation of the docs for the custom_ts_project macro used above
 stardoc(
     name = "docs",
     out = "docs.md",

--- a/examples/from_source/index.bzl
+++ b/examples/from_source/index.bzl
@@ -1,22 +1,24 @@
 """Example package for generating stardoc from rules_nodejs at source"""
 
-load("@build_bazel_rules_nodejs//packages/typescript:index.bzl", "ts_library")
+load("@build_bazel_rules_nodejs//packages/typescript:index.bzl", "ts_project")
 
-def custom_ts_library(name, deps = [], **kwargs):
+def custom_ts_project(name, deps = [], **kwargs):
     """
-    Helper wrapper around ts_library adding default attributes and dependencies
+    Helper wrapper around ts_project adding default attributes and dependencies
 
     Args:
         name: The name that should be given the this rule
         deps: A list of dependencies for this rule
-        kwargs: All other attrs are passed to ts_library
+        kwargs: All other attrs are passed to ts_project
     """
 
-    ts_library(
+    ts_project(
         name = name,
+        tsconfig = "tsconfig.json",
         deps = [
             "@npm//tsutils",
             "@npm//@types/node",
         ] + deps,
+        validate = False,
         **kwargs
     )

--- a/examples/from_source/tsconfig.json
+++ b/examples/from_source/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "lib": [
-      "ES2017"
+      "ES2017",
+      "dom"
     ],
     "types": []
   }


### PR DESCRIPTION
We no longer recommend ts_library so we shouldn't use it in examples
