### PR TITLE
refactor: use ts_project in cypress example

### DIFF
--- a/examples/cypress/BUILD.bazel
+++ b/examples/cypress/BUILD.bazel
@@ -1,24 +1,35 @@
 load("@cypress//:index.bzl", "cypress_web_test")
-load("@yarn//@bazel/typescript:index.bzl", "ts_library")
+load("@yarn//@bazel/typescript:index.bzl", "ts_project")
 
-# You must create a cypress plugin in order to boot a server to serve your application. It can be written as a javascript file or in typescript using ts_library or ts_project.
-ts_library(
+# You must create a cypress plugin in order to boot a server to serve your application.
+# It can be written as a javascript file or in typescript using ts_project.
+ts_project(
     name = "plugins_file",
     testonly = True,
     srcs = ["plugin.ts"],
-    tsconfig = ":tsconfig.json",
+    extends = ":tsconfig.json",
+    tsconfig = {
+        "compilerOptions": {
+            "types": ["node"],
+        },
+    },
     deps = [
         "@yarn//@types/node",
         "@yarn//express",
     ],
 )
 
-# You can write your cypress tests a javascript files or in typescript using ts_library or ts_project.
-ts_library(
+# You can write your cypress tests a javascript files or in typescript.
+ts_project(
     name = "hello_spec",
     testonly = True,
     srcs = ["hello.spec.ts"],
-    tsconfig = ":tsconfig.json",
+    extends = ":tsconfig.json",
+    tsconfig = {
+        "compilerOptions": {
+            "types": ["cypress"],
+        },
+    },
     deps = [
         "@yarn//cypress",
     ],

--- a/examples/cypress/tsconfig.json
+++ b/examples/cypress/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
-    "types": []
+    "lib": ["ES2015", "DOM"],
+    "types": [
+      "cypress",
+      "node"
+    ]
   }
 }


### PR DESCRIPTION
We no longer recommend ts_library so we shouldn't use it in our examples
