### PR TITLE
fix(builtin): propogate tags to both generated targets in generated_file_test

### DIFF
--- a/internal/generated_file_test/generated_file_test.bzl
+++ b/internal/generated_file_test/generated_file_test.bzl
@@ -26,6 +26,8 @@ def generated_file_test(name, generated, src, substring_search = False, src_dbg 
     else:
         src_dbg = src
 
+    tags = kwargs.pop("tags", [])
+
     loc = "$(rootpath %s)"
     nodejs_test(
         name = name,
@@ -37,6 +39,7 @@ def generated_file_test(name, generated, src, substring_search = False, src_dbg 
             loc % generated,
         ],
         data = data,
+        tags = tags,
         visibility = visibility,
         **kwargs
     )
@@ -48,5 +51,6 @@ def generated_file_test(name, generated, src, substring_search = False, src_dbg 
             entry_point = "@build_bazel_rules_nodejs//internal/generated_file_test:bundle.js",
             templated_args = ["--out", loc % src, loc % src_dbg, loc % generated],
             data = data,
+            tags = tags,
             visibility = visibility,
         )


### PR DESCRIPTION
Both generated targets should have the tags so they can be used for build & test filters correctly

Pre-factor from https://github.com/bazelbuild/rules_nodejs/pull/2698'
