### PR TITLE
refactor(esbuild): refactor esbuild rule to use the esbuild API

### DIFF
--- a/docs/esbuild.md
+++ b/docs/esbuild.md
@@ -99,7 +99,7 @@ This will create an output directory containing all the code split chunks, along
 **USAGE**
 
 <pre>
-esbuild(<a href="#esbuild-name">name</a>, <a href="#esbuild-args">args</a>, <a href="#esbuild-define">define</a>, <a href="#esbuild-deps">deps</a>, <a href="#esbuild-entry_point">entry_point</a>, <a href="#esbuild-entry_points">entry_points</a>, <a href="#esbuild-external">external</a>, <a href="#esbuild-format">format</a>, <a href="#esbuild-launcher">launcher</a>,
+esbuild(<a href="#esbuild-name">name</a>, <a href="#esbuild-args">args</a>, <a href="#esbuild-args_file">args_file</a>, <a href="#esbuild-define">define</a>, <a href="#esbuild-deps">deps</a>, <a href="#esbuild-entry_point">entry_point</a>, <a href="#esbuild-entry_points">entry_points</a>, <a href="#esbuild-external">external</a>, <a href="#esbuild-format">format</a>, <a href="#esbuild-launcher">launcher</a>,
         <a href="#esbuild-link_workspace_root">link_workspace_root</a>, <a href="#esbuild-max_threads">max_threads</a>, <a href="#esbuild-minify">minify</a>, <a href="#esbuild-output">output</a>, <a href="#esbuild-output_css">output_css</a>, <a href="#esbuild-output_dir">output_dir</a>, <a href="#esbuild-output_map">output_map</a>,
         <a href="#esbuild-platform">platform</a>, <a href="#esbuild-sourcemap">sourcemap</a>, <a href="#esbuild-sources_content">sources_content</a>, <a href="#esbuild-srcs">srcs</a>, <a href="#esbuild-target">target</a>)
 </pre>
@@ -119,27 +119,33 @@ For further information about esbuild, see https://esbuild.github.io/
 
 <h4 id="esbuild-args">args</h4>
 
-(*List of strings*): A list of extra arguments that are included in the call to esbuild.
-    $(location ...) can be used to resolve the path to a Bazel target.
+(*<a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a>*): A dict of extra arguments that are included in the call to esbuild, where the key is the argument name.
+Values are subject to $(location ...) expansion
 
-Defaults to `[]`
+Defaults to `{}`
+
+<h4 id="esbuild-args_file">args_file</h4>
+
+(*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>*): A JSON file containing additional arguments that are passed to esbuild. Note: only one of args or args_file may be set
+
+Defaults to `None`
 
 <h4 id="esbuild-define">define</h4>
 
-(*List of strings*): A list of global identifier replacements.
+(*<a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a>*): A dict of global identifier replacements. Values are subject to $(location ...) expansion.
 Example:
 ```python
 esbuild(
     name = "bundle",
-    define = [
-        "process.env.NODE_ENV=\"production\""
-    ],
+    define = {
+        "process.env.NODE_ENV": "production"
+    },
 )
 ```
 
 See https://esbuild.github.io/api/#define for more details
 
-Defaults to `[]`
+Defaults to `{}`
 
 <h4 id="esbuild-deps">deps</h4>
 

--- a/packages/esbuild/BUILD.bazel
+++ b/packages/esbuild/BUILD.bazel
@@ -76,6 +76,7 @@ pkg_npm(
     build_file_content = """exports_files(["launcher.js"])""",
     substitutions = dict({
         "@build_bazel_rules_nodejs//packages/esbuild": "//@bazel/esbuild",
+        "package_path = \"packages/esbuild\",": "package_path = \"external/\" + pkg_label.workspace_name + \"/@bazel/esbuild\",",
     }),
     deps = [
         ":README.md",

--- a/packages/esbuild/esbuild_repositories.bzl
+++ b/packages/esbuild/esbuild_repositories.bzl
@@ -3,6 +3,7 @@ Helper macro for fetching esbuild versions
 """
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@build_bazel_rules_nodejs//:index.bzl", "npm_install")
 load(":esbuild_packages.bzl", "ESBUILD_PACKAGES")
 
 def _maybe(repo_rule, name, **kwargs):
@@ -28,3 +29,18 @@ def esbuild_repositories(name = ""):
 
         toolchain_label = Label("@build_bazel_rules_nodejs//packages/esbuild/toolchain:esbuild_%s_toolchain" % name)
         native.register_toolchains("@%s//%s:%s" % (toolchain_label.workspace_name, toolchain_label.package, toolchain_label.name))
+
+    pkg_label = Label("@build_bazel_rules_nodejs//packages/esbuild/toolchain:package.json")
+    npm_install(
+        name = "esbuild_npm",
+        package_json = pkg_label,
+        package_lock_json = Label("@build_bazel_rules_nodejs//packages/esbuild/toolchain:package-lock.json"),
+        args = [
+            # Install is run with ignore scripts so that esbuild's postinstall script does not run,
+            # as we never use the downloaded binary anyway and instead set 'ESBUILD_BINARY_PATH' to the toolchains path.
+            # This allows us to deal with --platform
+            "--ignore-scripts",
+        ],
+        symlink_node_modules = False,
+        package_path = "packages/esbuild",
+    )

--- a/packages/esbuild/helpers.bzl
+++ b/packages/esbuild/helpers.bzl
@@ -150,3 +150,12 @@ def write_jsconfig_file(ctx, path_alias_mappings):
     )
 
     return jsconfig_file
+
+def write_args_file(ctx, args):
+    args_file = ctx.actions.declare_file("%s.args.json" % ctx.attr.name)
+    ctx.actions.write(
+        output = args_file,
+        content = json.encode(args),
+    )
+
+    return args_file

--- a/packages/esbuild/test/alias-mapping/BUILD.bazel
+++ b/packages/esbuild/test/alias-mapping/BUILD.bazel
@@ -3,7 +3,9 @@ load("//packages/esbuild:index.bzl", "esbuild")
 
 esbuild(
     name = "bundle",
-    args = ["--keep-names"],
+    args = {
+        "keepNames": True,
+    },
     entry_point = "main.js",
     format = "esm",
     deps = [

--- a/packages/esbuild/test/bundle/BUILD.bazel
+++ b/packages/esbuild/test/bundle/BUILD.bazel
@@ -16,14 +16,18 @@ ts_library(
 
 esbuild(
     name = "bundle",
-    args = ["--keep-names"],
+    args = {
+        "keepNames": True,
+    },
     entry_point = "a.ts",
     deps = [":lib"],
 )
 
 esbuild(
     name = "bundle.min",
-    args = ["--keep-names"],
+    args = {
+        "keepNames": True,
+    },
     entry_point = "a.ts",
     minify = True,
     deps = [":lib"],
@@ -31,7 +35,9 @@ esbuild(
 
 esbuild(
     name = "bundle.split",
-    args = ["--keep-names"],
+    args = {
+        "keepNames": True,
+    },
     entry_point = "a.ts",
     output_dir = True,
     deps = [":lib"],

--- a/packages/esbuild/test/css/BUILD.bazel
+++ b/packages/esbuild/test/css/BUILD.bazel
@@ -34,10 +34,13 @@ ts_library(
 
 esbuild(
     name = "default",
-    args = [
-        "--keep-names",
-        "--resolve-extensions=.mjs,.js",
-    ],
+    args = {
+        "keepNames": True,
+        "resolveExtensions": [
+            ".mjs",
+            ".js",
+        ],
+    },
     entry_point = "main.ts",
     deps = [
         ":main",
@@ -46,10 +49,13 @@ esbuild(
 
 esbuild(
     name = "with_css",
-    args = [
-        "--keep-names",
-        "--resolve-extensions=.mjs,.js",
-    ],
+    args = {
+        "keepNames": True,
+        "resolveExtensions": [
+            ".mjs",
+            ".js",
+        ],
+    },
     entry_point = "main.ts",
     output_css = "with_css.css",
     deps = [

--- a/packages/esbuild/test/css/main.ts
+++ b/packages/esbuild/test/css/main.ts
@@ -1,3 +1,5 @@
 import { dep } from "./dep";
 
 dep();
+
+console.log(process.cwd())

--- a/packages/esbuild/test/define/BUILD.bazel
+++ b/packages/esbuild/test/define/BUILD.bazel
@@ -14,10 +14,16 @@ ts_library(
 
 esbuild(
     name = "bundle",
-    args = ["--keep-names"],
-    define = [
-        "process.env.NODE_ENV=\"defined_in_bundle\"",
+    srcs = [
+        "shim.js",
     ],
+    args = {
+        "inject": ["$(execpath :shim.js)"],
+        "keepNames": True,
+    },
+    define = {
+        "process.env.NODE_ENV": "\"defined_in_bundle\"",
+    },
     entry_point = "main.ts",
     deps = [":main"],
 )

--- a/packages/esbuild/test/define/bundle_test.js
+++ b/packages/esbuild/test/define/bundle_test.js
@@ -7,5 +7,6 @@ describe('esbuild define', () => {
   it('defines variables', () => {
     const bundle = readFileSync(location, {encoding: 'utf8'});
     expect(bundle).toContain(`nodeEnv = "defined_in_bundle"`);
+    expect(bundle).toContain(`cwd: () => "rules_nodejs"`);
   });
 })

--- a/packages/esbuild/test/define/main.ts
+++ b/packages/esbuild/test/define/main.ts
@@ -1,1 +1,2 @@
 export const nodeEnv = process.env.NODE_ENV;
+console.log(process.cwd());

--- a/packages/esbuild/test/define/shim.js
+++ b/packages/esbuild/test/define/shim.js
@@ -1,0 +1,4 @@
+// process-shim.js
+export let process = {
+    cwd: () => 'rules_nodejs'
+}

--- a/packages/esbuild/test/external-flag/BUILD.bazel
+++ b/packages/esbuild/test/external-flag/BUILD.bazel
@@ -14,7 +14,9 @@ ts_library(
 
 esbuild(
     name = "bundle",
-    args = ["--keep-names"],
+    args = {
+        "keepNames": True,
+    },
     entry_point = "main.ts",
     external = [
         "fs",

--- a/packages/esbuild/test/output/BUILD.bazel
+++ b/packages/esbuild/test/output/BUILD.bazel
@@ -14,7 +14,9 @@ ts_library(
 
 esbuild(
     name = "bundle_different_output",
-    args = ["--keep-names"],
+    args = {
+        "keepNames": True,
+    },
     entry_point = "main.ts",
     output = "different_output.js",
     deps = [":main"],

--- a/packages/esbuild/test/sourcemap/BUILD.bazel
+++ b/packages/esbuild/test/sourcemap/BUILD.bazel
@@ -14,14 +14,18 @@ ts_library(
 
 esbuild(
     name = "bundle_default",
-    args = ["--keep-names"],
+    args = {
+        "keepNames": True,
+    },
     entry_point = "main.ts",
     deps = [":main"],
 )
 
 esbuild(
     name = "bundle_inline",
-    args = ["--keep-names"],
+    args = {
+        "keepNames": True,
+    },
     entry_point = "main.ts",
     sourcemap = "inline",
     deps = [":main"],
@@ -29,7 +33,9 @@ esbuild(
 
 esbuild(
     name = "bundle_external",
-    args = ["--keep-names"],
+    args = {
+        "keepNames": True,
+    },
     entry_point = "main.ts",
     sourcemap = "external",
     deps = [":main"],
@@ -37,7 +43,9 @@ esbuild(
 
 esbuild(
     name = "bundle_both",
-    args = ["--keep-names"],
+    args = {
+        "keepNames": True,
+    },
     entry_point = "main.ts",
     sourcemap = "both",
     deps = [":main"],

--- a/packages/esbuild/test/splitting/BUILD.bazel
+++ b/packages/esbuild/test/splitting/BUILD.bazel
@@ -16,12 +16,9 @@ ts_library(
 
 esbuild(
     name = "bundle",
-    args = [
-        # info log level may be helpful when splitting as esbuild will show each file emitted
-        # where as bazel will only list the output directory
-        "--log-level=info",
-        "--keep-names",
-    ],
+    args = {
+        "keepNames": True,
+    },
     entry_point = "main.ts",
     output_dir = True,
     deps = [":main"],

--- a/packages/esbuild/test/typescript/BUILD.bazel
+++ b/packages/esbuild/test/typescript/BUILD.bazel
@@ -19,10 +19,13 @@ ts_library(
 
 esbuild(
     name = "bundle",
-    args = [
-        "--keep-names",
-        "--resolve-extensions=.mjs,.js",
-    ],
+    args = {
+        "keepNames": True,
+        "resolveExtensions": [
+            ".mjs",
+            ".js",
+        ],
+    },
     entry_point = "main.ts",
     format = "esm",
     deps = [":main"],

--- a/packages/esbuild/test/workspace-mapping/BUILD.bazel
+++ b/packages/esbuild/test/workspace-mapping/BUILD.bazel
@@ -3,7 +3,9 @@ load("//packages/esbuild:index.bzl", "esbuild")
 
 esbuild(
     name = "bundle",
-    args = ["--keep-names"],
+    args = {
+        "keepNames": True,
+    },
     entry_point = "main.js",
     format = "esm",
     link_workspace_root = True,

--- a/packages/esbuild/toolchain/BUILD.bazel
+++ b/packages/esbuild/toolchain/BUILD.bazel
@@ -2,6 +2,11 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@build_bazel_rules_nodejs//packages/esbuild:esbuild_packages.bzl", "ESBUILD_PACKAGES")
 load(":toolchain.bzl", "configure_esbuild_toolchains")
 
+exports_files([
+    "package.json",
+    "package-lock.json",
+])
+
 toolchain_type(
     name = "toolchain_type",
     visibility = ["//visibility:public"],
@@ -23,6 +28,8 @@ filegroup(
     name = "srcs",
     srcs = [
         "BUILD.bazel",
+        "package.json",
+        "package-lock.json",
         "toolchain.bzl",
     ],
     visibility = ["//packages/esbuild:__pkg__"],

--- a/packages/esbuild/toolchain/package-lock.json
+++ b/packages/esbuild/toolchain/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.0-PLACEHOLDER",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "esbuild": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.5.tgz",
+      "integrity": "sha512-vcuP53pA5XiwUU4FnlXM+2PnVjTfHGthM7uP1gtp+9yfheGvFFbq/KyuESThmtoHPUrfZH5JpxGVJIFDVD1Egw=="
+    }
+  }
+}

--- a/packages/esbuild/toolchain/package.json
+++ b/packages/esbuild/toolchain/package.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.0.0-PLACEHOLDER",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bazelbuild/rules_nodejs.git",
+    "directory": "packages/esbuild"
+  },
+  "bugs": {
+    "url": "https://github.com/bazelbuild/rules_nodejs/issues"
+  },
+  "keywords": [
+    "bazel"
+  ],
+  "dependencies": {
+    "esbuild": "0.12.5"
+  }
+}

--- a/scripts/update-esbuild-versions.js
+++ b/scripts/update-esbuild-versions.js
@@ -1,6 +1,6 @@
 const https = require('https');
 const { exec } = require('shelljs');
-const { mkdirSync, rmdirSync, createWriteStream, readFileSync, writeFileSync } = require('fs');
+const { mkdirSync, createWriteStream, readFileSync, writeFileSync } = require('fs');
 const { join } = require('path');
 const { tmpdir } = require('os');
 
@@ -80,6 +80,10 @@ async function main() {
 
   replacements.push([/_VERSION = "(.+?)"/, version]);
   replaceFileContent('packages/esbuild/esbuild_packages.bzl', replacements);
+
+  // update package.json used for API wrapper
+  replaceFileContent('packages/esbuild/toolchain/package.json', [[/"esbuild": "(.+?)"/, version]]);
+  exec(`npm i --package-lock-only`, {silent: true, cwd: 'packages/esbuild/toolchain'});
 }
 
 main();


### PR DESCRIPTION
**BREAKING CHANGE**

Refactors the esbuild rule to use esbuild's API, rather than calling the CLI directly. This serves as a prefactor PR for adding plugin support.

`args` now takes a dict (was `string_list`), where the keys are the arg names from the JS API for esbuild.
`define` now takes a dict (was `string_list`), following the format of the `define` esbuild JS API.