### PR TITLE
feat: support dict style directory_file_path entry_point in nodejs_binary, nodejs_test & jasmine_node_test

### DIFF
--- a/index.bzl
+++ b/index.bzl
@@ -26,8 +26,8 @@ load("//internal/generated_file_test:generated_file_test.bzl", _generated_file_t
 load("//internal/js_library:js_library.bzl", _js_library = "js_library")
 load(
     "//internal/node:node.bzl",
-    _nodejs_binary = "nodejs_binary",
-    _nodejs_test = "nodejs_test",
+    _nodejs_binary = "nodejs_binary_macro",
+    _nodejs_test = "nodejs_test_macro",
 )
 load("//internal/node:node_repositories.bzl", _node_repositories = "node_repositories")
 load("//internal/node:npm_package_bin.bzl", _npm_bin = "npm_package_bin")

--- a/internal/common/maybe_directory_file_path.bzl
+++ b/internal/common/maybe_directory_file_path.bzl
@@ -1,0 +1,35 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helper function to accept either a label or a directory_file_path as dict
+"""
+
+load("//internal/providers:tree_artifacts.bzl", "directory_file_path")
+
+def maybe_directory_file_path(name, value):
+    """Pass-through a value or convert a dict with a single key/value pair to a directory_file_path and return its label
+    """
+    if value and type(value) == "dict":
+        # convert {"//directory/artifact:target": "file/path"} to
+        # a directory_file_path value
+        keys = value.keys()
+        if len(keys) != 1:
+            fail("Expected a dict with a single entry that corresponds to the directory_file_path directory key & path value")
+        directory_file_path(
+            name = "%s_directory_file_path" % name,
+            directory = keys[0],
+            path = value[keys[0]],
+        )
+        value = ":%s_directory_file_path" % name
+    return value

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -22,6 +22,7 @@ a `module_name` attribute can be `require`d by that name.
 
 load("//:providers.bzl", "DirectoryFilePathInfo", "ExternalNpmPackageInfo", "JSModuleInfo", "JSNamedModuleInfo", "NodeRuntimeDepsInfo", "node_modules_aspect")
 load("//internal/common:expand_into_runfiles.bzl", "expand_location_into_runfiles")
+load("//internal/common:maybe_directory_file_path.bzl", "maybe_directory_file_path")
 load("//internal/common:module_mappings.bzl", "module_mappings_runtime_aspect")
 load("//internal/common:path_utils.bzl", "strip_external")
 load("//internal/common:preserve_legacy_templated_args.bzl", "preserve_legacy_templated_args")
@@ -637,6 +638,13 @@ nodejs_binary = rule(
     ],
 )
 
+def nodejs_binary_macro(name, **kwargs):
+    nodejs_binary(
+        name = name,
+        entry_point = maybe_directory_file_path(name, kwargs.pop("entry_point", None)),
+        **kwargs
+    )
+
 nodejs_test = rule(
     implementation = _nodejs_binary_impl,
     attrs = dict(_NODEJS_EXECUTABLE_ATTRS, **{
@@ -685,3 +693,10 @@ remote debugger.
         "@bazel_tools//tools/sh:toolchain_type",
     ],
 )
+
+def nodejs_test_macro(name, **kwargs):
+    nodejs_test(
+        name = name,
+        entry_point = maybe_directory_file_path(name, kwargs.pop("entry_point", None)),
+        **kwargs
+    )

--- a/packages/jasmine/jasmine_node_test.bzl
+++ b/packages/jasmine/jasmine_node_test.bzl
@@ -19,7 +19,7 @@ than launching a test in Karma, for example.
 """
 
 load("@build_bazel_rules_nodejs//:providers.bzl", "JSModuleInfo")
-load("@build_bazel_rules_nodejs//internal/node:node.bzl", "nodejs_test")
+load("@build_bazel_rules_nodejs//internal/node:node.bzl", nodejs_test = "nodejs_test_macro")
 
 def _js_sources_impl(ctx):
     depsets = []


### PR DESCRIPTION
This PR adds syntactical sugar to nodejs_binary, nodejs_test & jasmine_node_test entry_point such that you can specify a directory_file_path entry point with

```
entry_point = { "//directory/artifact:target": "file/path/main.js" }
```

Pre-factor to https://github.com/bazelbuild/rules_nodejs/pull/2698
