### PR TITLE
refactor: rename API provider field 'type_blacklisted_declarations' t…

### DIFF
--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -15,7 +15,7 @@ Users should not load files under "/internal"
 **USAGE**
 
 <pre>
-DeclarationInfo(<a href="#DeclarationInfo-declarations">declarations</a>, <a href="#DeclarationInfo-transitive_declarations">transitive_declarations</a>, <a href="#DeclarationInfo-type_blacklisted_declarations">type_blacklisted_declarations</a>)
+DeclarationInfo(<a href="#DeclarationInfo-declarations">declarations</a>, <a href="#DeclarationInfo-transitive_declarations">transitive_declarations</a>, <a href="#DeclarationInfo-type_blocklisted_declarations">type_blocklisted_declarations</a>)
 </pre>
 
 The DeclarationInfo provider allows JS rules to communicate typing information.
@@ -36,7 +36,7 @@ Note: historically this was a subset of the string-typed "typescript" provider.
 
  A depset of typings files produced by this rule and all its transitive dependencies.
 This prevents needing an aspect in rules that consume the typings, which improves performance. 
-<h4 id="DeclarationInfo-type_blacklisted_declarations">type_blacklisted_declarations</h4>
+<h4 id="DeclarationInfo-type_blocklisted_declarations">type_blocklisted_declarations</h4>
 
  A depset of .d.ts files that we should not use to infer JSCompiler types (via tsickle) 
 

--- a/internal/providers/declaration_info.bzl
+++ b/internal/providers/declaration_info.bzl
@@ -29,7 +29,7 @@ Note: historically this was a subset of the string-typed "typescript" provider.
         "declarations": "A depset of typings files produced by this rule",
         "transitive_declarations": """A depset of typings files produced by this rule and all its transitive dependencies.
 This prevents needing an aspect in rules that consume the typings, which improves performance.""",
-        "type_blacklisted_declarations": """A depset of .d.ts files that we should not use to infer JSCompiler types (via tsickle)""",
+        "type_blocklisted_declarations": """A depset of .d.ts files that we should not use to infer JSCompiler types (via tsickle)""",
     },
 )
 
@@ -55,5 +55,5 @@ def declaration_info(declarations, deps = []):
         transitive_declarations = depset(transitive = transitive_depsets),
         # Downstream ts_library rules will fail if they don't find this field
         # Even though it is only for Google Closure Compiler externs generation
-        type_blacklisted_declarations = depset(),
+        type_blocklisted_declarations = depset(),
     )

--- a/packages/labs/grpc_web/ts_proto_library.bzl
+++ b/packages/labs/grpc_web/ts_proto_library.bzl
@@ -201,7 +201,7 @@ def _ts_proto_library_impl(ctx):
         DeclarationInfo(
             declarations = dts_outputs,
             transitive_declarations = transitive_declarations,
-            type_blacklisted_declarations = depset([]),
+            type_blocklisted_declarations = depset([]),
         ),
     ]
 

--- a/third_party/github.com/bazelbuild/rules_typescript/internal/common/compilation.bzl
+++ b/third_party/github.com/bazelbuild/rules_typescript/internal/common/compilation.bzl
@@ -104,7 +104,7 @@ def _collect_dep_declarations(ctx, declaration_infos):
         transitive_deps_declarations.append(ctx.attr._typescript_typings[DeclarationInfo].transitive_declarations)
 
     # .d.ts files whose types tsickle will not emit (used for ts_declaration(generate_externs=False).
-    type_blacklisted_declarations = [dep.type_blacklisted_declarations for dep in declaration_infos]
+    type_blocklisted_declarations = [dep.type_blocklisted_declarations for dep in declaration_infos]
 
     # If a tool like github.com/angular/clutz can create .d.ts from type annotated .js
     # its output will be collected here.
@@ -112,7 +112,7 @@ def _collect_dep_declarations(ctx, declaration_infos):
     return DeclarationInfo(
         declarations = depset(transitive = direct_deps_declarations),
         transitive_declarations = depset(ctx.files._additional_d_ts, transitive = transitive_deps_declarations),
-        type_blacklisted_declarations = depset(transitive = type_blacklisted_declarations),
+        type_blocklisted_declarations = depset(transitive = type_blocklisted_declarations),
     )
 
 def _should_generate_externs(ctx):
@@ -278,9 +278,9 @@ def compile_ts(
 
     dep_declarations = _collect_dep_declarations(ctx, declaration_infos)
 
-    type_blacklisted_declarations = dep_declarations.type_blacklisted_declarations
+    type_blocklisted_declarations = dep_declarations.type_blocklisted_declarations
     if not is_library and not _should_generate_externs(ctx):
-        type_blacklisted_declarations = depset(srcs_files, transitive = [type_blacklisted_declarations])
+        type_blocklisted_declarations = depset(srcs_files, transitive = [type_blocklisted_declarations])
 
     # The depsets of output files. These are the files that are always built
     # (including e.g. if you "blaze build :the_target" directly).
@@ -314,7 +314,7 @@ def compile_ts(
         srcs_files,
         jsx_factory = jsx_factory,
         tsickle_externs = tsickle_externs_path,
-        type_blacklisted_declarations = type_blacklisted_declarations.to_list(),
+        type_blocklisted_declarations = type_blocklisted_declarations.to_list(),
         allowed_deps = allowed_deps,
     )
 
@@ -448,7 +448,7 @@ def compile_ts(
     declarations_provider = DeclarationInfo(
         declarations = depset(transitive = declarations_depsets),
         transitive_declarations = transitive_decls,
-        type_blacklisted_declarations = type_blacklisted_declarations,
+        type_blocklisted_declarations = type_blocklisted_declarations,
     )
 
     # @unsorted-dict-items

--- a/third_party/github.com/bazelbuild/rules_typescript/internal/common/tsconfig.bzl
+++ b/third_party/github.com/bazelbuild/rules_typescript/internal/common/tsconfig.bzl
@@ -25,7 +25,7 @@ def create_tsconfig(
         srcs,
         devmode_manifest = None,
         tsickle_externs = None,
-        type_blacklisted_declarations = [],
+        type_blocklisted_declarations = [],
         out_dir = None,
         disable_strict_deps = False,
         allowed_deps = depset(),
@@ -42,7 +42,7 @@ def create_tsconfig(
       srcs: Immediate sources being compiled, as opposed to transitive deps.
       devmode_manifest: path to the manifest file to write for --target=es5
       tsickle_externs: path to write tsickle-generated externs.js.
-      type_blacklisted_declarations: types declared in these files will never be
+      type_blocklisted_declarations: types declared in these files will never be
           mentioned in generated .d.ts.
       out_dir: directory for generated output. Default is ctx.bin_dir
       disable_strict_deps: whether to disable the strict deps check
@@ -148,7 +148,7 @@ def create_tsconfig(
         "tsickleGenerateExterns": getattr(ctx.attr, "generate_externs", True),
         "tsickleExternsPath": tsickle_externs.path if tsickle_externs else "",
         "untyped": not getattr(ctx.attr, "tsickle_typed", False),
-        "typeBlackListPaths": [f.path for f in type_blacklisted_declarations],
+        "typeBlackListPaths": [f.path for f in type_blocklisted_declarations],
         # This is overridden by first-party javascript/typescript/tsconfig.bzl
         "ignoreWarningPaths": [],
         "es5Mode": devmode_manifest != None,


### PR DESCRIPTION
BREAKING CHANGE

Renames the field `type_blacklisted_declarations` to `type_blocklisted_declarations` within the `DeclarationInfo` provider API