### PR TITLE
chore: switch buildifier lint to blocklist

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,7 +6,7 @@ buildifier:
   version: 4.0.1
   # Keep this in sync with the list in .pre-commit-config.yaml
   # https://github.com/bazelbuild/buildtools/issues/479 should fix this by giving us a config file
-  warnings: "attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,confusing-name,constant-glob,ctx-actions,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,function-docstring,git-repository,http-archive,integer-division,load,load-on-top,module-docstring,name-conventions,native-build,native-package,out-of-order-load,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,return-value,same-origin-load,string-iteration,unreachable,unsorted-dict-items,unused-variable"
+  warnings: "-bzl-visibility,-function-docstring-args,-function-docstring-return,-print,-unnamed-macro,-provider-params,-function-docstring-header,-no-effect,-uninitialized,-rule-impl-return"
   # Note, we ought to be able to exclude third_party from this check, but currently cannot:
   # https://github.com/bazelbuild/continuous-integration/issues/1162
 tasks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,6 @@ repos:
       - id: buildifier
         args: &args
           # Keep this argument in sync with .bazelci/presubmit.yml
-          - --warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,confusing-name,constant-glob,ctx-actions,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,function-docstring,git-repository,http-archive,integer-division,load,load-on-top,module-docstring,name-conventions,native-build,native-package,out-of-order-load,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,return-value,same-origin-load,string-iteration,unreachable,unsorted-dict-items,unused-variable
+          - --warnings=-bzl-visibility,-function-docstring-args,-function-docstring-return,-print,-unnamed-macro,-provider-params,-function-docstring-header,-no-effect,-uninitialized,-rule-impl-return
       - id: buildifier-lint
         args: *args

--- a/internal/pkg_npm/pkg_npm.bzl
+++ b/internal/pkg_npm/pkg_npm.bzl
@@ -189,7 +189,7 @@ def create_package(ctx, deps_files, nested_packages):
     scripts.
 
     Args:
-      ctx: the skylark rule context
+      ctx: the starlark rule context
       deps_files: list of files to include in the package which have been
                   specified as dependencies
       nested_packages: list of TreeArtifact outputs from other actions which are

--- a/packages/jasmine/jasmine_node_test.bzl
+++ b/packages/jasmine/jasmine_node_test.bzl
@@ -126,8 +126,8 @@ def jasmine_node_test(
         all_data.extend(["@npm//jasmine", "@npm//jasmine-reporters", "@npm//c8"])
 
     # END-INTERNAL
-    all_data += [":%s_js_sources.MF" % name]
-    all_data += [Label("@build_bazel_rules_nodejs//third_party/github.com/bazelbuild/bazel/tools/bash/runfiles")]
+    all_data.append(":%s_js_sources.MF" % name)
+    all_data.append(Label("@build_bazel_rules_nodejs//third_party/github.com/bazelbuild/bazel/tools/bash/runfiles"))
 
     # jasmine_runner.js consumes the first 3 args.
     # The remaining target templated_args will be passed through to jasmine or

--- a/packages/typescript/internal/build_defs.bzl
+++ b/packages/typescript/internal/build_defs.bzl
@@ -93,14 +93,14 @@ def _trim_package_node_modules(package_name):
     for n in package_name.split("/"):
         if n == "node_modules":
             break
-        segments += [n]
+        segments.append(n)
     return "/".join(segments)
 
 def _compute_node_modules_root(ctx):
     """Computes the node_modules root from the node_modules and deps attributes.
 
     Args:
-      ctx: the skylark execution context
+      ctx: the starlark execution context
 
     Returns:
       The node_modules root as a string

--- a/third_party/github.com/bazelbuild/rules_typescript/internal/common/compilation.bzl
+++ b/third_party/github.com/bazelbuild/rules_typescript/internal/common/compilation.bzl
@@ -163,22 +163,22 @@ def _outputs(ctx, label, srcs_files = []):
         # Temporary until all imports of ngfactory/ngsummary files are removed
         # TODO(alexeagle): clean up after Ivy launch
         if getattr(ctx.attr, "use_angular_plugin", False):
-            closure_js_files += [ctx.actions.declare_file(basename + ".ngfactory.mjs")]
-            closure_js_files += [ctx.actions.declare_file(basename + ".ngsummary.mjs")]
+            closure_js_files.append(ctx.actions.declare_file(basename + ".ngfactory.mjs"))
+            closure_js_files.append(ctx.actions.declare_file(basename + ".ngsummary.mjs"))
 
         if not is_dts:
             devmode_js_file = ctx.actions.declare_file(basename + ".js")
             devmode_js_files.append(devmode_js_file)
             transpilation_infos.append(struct(closure = closure_js_file, devmode = devmode_js_file))
-            declaration_files += [ctx.actions.declare_file(basename + ".d.ts")]
+            declaration_files.append(ctx.actions.declare_file(basename + ".d.ts"))
 
             # Temporary until all imports of ngfactory/ngsummary files are removed
             # TODO(alexeagle): clean up after Ivy launch
             if getattr(ctx.attr, "use_angular_plugin", False):
-                devmode_js_files += [ctx.actions.declare_file(basename + ".ngfactory.js")]
-                devmode_js_files += [ctx.actions.declare_file(basename + ".ngsummary.js")]
-                declaration_files += [ctx.actions.declare_file(basename + ".ngfactory.d.ts")]
-                declaration_files += [ctx.actions.declare_file(basename + ".ngsummary.d.ts")]
+                devmode_js_files.append(ctx.actions.declare_file(basename + ".ngfactory.js"))
+                devmode_js_files.append(ctx.actions.declare_file(basename + ".ngsummary.js"))
+                declaration_files.append(ctx.actions.declare_file(basename + ".ngfactory.d.ts"))
+                declaration_files.append(ctx.actions.declare_file(basename + ".ngsummary.d.ts"))
     return struct(
         closure_js = closure_js_files,
         devmode_js = devmode_js_files,
@@ -261,7 +261,7 @@ def compile_ts(
                 fail("srcs must contain only type declarations (.d.ts files), " +
                      "but %s contains %s" % (src.label, f.short_path), "srcs")
             if f.path.endswith(".d.ts"):
-                src_declarations += [f]
+                src_declarations.append(f)
                 continue
 
     outs = outputs(ctx, ctx.label, srcs_files)
@@ -442,7 +442,7 @@ def compile_ts(
     transitive_es6_sources_sets = [es6_sources]
     for dep in getattr(ctx.attr, "deps", []):
         if hasattr(dep, "typescript"):
-            transitive_es6_sources_sets += [dep.typescript.transitive_es6_sources]
+            transitive_es6_sources_sets.append(dep.typescript.transitive_es6_sources)
     transitive_es6_sources = depset(transitive = transitive_es6_sources_sets)
 
     declarations_provider = DeclarationInfo(
@@ -483,7 +483,7 @@ def compile_ts(
         # e.g. rollup_bundle under Bazel needs to convert this into a UMD global
         # name in the Rollup configuration.
         "module_name": getattr(ctx.attr, "module_name", None),
-        # Expose the tags so that a Skylark aspect can access them.
+        # Expose the tags so that a Bazel aspect can access them.
         "tags": ctx.attr.tags if hasattr(ctx.attr, "tags") else ctx.rule.attr.tags,
         # @unsorted-dict-items
         "typescript": {

--- a/third_party/github.com/bazelbuild/rules_typescript/internal/common/json_marshal.bzl
+++ b/third_party/github.com/bazelbuild/rules_typescript/internal/common/json_marshal.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Marshal an arbitrary Skylark object to JSON."""
+"""Marshal an arbitrary Starlark object to JSON."""
 
 def json_marshal(data):
     """Serializes arbitrary data to JSON.

--- a/third_party/github.com/bazelbuild/rules_typescript/internal/common/module_mappings.bzl
+++ b/third_party/github.com/bazelbuild/rules_typescript/internal/common/module_mappings.bzl
@@ -124,7 +124,7 @@ module_mappings_aspect = aspect(
 def _module_mappings_runtime_aspect_impl(target, ctx):
     if target.label.workspace_root:
         # We need the workspace_name for the target being visited.
-        # Skylark doesn't have this - instead they have a workspace_root
+        # Starlark doesn't have this - instead they have a workspace_root
         # which looks like "external/repo_name" - so grab the second path segment.
         # TODO(alexeagle): investigate a better way to get the workspace name
         workspace_name = target.label.workspace_root.split("/")[1]

--- a/third_party/github.com/bazelbuild/rules_typescript/internal/common/tsconfig.bzl
+++ b/third_party/github.com/bazelbuild/rules_typescript/internal/common/tsconfig.bzl
@@ -37,7 +37,7 @@ def create_tsconfig(
     """Creates an object representing the TypeScript configuration to run the compiler under Bazel.
 
     Args:
-      ctx: the skylark execution context
+      ctx: the starlark execution context
       files: Labels of all TypeScript compiler inputs
       srcs: Immediate sources being compiled, as opposed to transitive deps.
       devmode_manifest: path to the manifest file to write for --target=es5


### PR DESCRIPTION
tidy up a couple of warnings at the same time.
This lets us burn them down by removing exclusions.
