### PR TITLE
feat(esbuild): filter ts declaration files by default

### DIFF
--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -45,6 +45,9 @@ def _esbuild_impl(ctx):
 
     # TODO(mattem): 4.0.0 breaking change, entry_points must exist in deps, and are not considered additional srcs
     inputs = deps_inputs + ctx.files.srcs + filter_files(entry_points)
+
+    inputs = [d for d in inputs if not (d.path.endswith(".d.ts") or d.path.endswith(".tsbuildinfo"))]
+
     outputs = []
 
     args = dict({


### PR DESCRIPTION
Transitive targets which produce only declarations can be skipped,
making the round trip time from editing a .ts(x) file to seeing
that change bundled greately reduced since tsc is not invoked.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Esbuild includes .d.ts files emitted by ts_project which requires tsc be run before esbuild

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


