### PR TITLE
feat(esbuild): allow for .ts, .tsx and .jsx entry points

### DIFF
--- a/docs/esbuild.md
+++ b/docs/esbuild.md
@@ -101,7 +101,7 @@ This will create an output directory containing all the code split chunks, along
 <pre>
 esbuild(<a href="#esbuild-name">name</a>, <a href="#esbuild-args">args</a>, <a href="#esbuild-args_file">args_file</a>, <a href="#esbuild-define">define</a>, <a href="#esbuild-deps">deps</a>, <a href="#esbuild-entry_point">entry_point</a>, <a href="#esbuild-entry_points">entry_points</a>, <a href="#esbuild-external">external</a>, <a href="#esbuild-format">format</a>, <a href="#esbuild-launcher">launcher</a>,
         <a href="#esbuild-link_workspace_root">link_workspace_root</a>, <a href="#esbuild-max_threads">max_threads</a>, <a href="#esbuild-minify">minify</a>, <a href="#esbuild-output">output</a>, <a href="#esbuild-output_css">output_css</a>, <a href="#esbuild-output_dir">output_dir</a>, <a href="#esbuild-output_map">output_map</a>,
-        <a href="#esbuild-platform">platform</a>, <a href="#esbuild-sourcemap">sourcemap</a>, <a href="#esbuild-sources_content">sources_content</a>, <a href="#esbuild-srcs">srcs</a>, <a href="#esbuild-target">target</a>)
+        <a href="#esbuild-platform">platform</a>, <a href="#esbuild-sourcemap">sourcemap</a>, <a href="#esbuild-sources_content">sources_content</a>, <a href="#esbuild-splitting">splitting</a>, <a href="#esbuild-srcs">srcs</a>, <a href="#esbuild-target">target</a>)
 </pre>
 
 Runs the esbuild bundler under Bazel
@@ -234,9 +234,7 @@ file is named 'foo.js', you should set this to 'foo.css'.
 
 <h4 id="esbuild-output_dir">output_dir</h4>
 
-(*Boolean*): If true, esbuild produces an output directory containing all the output files from code splitting for multiple entry points
-
-See https://esbuild.github.io/api/#splitting and https://esbuild.github.io/api/#entry-points for more details
+(*Boolean*): If true, esbuild produces an output directory containing all output files
 
 Defaults to `False`
 
@@ -266,6 +264,14 @@ Defaults to `""`
 (*Boolean*): If False, omits the `sourcesContent` field from generated source maps
 
 See https://esbuild.github.io/api/#sources-content for more details
+
+Defaults to `False`
+
+<h4 id="esbuild-splitting">splitting</h4>
+
+(*Boolean*): If true, esbuild produces an output directory containing all the output files from code splitting for multiple entry points
+
+See https://esbuild.github.io/api/#splitting and https://esbuild.github.io/api/#entry-points for more details
 
 Defaults to `False`
 

--- a/packages/esbuild/helpers.bzl
+++ b/packages/esbuild/helpers.bzl
@@ -5,7 +5,7 @@ Utility helper functions for the esbuild rule
 load("@build_bazel_rules_nodejs//third_party/github.com/bazelbuild/bazel-skylib:lib/paths.bzl", "paths")
 
 TS_EXTENSIONS = ["ts", "tsx"]
-JS_EXTENSIONS = ["js", "mjs"]
+JS_EXTENSIONS = ["js", "jsx", "mjs"]
 ALLOWED_EXTENSIONS = JS_EXTENSIONS + TS_EXTENSIONS
 
 def strip_ext(f):
@@ -13,7 +13,7 @@ def strip_ext(f):
     return f.short_path[:-len(f.extension) - 1]
 
 def resolve_entry_point(f, inputs, srcs):
-    """Find a corresponding javascript entrypoint for a provided file
+    """Find a corresponding entrypoint for a provided file
 
     Args:
         f: The file where its basename is used to match the entrypoint
@@ -26,15 +26,13 @@ def resolve_entry_point(f, inputs, srcs):
 
     no_ext = strip_ext(f)
 
-    # check for the ts file in srcs
-    for i in srcs:
-        if i.extension in TS_EXTENSIONS:
+    for i in inputs:
+        if i.extension in ALLOWED_EXTENSIONS:
             if strip_ext(i) == no_ext:
                 return i
 
-    # check for a js files everywhere else
-    for i in inputs:
-        if i.extension in JS_EXTENSIONS:
+    for i in srcs:
+        if i.extension in ALLOWED_EXTENSIONS:
             if strip_ext(i) == no_ext:
                 return i
 

--- a/packages/esbuild/test/entries/BUILD.bazel
+++ b/packages/esbuild/test/entries/BUILD.bazel
@@ -24,6 +24,7 @@ esbuild(
         "a.ts",
         "b.ts",
     ],
+    splitting = True,
     deps = [":lib"],
 )
 

--- a/packages/esbuild/test/splitting/BUILD.bazel
+++ b/packages/esbuild/test/splitting/BUILD.bazel
@@ -21,6 +21,7 @@ esbuild(
     },
     entry_point = "main.ts",
     output_dir = True,
+    splitting = True,
     deps = [":main"],
 )
 


### PR DESCRIPTION
Only enable code splitting when user opts into it. Previously
there was no way to produce an output directory without also
enabling code splitting.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Prior to this change, only .js and .jsm entry points could be used by esbuild

Issue Number: N/A


## What is the new behavior?
Now .ts, .tsx, and .jsx entry points can also be used

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Additionally, code splitting used to enabled when output_dir was set to true. This change also introduces a new `splitting` attribute so that user's can have an output directory without also opting into code splitting

## Other information

