### PR TITLE
refactor: convert web_testing example to ts_project

### DIFF
--- a/examples/web_testing/BUILD.bazel
+++ b/examples/web_testing/BUILD.bazel
@@ -1,22 +1,38 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
 load("@npm//@bazel/concatjs:index.bzl", "karma_web_test_suite")
-load("@npm//@bazel/typescript:index.bzl", "ts_config", "ts_library")
+load("@npm//@bazel/typescript:index.bzl", "ts_project")
 
-ts_library(
-    name = "lib",
+ts_project(
+    name = "compile",
     srcs = ["decrement.ts"],
+    extends = "tsconfig.json",
+    tsconfig = {
+        "compilerOptions": {
+            "declaration": True,
+        },
+    },
 )
 
-ts_config(
-    name = "tsconfig-test",
-    src = "tsconfig-test.json",
-    deps = [":tsconfig.json"],
+js_library(
+    name = "lib",
+    package_name = "decrement-lib",
+    named_module_srcs = [":compile"],
+    deps = [":compile"],
 )
 
-ts_library(
-    name = "tests",
+ts_project(
+    name = "compile_tests",
     testonly = 1,
     srcs = glob(["*.spec.ts"]),
-    tsconfig = ":tsconfig-test",
+    extends = "tsconfig.json",
+    tsconfig = {
+        "compilerOptions": {
+            "types": [
+                "jasmine",
+                "node",
+            ],
+        },
+    },
     deps = [
         ":lib",
         "@npm//@types/jasmine",
@@ -24,15 +40,29 @@ ts_library(
     ],
 )
 
-ts_library(
-    name = "tests_setup",
+js_library(
+    name = "tests",
+    testonly = 1,
+    named_module_srcs = [":compile_tests"],
+    deps = ["lib"],
+)
+
+ts_project(
+    name = "compile_tests_setup",
     testonly = 1,
     srcs = ["setup_script.ts"],
-    tsconfig = ":tsconfig-test",
+    extends = "tsconfig.json",
+    tsconfig = {},
     deps = [
         "@npm//@types/jasmine",
         "@npm//@types/node",
     ],
+)
+
+js_library(
+    name = "tests_setup",
+    testonly = 1,
+    named_module_srcs = [":compile_tests_setup"],
 )
 
 karma_web_test_suite(

--- a/examples/web_testing/decrement.spec.ts
+++ b/examples/web_testing/decrement.spec.ts
@@ -1,4 +1,5 @@
-import {decrement} from './decrement';
+/// <amd-module name="examples_webtesting/decrement.spec"/>
+import {decrement} from 'decrement-lib/decrement';
 
 describe('decrementing', () => {
   it('should do that', () => {

--- a/examples/web_testing/decrement.ts
+++ b/examples/web_testing/decrement.ts
@@ -1,3 +1,4 @@
+/// <amd-module name="examples_webtesting/decrement"/>
 export function decrement(n: number) {
   return n - 1;
 }

--- a/examples/web_testing/setup_script.spec.ts
+++ b/examples/web_testing/setup_script.spec.ts
@@ -1,3 +1,4 @@
+/// <amd-module name="examples_webtesting/setup_script.spec"/>
 describe('setup script', () => {
   it('should load before the spec', async () => {
     expect((window as any).setupGlobal).toBe('setupGlobalValue');

--- a/examples/web_testing/setup_script.ts
+++ b/examples/web_testing/setup_script.ts
@@ -1,3 +1,5 @@
+/// <amd-module name="examples_webtesting/setup_script"/>
+
 // Setup global value that the test expect to be present.
 (window as any).setupGlobal = 'setupGlobalValue';
 

--- a/examples/web_testing/static_script.spec.ts
+++ b/examples/web_testing/static_script.spec.ts
@@ -1,3 +1,4 @@
+/// <amd-module name="examples_webtesting/static_script.spec"/>
 const someGlobal = new Promise<string>((resolve, reject) => {
   const script = document.createElement('script');
   script.src = `base/examples_webtesting/static_script.js`;

--- a/examples/web_testing/tsconfig.json
+++ b/examples/web_testing/tsconfig.json
@@ -2,6 +2,9 @@
   "compilerOptions": {
     "strict": true,
     "lib": ["es2015.promise", "dom", "es5"],
-  }
+    "module": "umd",
+    "moduleResolution": "node"
+  },
+  "exclude": ["external"]
 }
 

--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -631,7 +631,7 @@ def ts_project_macro(
             name = "_gen_tsconfig_%s" % name,
             config = tsconfig,
             files = [s for s in srcs if _is_ts_src(s, allow_js)],
-            extends = Label("//%s:%s" % (native.package_name(), name)).relative(extends) if extends else None,
+            extends = Label("%s//%s:%s" % (native.repository_name(), native.package_name(), name)).relative(extends) if extends else None,
             out = "tsconfig_%s.json" % name,
         )
 


### PR DESCRIPTION
We no longer recommend using ts_library so our examples shouldn't demonstrate it.
Note that for karma_web_test to work, it needs the JSNamedModuleInfo provider, so each ts_project is wrapped with a js_library that exposes the .js files to that provider. Also we add the triple-slash directive so TypeScript produces named umd outputs that work with concatjs
