### PR TITLE
chore: update default node.js to current LTS

### DIFF
--- a/docs/Built-ins.md
+++ b/docs/Built-ins.md
@@ -166,7 +166,7 @@ Defaults to `["https://nodejs.org/dist/v{version}/{filename}"]`
 
 (*String*): the specific version of NodeJS to install or, if vendored_node is specified, the vendored version of node
 
-Defaults to `"12.13.0"`
+Defaults to `"14.17.1"`
 
 <h4 id="node_repositories-package_json">package_json</h4>
 

--- a/examples/angular/WORKSPACE
+++ b/examples/angular/WORKSPACE
@@ -45,7 +45,11 @@ http_archive(
 )
 
 # Check the bazel version and download npm dependencies
-load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
+
+node_repositories(
+    node_version = "12.13.0",
+)
 
 # Setup the Node.js toolchain & install our npm dependencies into @npm
 yarn_install(

--- a/examples/angular_view_engine/WORKSPACE
+++ b/examples/angular_view_engine/WORKSPACE
@@ -32,7 +32,11 @@ http_archive(
 )
 
 # Check the bazel version and download npm dependencies
-load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
+
+node_repositories(
+    node_version = "12.13.0",
+)
 
 # Setup the Node.js toolchain & install our npm dependencies into @npm
 yarn_install(

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -24,7 +24,7 @@ load("//internal/node:node_versions.bzl", "NODE_VERSIONS")
 load("//third_party/github.com/bazelbuild/bazel-skylib:lib/paths.bzl", "paths")
 load("//toolchains/node:node_toolchain_configure.bzl", "node_toolchain_configure")
 
-_DEFAULT_NODE_VERSION = "12.13.0"
+_DEFAULT_NODE_VERSION = "14.17.1"
 
 # @unsorted-dict-items
 _YARN_VERSIONS = {


### PR DESCRIPTION
This matches 'Recommended for most Users' on nodejs.org/en/download

