### PR TITLE
feat: support directory_file_path entry_point in npm_umd_bundle

### DIFF
--- a/internal/npm_install/npm_umd_bundle.bzl
+++ b/internal/npm_install/npm_umd_bundle.bzl
@@ -17,19 +17,29 @@
 For use by yarn_install and npm_install. Not meant to be part of the public API.
 """
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "ExternalNpmPackageInfo", "node_modules_aspect")
+load("//:providers.bzl", "DirectoryFilePathInfo", "ExternalNpmPackageInfo", "node_modules_aspect")
+load("//internal/common:maybe_directory_file_path.bzl", "maybe_directory_file_path")
 
-def _npm_umd_bundle(ctx):
-    if len(ctx.attr.entry_point.files.to_list()) != 1:
+def _entry_point_path(ctx):
+    if len(ctx.attr.entry_point.files.to_list()) > 1:
         fail("labels in entry_point must contain exactly one file")
+    if len(ctx.files.entry_point) == 1:
+        return ctx.files.entry_point[0].path
+    if DirectoryFilePathInfo in ctx.attr.entry_point:
+        return "/".join([
+            ctx.attr.entry_point[DirectoryFilePathInfo].directory.path,
+            ctx.attr.entry_point[DirectoryFilePathInfo].path,
+        ])
+    fail("entry_point must either be a file, or provide DirectoryFilePathInfo")
 
+def _impl(ctx):
     output = ctx.actions.declare_file("%s.umd.js" % ctx.attr.package_name)
 
     args = ctx.actions.args()
 
     args.add(ctx.workspace_name)
     args.add(ctx.attr.package_name)
-    args.add(ctx.file.entry_point.path)
+    args.add(_entry_point_path(ctx))
     args.add(output.path)
     args.add_joined(ctx.attr.excluded, join_with = ",")
 
@@ -56,11 +66,11 @@ def _npm_umd_bundle(ctx):
         OutputGroupInfo(umd = depset([output])),
     ]
 
-NPM_UMD_ATTRS = {
+_ATTRS = {
     "entry_point": attr.label(
         doc = """Entry point for the npm package""",
         mandatory = True,
-        allow_single_file = True,
+        allow_files = True,
     ),
     "excluded": attr.string_list(
         doc = """List of excluded packages that should not be bundled by browserify.
@@ -100,9 +110,16 @@ This target would be then be used instead of the generated `@npm//typeorm:typeor
     ),
 }
 
-npm_umd_bundle = rule(
-    implementation = _npm_umd_bundle,
-    attrs = NPM_UMD_ATTRS,
+_npm_umd_bundle = rule(
+    implementation = _impl,
+    attrs = _ATTRS,
     outputs = {"umd": "%{package_name}.umd.js"},
     doc = """Node package umd bundling""",
 )
+
+def npm_umd_bundle(name, **kwargs):
+    _npm_umd_bundle(
+        name = name,
+        entry_point = maybe_directory_file_path(name, kwargs.pop("entry_point", None)),
+        **kwargs
+    )


### PR DESCRIPTION
Similar to https://github.com/bazelbuild/rules_nodejs/pull/2749, adds support for directory_file_path entry points to npm_umd_bundle.

Adds syntactical sugar such that you can specify a directory_file_path entry point with

```
entry_point = { "//directory/artifact:target": "file/path/main.js" }
```

Pre-factor to https://github.com/bazelbuild/rules_nodejs/pull/2698