### PR TITLE
refactor: switch to using json.encode rather than to_json on structs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -52,5 +52,7 @@ build:docker-sandbox --experimental_docker_image=gcr.io/cloud-marketplace/google
 # Incompatible flags to run with
 build --incompatible_no_implicit_file_export
 build --incompatible_restrict_string_escapes
+# TODO(mattem): flip this when dependencies allow
+# build --incompatible_struct_has_no_methods
 # TODO(alexeagle): turn on this flag when dependencies allow
 # build --incompatible_use_platforms_repo_for_constraints

--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -277,18 +277,20 @@ def _create_build_files(repository_ctx, rule_type, node, lock_file, generate_loc
         if not v.startswith("@"):
             fail("link target must be label of form '@wksp//path/to:target', '@//path/to:target' or '//path/to:target'")
         validated_links[k] = v
-    generate_config_json = struct(
-        generate_local_modules_build_files = generate_local_modules_build_files,
-        included_files = repository_ctx.attr.included_files,
-        links = validated_links,
-        package_json = str(repository_ctx.path(repository_ctx.attr.package_json)),
-        package_lock = str(repository_ctx.path(lock_file)),
-        package_path = repository_ctx.attr.package_path,
-        rule_type = rule_type,
-        strict_visibility = repository_ctx.attr.strict_visibility,
-        workspace = repository_ctx.attr.name,
-        workspace_root_prefix = _workspace_root_prefix(repository_ctx),
-    ).to_json()
+    generate_config_json = json.encode(
+        struct(
+            generate_local_modules_build_files = generate_local_modules_build_files,
+            included_files = repository_ctx.attr.included_files,
+            links = validated_links,
+            package_json = str(repository_ctx.path(repository_ctx.attr.package_json)),
+            package_lock = str(repository_ctx.path(lock_file)),
+            package_path = repository_ctx.attr.package_path,
+            rule_type = rule_type,
+            strict_visibility = repository_ctx.attr.strict_visibility,
+            workspace = repository_ctx.attr.name,
+            workspace_root_prefix = _workspace_root_prefix(repository_ctx),
+        ),
+    )
     repository_ctx.file("generate_config.json", generate_config_json)
     result = repository_ctx.execute(
         [node, "index.js"],

--- a/packages/esbuild/helpers.bzl
+++ b/packages/esbuild/helpers.bzl
@@ -135,14 +135,18 @@ def write_jsconfig_file(ctx, path_alias_mappings):
     # declare the jsconfig_file
     jsconfig_file = ctx.actions.declare_file("%s.config.json" % ctx.attr.name)
 
-    # write the config file
-    ctx.actions.write(
-        output = jsconfig_file,
-        content = struct(compilerOptions = struct(
+    jsconfig = struct(
+        compilerOptions = struct(
             rootDirs = ["."],
             baseUrl = base_url_path,
             paths = path_alias_mappings,
-        )).to_json(),
+        ),
+    )
+
+    # write the config file
+    ctx.actions.write(
+        output = jsconfig_file,
+        content = json.encode(jsconfig),
     )
 
     return jsconfig_file

--- a/packages/typescript/internal/ts_config.bzl
+++ b/packages/typescript/internal/ts_config.bzl
@@ -128,6 +128,6 @@ def write_tsconfig(name, config, files, out, extends = None):
         name = name,
         files = files,
         extends = extends,
-        content = [amended_config.to_json()],
+        content = [json.encode(amended_config)],
         out = out,
     )

--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -267,7 +267,7 @@ def _validate_options_impl(ctx):
     marker = ctx.actions.declare_file("%s.optionsvalid.d.ts" % ctx.label.name)
 
     arguments = ctx.actions.args()
-    arguments.add_all([ctx.file.tsconfig.path, marker.path, ctx.attr.target, struct(
+    config = struct(
         allow_js = ctx.attr.allow_js,
         declaration = ctx.attr.declaration,
         declaration_map = ctx.attr.declaration_map,
@@ -277,7 +277,8 @@ def _validate_options_impl(ctx):
         source_map = ctx.attr.source_map,
         incremental = ctx.attr.incremental,
         ts_build_info_file = ctx.attr.ts_build_info_file,
-    ).to_json()])
+    )
+    arguments.add_all([ctx.file.tsconfig.path, marker.path, ctx.attr.target, json.encode(config)])
 
     inputs = _tsconfig_inputs(ctx)
 


### PR DESCRIPTION
**BREAKING CHANGE**

Switch to using `json.encode` rather than `to_json` on structs.
Can't yet flip `--incompatible_struct_has_no_methods` as other dependencies use the deprecated methods.

As the `json` and `proto` modules are only available in bazel 4.x (LTS) and above, this change removes support for any versions below 4.0.0. 