### PR TITLE
fix(builtin): support directory_file_path entry_point in nodejs_binary & nodejs_test when --bazel_patch_module_resolver is set

### DIFF
--- a/internal/node/launcher.sh
+++ b/internal/node/launcher.sh
@@ -361,9 +361,9 @@ else
   # Always set up source-map-support using our vendored copy, just like the require_patch_script
   register_source_map_support=$(rlocation build_bazel_rules_nodejs/third_party/github.com/source-map-support/register.js)
   LAUNCHER_NODE_OPTIONS+=( "--require" "${register_source_map_support}" )
-fi
-if [[ -n "TEMPLATED_entry_point_main" ]]; then
-  MAIN="${MAIN}/"TEMPLATED_entry_point_main
+  if [[ -n "TEMPLATED_entry_point_main" ]]; then
+    MAIN="${MAIN}/"TEMPLATED_entry_point_main
+  fi
 fi
 
 # The EXPECTED_EXIT_CODE lets us write bazel tests which assert that

--- a/internal/node/loader.js
+++ b/internal/node/loader.js
@@ -26,8 +26,10 @@ process.env.PATH = [require('path').dirname(process.execPath), process.env.PATH]
 if (require.main === module) {
   // Set the actual entry point in the arguments list.
   // argv[0] == node, argv[1] == entry point.
-  // NB: 'TEMPLATED_entry_point' below is replaced during the build process.
-  var mainScript = process.argv[1] = 'TEMPLATED_entry_point';
+  // NB: 'TEMPLATED_entry_point_path' & 'TEMPLATED_entry_point' below are replaced during the build process.
+  var entryPointPath = 'TEMPLATED_entry_point_path';
+  var entryPointMain = 'TEMPLATED_entry_point_main';
+  var mainScript = process.argv[1] = entryPointMain ? `${entryPointPath}/${entryPointMain}` : entryPointPath;
   try {
     module.constructor._load(mainScript, this, /*isMain=*/true);
   } catch (e) {

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -117,12 +117,17 @@ def _get_entry_point_file(ctx):
     fail("entry_point must either be a file, or provide DirectoryFilePathInfo")
 
 def _write_loader_script(ctx):
-    entry_point_path = _ts_to_js(_to_manifest_path(ctx, _get_entry_point_file(ctx)))
+    substitutions = {}
+    substitutions["TEMPLATED_entry_point_path"] = _ts_to_js(_to_manifest_path(ctx, _get_entry_point_file(ctx)))
+    if DirectoryFilePathInfo in ctx.attr.entry_point:
+        substitutions["TEMPLATED_entry_point_main"] = ctx.attr.entry_point[DirectoryFilePathInfo].path
+    else:
+        substitutions["TEMPLATED_entry_point_main"] = ""
 
     ctx.actions.expand_template(
         template = ctx.file._loader_template,
         output = ctx.outputs.loader_script,
-        substitutions = {"TEMPLATED_entry_point": entry_point_path},
+        substitutions = substitutions,
         is_executable = True,
     )
 


### PR DESCRIPTION
Pre-factor to https://github.com/bazelbuild/rules_nodejs/pull/2698. Fixes protractor_web_test issue with directory_artifacts.