### PR TITLE
docs: update supported bazel versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ so this repo can be thought of as "JavaScript rules for Bazel" as well. (We woul
 
 This repository is maintained by volunteers in the Bazel community. Neither Google, nor the Bazel team, provides support for the code. However, this repository is part of the test suite used to vet new Bazel releases.
 
-We follow semantic versioning. Patch releases have bugfixes, minor releases have new features. Only major releases (1.x, 2.x) have breaking changes. We support the last two major releases of Bazel, see `SUPPORTED_BAZEL_VERSIONS` in our `/index.bzl` for the list we test against.
+We follow semantic versioning. Patch releases have bugfixes, minor releases have new features. Only major releases (1.x, 2.x) have breaking changes. We support [LTS releases](https://blog.bazel.build/2020/11/10/long-term-support-release.html) of Bazel (starting at 4.x), see `SUPPORTED_BAZEL_VERSIONS` in our `/index.bzl` for the list we test against.
 
 We strive to give you an easy upgrade path when we do introduce a breaking change by documenting a migration path.
 If you use code from an `/internal` path, or the labs package, these are not subject to our support policy and may have breaking changes or removals with no warning or migration path.


### PR DESCRIPTION
Update the root README with the bazel version support choices.