### PR TITLE
perf(cypress): export cypress files as a single symlink

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,7 +17,6 @@ build:release --stamp --workspace_status_command=./scripts/current_version.sh
 build --define=SOME_TEST_ENV=some_value
 test --define=SOME_TEST_ENV=some_value
 build --action_env=SOME_OTHER_ENV=some_other_value
-build --experimental_inprocess_symlink_creation
 
 ###############################
 # Remote Build Execution support

--- a/docs/Cypress.html
+++ b/docs/Cypress.html
@@ -208,14 +208,6 @@
 </span><span class="n">cypress_repository</span><span class="p">(</span><span class="n">name</span> <span class="o">=</span> <span class="s">"cypress"</span><span class="p">)</span>
 </code></pre></div></div>
 
-<h3 id="macos-install-requirements">macOS install requirements</h3>
-<p>On macOS, <code class="language-plaintext highlighter-rouge">cypress_repository</code> generates an external repository containing files whose names contain spaces. In order to make these files compatible with bazel you will need to add the following flag to your <code class="language-plaintext highlighter-rouge">.bazelrc</code> file:</p>
-<div class="language-python highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="c1"># Required for cypress_repository on macOS
-</span><span class="n">build</span> <span class="o">--</span><span class="n">experimental_inprocess_symlink_creation</span>
-</code></pre></div></div>
-
-<h3 id="windows-install-requirements">windows install requirements</h3>
-<p>At this point in time, <code class="language-plaintext highlighter-rouge">cypress_repository</code> is incompatible with bazel sandboxing on Windows. This may change in the future, but for now using cypress on windows requires windows sandboxing be disabled (it is disabled by default)</p>
 
 <h2 id="example-use-of-cypress_web_test">Example use of cypress_web_test</h2>
 <p>This example assumes you’ve named your external repository for node_modules as <code class="language-plaintext highlighter-rouge">npm</code> and for cypress as <code class="language-plaintext highlighter-rouge">cypress</code></p>

--- a/docs/Cypress.md
+++ b/docs/Cypress.md
@@ -32,15 +32,6 @@ load("@npm//@bazel/cypress:index.bzl", "cypress_repositories")
 cypress_repositories(name = "cypress", version = "MATCH_VERSION_IN_PACKAGE_JSON")
 ```
 
-### macOS install requirements
-On macOS, `cypress_repositories` generates an external repository containing files whose names contain spaces. In order to make these files compatible with bazel you will need to add the following flag to your `.bazelrc` file:
-```python
-# Required for cypress_repositories on macOS
-build --experimental_inprocess_symlink_creation
-```
-
-### windows install requirements
-At this point in time, `cypress_repositories` is incompatible with bazel sandboxing on Windows. This may change in the future, but for now using cypress on windows requires windows sandboxing be disabled (it is disabled by default)
 
 ## Example use of cypress_web_test
 This example assumes you've named your external repository for node_modules as `npm` and for cypress as `cypress`

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -110,13 +110,15 @@ example_integration_test(
 
 example_integration_test(
     name = "examples_cypress",
-    bazel_commands = ["test --sandbox_debug //..."],
+    bazel_commands = ["test //..."],
     npm_packages = {
         "//packages/cypress:npm_package": "@bazel/cypress",
         "//packages/typescript:npm_package": "@bazel/typescript",
     },
     owners = ["@mrmeku"],
-    tags = ["cypress"],
+    tags = [
+        "cypress",
+    ],
 )
 
 example_integration_test(

--- a/examples/cypress/.bazelrc
+++ b/examples/cypress/.bazelrc
@@ -1,3 +1,1 @@
 import %workspace%/../../common.bazelrc
-
-build --experimental_inprocess_symlink_creation

--- a/packages/cypress/index.bzl
+++ b/packages/cypress/index.bzl
@@ -40,15 +40,6 @@ load("@npm//@bazel/cypress:index.bzl", "cypress_repositories")
 cypress_repositories(name = "cypress", version = "MATCH_VERSION_IN_PACKAGE_JSON")
 ```
 
-### macOS install requirements
-On macOS, `cypress_repositories` generates an external repository containing files whose names contain spaces. In order to make these files compatible with bazel you will need to add the following flag to your `.bazelrc` file:
-```python
-# Required for cypress_repositories on macOS
-build --experimental_inprocess_symlink_creation
-```
-
-### windows install requirements
-At this point in time, `cypress_repositories` is incompatible with bazel sandboxing on Windows. This may change in the future, but for now using cypress on windows requires windows sandboxing be disabled (it is disabled by default)
 
 ## Example use of cypress_web_test
 This example assumes you've named your external repository for node_modules as `npm` and for cypress as `cypress`

--- a/packages/cypress/internal/cypress_repositories.bzl
+++ b/packages/cypress/internal/cypress_repositories.bzl
@@ -45,17 +45,16 @@ def cypress_repositories(
         urls = windows_urls + [
             "https://cdn.cypress.io/desktop/{}/win32-x64/cypress.zip".format(version),
         ],
-        strip_prefix = "Cypress",
         build_file_content = """
 filegroup(
     name = "files",
-    srcs = glob(["**"]),
+    srcs = ["Cypress"],
     visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "bin",
-    srcs = ["Cypress.exe"],
+    srcs = ["Cypress/Cypress.exe"],
     visibility = ["//visibility:public"],
 )
 """,
@@ -65,21 +64,20 @@ filegroup(
         name = "cypress_darwin".format(name),
         sha256 = darwin_sha256,
         # Cypress checks that the binary path matches **/Contents/MacOS/Cypress so we do not strip that particular prefix.
-        strip_prefix = "Cypress.app",
         urls = darwin_urls + [
             "https://cdn.cypress.io/desktop/{}/darwin-x64/cypress.zip".format(version),
         ],
         build_file_content = """
 filegroup(
     name = "files",
-    srcs = glob(["**"]),
+    srcs = ["Cypress.app"],
     visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "bin",
     # Cypress checks that the binary path matches **/Contents/MacOS/Cypress
-    srcs = ["Contents/MacOS/Cypress"],
+    srcs = ["Cypress.app/Contents/MacOS/Cypress"],
     visibility = ["//visibility:public"],
 )
 """,
@@ -88,20 +86,19 @@ filegroup(
     http_archive(
         name = "cypress_linux".format(name),
         sha256 = linux_sha256,
-        strip_prefix = "Cypress",
         urls = linux_urls + [
             "https://cdn.cypress.io/desktop/{}/linux-x64/cypress.zip".format(version),
         ],
         build_file_content = """
 filegroup(
     name = "files",
-    srcs = glob(["**"]),
+    srcs = ["Cypress"],
     visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "bin",
-    srcs = ["Cypress"],
+    srcs = ["Cypress/Cypress"],
     visibility = ["//visibility:public"],
 )
 """,


### PR DESCRIPTION
Rather than using a glob to expose the extract cypress files, we expose a symlink to the directory in which those files live. This has two main benefits:

- Reduces the amount of time to construct a runfiles tree for a cypress test
- Removes the need for --experimental_inprocess_symlink_creation on MacOS