### PR TITLE
refactor: tidy after exports_directories_only change

### DIFF
--- a/internal/npm_install/generate_build_file.ts
+++ b/internal/npm_install/generate_build_file.ts
@@ -151,9 +151,9 @@ function generateBuildFiles(pkgs: Dep[]) {
   generateLinksBuildFiles(config.links)
 }
 
-function generateLinksBuildFiles(deps: {[key: string]: string}) {
-  for (const packageName of Object.keys(deps)) {
-    const target = deps[packageName];
+function generateLinksBuildFiles(links: {[key: string]: string}) {
+  for (const packageName of Object.keys(links)) {
+    const target = links[packageName];
     const basename = packageName.split('/').pop();
     const starlark = generateBuildFileHeader() +
         `load("@build_bazel_rules_nodejs//internal/linker:npm_link.bzl", "npm_link")

--- a/internal/npm_install/index.js
+++ b/internal/npm_install/index.js
@@ -70,9 +70,9 @@ function generateBuildFiles(pkgs) {
     findScopes().forEach(scope => generateScopeBuildFiles(scope, pkgs));
     generateLinksBuildFiles(config.links);
 }
-function generateLinksBuildFiles(deps) {
-    for (const packageName of Object.keys(deps)) {
-        const target = deps[packageName];
+function generateLinksBuildFiles(links) {
+    for (const packageName of Object.keys(links)) {
+        const target = links[packageName];
         const basename = packageName.split('/').pop();
         const starlark = generateBuildFileHeader() +
             `load("@build_bazel_rules_nodejs//internal/linker:npm_link.bzl", "npm_link")

--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -51,7 +51,7 @@ repository so all files that the package manager depends on must be listed.
 Turning this on will decrease the time it takes for Bazel to setup runfiles and sandboxing when
 there are a large number of npm dependencies as inputs to an action.
 
-This breaks compatibility for label that reference files within npm packages such as `@npm//:node_modules/prettier/bin-prettier.js`.
+This breaks compatibility for labels that reference files within npm packages such as `@npm//:node_modules/prettier/bin-prettier.js`.
 To reference files within npm packages, you can use the `directory_file_path` rule and/or `DirectoryFilePathInfo` provider.
 Note, some rules still need upgrading to support consuming `DirectoryFilePathInfo` where needed.
 
@@ -59,12 +59,12 @@ NB: This feature requires runfiles be enabled due to an issue in Bazel which we 
     On Windows runfiles are off by default and must be enabled with the `--enable_runfiles` flag when
     using this feature.
 
-NB: `ts_library` does not support directory artifact npm deps due to internal dependency on having all input sources files explicitly specified
+NB: `ts_library` does not support directory npm deps due to internal dependency on having all input sources files explicitly specified.
 
-NB: `protractor_web_test` and `protractor_web_test_suite` do not support directory artifact npm deps
+NB: `protractor_web_test` and `protractor_web_test_suite` do not support directory npm deps.
 
 For the `nodejs_binary` & `nodejs_test` `entry_point` attribute (which often needs to reference a file within
-an npm package) you can set the entry_point to a dict with a single entry, where the key corresponds to the directory artifact
+an npm package) you can set the entry_point to a dict with a single entry, where the key corresponds to the directory
 label and the value corresponds to the path within that directory to the entry point.
 
 For example,
@@ -87,8 +87,8 @@ nodejs_binary(
 )
 ```
 
-For other labels that are passed to `$(rootpath)`, `$(execpath)`, or `$(location)` you can simply break these apart into
-the directory artifact label that gets passed to the expander & path part to follows it.
+For labels that are passed to `$(rootpath)`, `$(execpath)`, or `$(location)` you can simply break these apart into
+the directory label that gets passed to the expander & path part to follows it.
 
 For example,
 
@@ -130,7 +130,7 @@ When False, the rule will not auto generate BUILD files for `node_modules` that 
         doc = """List of file extensions to be included in the npm package targets.
 
 NB: This option has no effect when exports_directories_only is True as all files are
-automatically included in the export directory artifact targets for each npm package.
+automatically included in the exported directory for each npm package.
 
 For example, [".js", ".d.ts", ".proto", ".json", ""].
 

--- a/internal/providers/external_npm_package_info.bzl
+++ b/internal/providers/external_npm_package_info.bzl
@@ -22,7 +22,7 @@ ExternalNpmPackageInfo = provider(
     doc = "Provides information about one or more external npm packages",
     fields = {
         "direct_sources": "Depset of direct source files in these external npm package(s)",
-        "has_directories": "True if any sources are directory artifacts",
+        "has_directories": "True if any sources are directories",
         "path": "The local workspace path that these external npm deps should be linked at. If empty, they will be linked at the root.",
         "sources": "Depset of direct & transitive source files in these external npm package(s) and transitive dependencies",
         "workspace": "The workspace name that these external npm package(s) are provided from",
@@ -39,10 +39,9 @@ def _node_modules_aspect_impl(target, ctx):
     # map of 'path' to [workspace, sources_depsets]
     paths = {}
 
-    # if any deps have has_directories then has_directories will be true
-    has_directories = False
-
     if hasattr(ctx.rule.attr, "deps"):
+        # if any deps have has_directories set then has_directories will be true in the exported ExternalNpmPackageInfo
+        has_directories = False
         for dep in ctx.rule.attr.deps:
             if ExternalNpmPackageInfo in dep:
                 has_directories = has_directories or dep[ExternalNpmPackageInfo].has_directories


### PR DESCRIPTION
Small follow up to https://github.com/bazelbuild/rules_nodejs/pull/2698 with some cleanup & house keeping