### PR TITLE
docs: link to the 'main' URL for bazel.build docs

### DIFF
--- a/docs/Built-ins.md
+++ b/docs/Built-ins.md
@@ -389,14 +389,14 @@ Defaults to `False`
         To pass a node startup option, prepend it with `--node_options=`, e.g.
         `--node_options=--preserve-symlinks`.
 
-Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/master/be/make-variables.html.
+Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/main/be/make-variables.html.
 
 1. Subject to predefined source/output path variables substitutions.
 
 The predefined variables `execpath`, `execpaths`, `rootpath`, `rootpaths`, `location`, and `locations` take
 label parameters (e.g. `$(execpath //foo:bar)`) and substitute the file paths denoted by that label.
 
-See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_label_variables for more info.
+See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_label_variables for more info.
 
 NB: This $(location) substition returns the manifest file path which differs from the *_binary & *_test
 args and genrule bazel substitions. This will be fixed in a future major release.
@@ -439,7 +439,7 @@ const some_file = runfiles.resolveWorkspaceRelative(args[0]);
 
 NB: Bazel will error if it sees the single dollar sign $(rlocation path) in `templated_args` as it will try to
 expand `$(rlocation)` since we now expand predefined & custom "make" variables such as `$(COMPILATION_MODE)`,
-`$(BINDIR)` & `$(TARGET_CPU)` using `ctx.expand_make_variables`. See https://docs.bazel.build/versions/master/be/make-variables.html.
+`$(BINDIR)` & `$(TARGET_CPU)` using `ctx.expand_make_variables`. See https://docs.bazel.build/versions/main/be/make-variables.html.
 
 To prevent expansion of `$(rlocation)` write it as `$$(rlocation)`. Bazel understands `$$` to be
 the string literal `$` and the expansion results in `$(rlocation)` being passed as an arg instead
@@ -455,10 +455,10 @@ need to update to `$$(rlocation)`. This may be changed in the future.
 2. Subject to predefined variables & custom variable substitutions.
 
 Predefined "Make" variables such as $(COMPILATION_MODE) and $(TARGET_CPU) are expanded.
-See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_variables.
+See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_variables.
 
 Custom variables are also expanded including variables set through the Bazel CLI with --define=SOME_VAR=SOME_VALUE.
-See https://docs.bazel.build/versions/master/be/make-variables.html#custom_variables.
+See https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables.
 
 Predefined genrule variables are not supported in this context.
 
@@ -643,14 +643,14 @@ Defaults to `False`
         To pass a node startup option, prepend it with `--node_options=`, e.g.
         `--node_options=--preserve-symlinks`.
 
-Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/master/be/make-variables.html.
+Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/main/be/make-variables.html.
 
 1. Subject to predefined source/output path variables substitutions.
 
 The predefined variables `execpath`, `execpaths`, `rootpath`, `rootpaths`, `location`, and `locations` take
 label parameters (e.g. `$(execpath //foo:bar)`) and substitute the file paths denoted by that label.
 
-See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_label_variables for more info.
+See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_label_variables for more info.
 
 NB: This $(location) substition returns the manifest file path which differs from the *_binary & *_test
 args and genrule bazel substitions. This will be fixed in a future major release.
@@ -693,7 +693,7 @@ const some_file = runfiles.resolveWorkspaceRelative(args[0]);
 
 NB: Bazel will error if it sees the single dollar sign $(rlocation path) in `templated_args` as it will try to
 expand `$(rlocation)` since we now expand predefined & custom "make" variables such as `$(COMPILATION_MODE)`,
-`$(BINDIR)` & `$(TARGET_CPU)` using `ctx.expand_make_variables`. See https://docs.bazel.build/versions/master/be/make-variables.html.
+`$(BINDIR)` & `$(TARGET_CPU)` using `ctx.expand_make_variables`. See https://docs.bazel.build/versions/main/be/make-variables.html.
 
 To prevent expansion of `$(rlocation)` write it as `$$(rlocation)`. Bazel understands `$$` to be
 the string literal `$` and the expansion results in `$(rlocation)` being passed as an arg instead
@@ -709,10 +709,10 @@ need to update to `$$(rlocation)`. This may be changed in the future.
 2. Subject to predefined variables & custom variable substitutions.
 
 Predefined "Make" variables such as $(COMPILATION_MODE) and $(TARGET_CPU) are expanded.
-See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_variables.
+See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_variables.
 
 Custom variables are also expanded including variables set through the Bazel CLI with --define=SOME_VAR=SOME_VALUE.
-See https://docs.bazel.build/versions/master/be/make-variables.html#custom_variables.
+See https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables.
 
 Predefined genrule variables are not supported in this context.
 
@@ -2001,9 +2001,9 @@ It also provides:
 - [JSModuleInfo](#jsmoduleinfo) so rules like bundlers can collect the transitive set of .js files
 - [JSNamedModuleInfo](#jsnamedmoduleinfo) for rules that expect named AMD or `goog.module` format JS
 
-[OutputGroupInfo]: https://docs.bazel.build/versions/master/skylark/lib/OutputGroupInfo.html
-[DefaultInfo]: https://docs.bazel.build/versions/master/skylark/lib/DefaultInfo.html
-[output_group]: https://docs.bazel.build/versions/master/be/general.html#filegroup.output_group
+[OutputGroupInfo]: https://docs.bazel.build/versions/main/skylark/lib/OutputGroupInfo.html
+[DefaultInfo]: https://docs.bazel.build/versions/main/skylark/lib/DefaultInfo.html
+[output_group]: https://docs.bazel.build/versions/main/be/general.html#filegroup.output_group
 
 
 **PARAMETERS**
@@ -2108,7 +2108,7 @@ By default, Bazel runs actions with a working directory set to your workspace ro
 Use the `chdir` attribute to change the working directory before the program runs.
 
 This is a great candidate to wrap with a macro, as documented:
-https://docs.bazel.build/versions/master/skylark/macros.html#full-example
+https://docs.bazel.build/versions/main/skylark/macros.html#full-example
 
 
 **PARAMETERS**
@@ -2135,7 +2135,7 @@ Defaults to `None`
 
 <h4 id="npm_package_bin-data">data</h4>
 
-similar to [genrule.srcs](https://docs.bazel.build/versions/master/be/general.html#genrule.srcs)
+similar to [genrule.srcs](https://docs.bazel.build/versions/main/be/general.html#genrule.srcs)
 may also include targets that produce or reference npm packages which are needed by the tool
 
 Defaults to `[]`
@@ -2148,7 +2148,7 @@ Defaults to `{}`
 
 <h4 id="npm_package_bin-outs">outs</h4>
 
-similar to [genrule.outs](https://docs.bazel.build/versions/master/be/general.html#genrule.outs)
+similar to [genrule.outs](https://docs.bazel.build/versions/main/be/general.html#genrule.outs)
 
 Defaults to `[]`
 
@@ -2156,11 +2156,11 @@ Defaults to `[]`
 
 Command-line arguments to the tool.
 
-Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/master/be/make-variables.html.
+Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/main/be/make-variables.html.
 
 1. Predefined source/output path substitions is applied first:
 
-See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_label_variables.
+See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_label_variables.
 
 Use $(execpath) $(execpaths) to expand labels to the execroot (where Bazel runs build actions).
 
@@ -2176,7 +2176,7 @@ for either $(execpath) or $(rootpath) depending on the context.
 2. "Make" variables are expanded second:
 
 Predefined "Make" variables such as $(COMPILATION_MODE) and $(TARGET_CPU) are expanded.
-See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_variables.
+See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_variables.
 
 Like genrule, you may also use some syntax sugar for locations.
 
@@ -2188,10 +2188,10 @@ Like genrule, you may also use some syntax sugar for locations.
 - `$(RULEDIR)`: the root output directory of the rule, corresponding with its package
     (can be used with output_dir=True or False)
 
-See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_genrule_variables.
+See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_genrule_variables.
 
 Custom variables are also expanded including variables set through the Bazel CLI with --define=SOME_VAR=SOME_VALUE.
-See https://docs.bazel.build/versions/master/be/make-variables.html#custom_variables.
+See https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables.
 
 Defaults to `[]`
 
@@ -2301,14 +2301,14 @@ Path of the output file, relative to this package.
 
 Arguments to concatenate into a params file.
 
-Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/master/be/make-variables.html.
+Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/main/be/make-variables.html.
 
 1. Subject to predefined source/output path variables substitutions.
 
 The predefined variables `execpath`, `execpaths`, `rootpath`, `rootpaths`, `location`, and `locations` take
 label parameters (e.g. `$(execpath //foo:bar)`) and substitute the file paths denoted by that label.
 
-See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_label_variables for more info.
+See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_label_variables for more info.
 
 NB: This $(location) substition returns the manifest file path which differs from the *_binary & *_test
 args and genrule bazel substitions. This will be fixed in a future major release.
@@ -2318,10 +2318,10 @@ for more info.
 2. Subject to predefined variables & custom variable substitutions.
 
 Predefined "Make" variables such as $(COMPILATION_MODE) and $(TARGET_CPU) are expanded.
-See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_variables.
+See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_variables.
 
 Custom variables are also expanded including variables set through the Bazel CLI with --define=SOME_VAR=SOME_VALUE.
-See https://docs.bazel.build/versions/master/be/make-variables.html#custom_variables.
+See https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables.
 
 Predefined genrule variables are not supported in this context.
 

--- a/docs/Cypress.md
+++ b/docs/Cypress.md
@@ -91,7 +91,7 @@ cypress_toolchain(<a href="#cypress_toolchain-name">name</a>, <a href="#cypress_
 
 Defines a cypress toolchain.
 
-For usage see https://docs.bazel.build/versions/master/toolchains.html#defining-toolchains.
+For usage see https://docs.bazel.build/versions/main/toolchains.html#defining-toolchains.
 
 
 **ATTRIBUTES**
@@ -270,14 +270,14 @@ Defaults to `[]`
         To pass a node startup option, prepend it with `--node_options=`, e.g.
         `--node_options=--preserve-symlinks`.
 
-Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/master/be/make-variables.html.
+Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/main/be/make-variables.html.
 
 1. Subject to predefined source/output path variables substitutions.
 
 The predefined variables `execpath`, `execpaths`, `rootpath`, `rootpaths`, `location`, and `locations` take
 label parameters (e.g. `$(execpath //foo:bar)`) and substitute the file paths denoted by that label.
 
-See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_label_variables for more info.
+See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_label_variables for more info.
 
 NB: This $(location) substition returns the manifest file path which differs from the *_binary & *_test
 args and genrule bazel substitions. This will be fixed in a future major release.
@@ -320,7 +320,7 @@ const some_file = runfiles.resolveWorkspaceRelative(args[0]);
 
 NB: Bazel will error if it sees the single dollar sign $(rlocation path) in `templated_args` as it will try to
 expand `$(rlocation)` since we now expand predefined & custom "make" variables such as `$(COMPILATION_MODE)`,
-`$(BINDIR)` & `$(TARGET_CPU)` using `ctx.expand_make_variables`. See https://docs.bazel.build/versions/master/be/make-variables.html.
+`$(BINDIR)` & `$(TARGET_CPU)` using `ctx.expand_make_variables`. See https://docs.bazel.build/versions/main/be/make-variables.html.
 
 To prevent expansion of `$(rlocation)` write it as `$$(rlocation)`. Bazel understands `$$` to be
 the string literal `$` and the expansion results in `$(rlocation)` being passed as an arg instead
@@ -336,10 +336,10 @@ need to update to `$$(rlocation)`. This may be changed in the future.
 2. Subject to predefined variables & custom variable substitutions.
 
 Predefined "Make" variables such as $(COMPILATION_MODE) and $(TARGET_CPU) are expanded.
-See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_variables.
+See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_variables.
 
 Custom variables are also expanded including variables set through the Bazel CLI with --define=SOME_VAR=SOME_VALUE.
-See https://docs.bazel.build/versions/master/be/make-variables.html#custom_variables.
+See https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables.
 
 Predefined genrule variables are not supported in this context.
 

--- a/docs/Jasmine.md
+++ b/docs/Jasmine.md
@@ -27,7 +27,7 @@ Runs tests in NodeJS using the Jasmine test runner.
 
 Detailed XML test results are found in the standard `bazel-testlogs`
 directory. This may be symlinked in your workspace.
-See https://docs.bazel.build/versions/master/output_directories.html
+See https://docs.bazel.build/versions/main/output_directories.html
 
 To debug the test, see debugging notes in `nodejs_test`.
 

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -757,7 +757,7 @@ Defaults to `True`
 Experimental! Use only with caution.
 
 Allows you to enable the Bazel Persistent Workers strategy for this project.
-See https://docs.bazel.build/versions/master/persistent-workers.html
+See https://docs.bazel.build/versions/main/persistent-workers.html
 
 This requires that the tsc binary support a `--watch` option.
 

--- a/examples/angular_bazel_architect/WORKSPACE
+++ b/examples/angular_bazel_architect/WORKSPACE
@@ -1,6 +1,6 @@
 # Bazel workspace created by @bazel/create 0.38.1
 # Declares that this directory is the root of a Bazel workspace.
-# See https://docs.bazel.build/versions/master/build-ref.html#workspace
+# See https://docs.bazel.build/versions/main/build-ref.html#workspace
 workspace(
     # How this workspace would be referenced with absolute labels from another workspace
     name = "angular_bazel_architect",

--- a/examples/kotlin/BUILD.bazel
+++ b/examples/kotlin/BUILD.bazel
@@ -1,5 +1,5 @@
 # Add rules here to build your software
-# See https://docs.bazel.build/versions/master/build-ref.html#BUILD_files
+# See https://docs.bazel.build/versions/main/build-ref.html#BUILD_files
 
 load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin", "pkg_web")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_js_import", "kt_js_library")

--- a/internal/common/download.bzl
+++ b/internal/common/download.bzl
@@ -12,7 +12,7 @@ bazel_download = repository_rule(
     doc = """Utility to call Bazel downloader.
 
     This is a simple pass-thru wrapper for Bazel's
-    [repository_ctx#download](https://docs.bazel.build/versions/master/skylark/lib/repository_ctx.html#download)
+    [repository_ctx#download](https://docs.bazel.build/versions/main/skylark/lib/repository_ctx.html#download)
     function.
     """,
     implementation = _bazel_download,

--- a/internal/common/expand_into_runfiles.bzl
+++ b/internal/common/expand_into_runfiles.bzl
@@ -41,7 +41,7 @@ def expand_location_into_runfiles(ctx, input, targets = []):
     given string by replacing with the expanded path. Expansion only works for labels that point to direct dependencies
     of this rule or that are explicitly listed in the optional argument targets.
 
-    See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_label_variables.
+    See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_label_variables.
 
     Use `$(rootpath)` and `$(rootpaths)` to expand labels to the runfiles path that a built binary can use
     to find its dependencies. This path is of the format:
@@ -60,11 +60,11 @@ def expand_location_into_runfiles(ctx, input, targets = []):
     The legacy `$(location)` and `$(locations)` expansion is DEPRECATED as it returns the runfiles manifest path of the
     format `repo/path/to/file` which behaves differently than the built-in `$(location)` expansion in args of *_binary
     and *_test rules which returns the rootpath.
-    See https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-binaries.
+    See https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes-binaries.
 
     The legacy `$(location)` and `$(locations)` expansion also differs from how the builtin `ctx.expand_location()` expansions
     of `$(location)` and `$(locations)` behave as that function returns either the execpath or rootpath depending on the context.
-    See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_label_variables.
+    See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_label_variables.
 
     The behavior of `$(location)` and `$(locations)` expansion will be fixed in a future major release to match the
     to default Bazel behavior and return the same path as `ctx.expand_location()` returns for these.
@@ -83,7 +83,7 @@ def expand_location_into_runfiles(ctx, input, targets = []):
     target = "@%s//%s:%s" % (ctx.workspace_name, "/".join(ctx.build_file_path.split("/")[:-1]), ctx.attr.name)
 
     # Loop through input an expand all predefined source/output path variables
-    # See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_label_variables.
+    # See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_label_variables.
     path = ""
     length = len(input)
     last = 0

--- a/internal/common/expand_variables.bzl
+++ b/internal/common/expand_variables.bzl
@@ -27,8 +27,8 @@ def expand_variables(ctx, s, outs = [], output_dir = False):
       - $(RULEDIR): The output directory of the rule, that is, the directory
         corresponding to the name of the package containing the rule under the bin tree.
 
-    See https://docs.bazel.build/versions/master/be/general.html#genrule.cmd and
-    https://docs.bazel.build/versions/master/be/make-variables.html#predefined_genrule_variables
+    See https://docs.bazel.build/versions/main/be/general.html#genrule.cmd and
+    https://docs.bazel.build/versions/main/be/make-variables.html#predefined_genrule_variables
     for more information of how these special variables are expanded.
     """
     rule_dir = [f for f in [

--- a/internal/common/params_file.bzl
+++ b/internal/common/params_file.bzl
@@ -87,14 +87,14 @@ def params_file(
         out: Path of the output file, relative to this package.
         args: Arguments to concatenate into a params file.
 
-            Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/master/be/make-variables.html.
+            Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/main/be/make-variables.html.
 
             1. Subject to predefined source/output path variables substitutions.
 
             The predefined variables `execpath`, `execpaths`, `rootpath`, `rootpaths`, `location`, and `locations` take
             label parameters (e.g. `$(execpath //foo:bar)`) and substitute the file paths denoted by that label.
 
-            See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_label_variables for more info.
+            See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_label_variables for more info.
 
             NB: This $(location) substition returns the manifest file path which differs from the *_binary & *_test
             args and genrule bazel substitions. This will be fixed in a future major release.
@@ -104,10 +104,10 @@ def params_file(
             2. Subject to predefined variables & custom variable substitutions.
 
             Predefined "Make" variables such as $(COMPILATION_MODE) and $(TARGET_CPU) are expanded.
-            See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_variables.
+            See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_variables.
 
             Custom variables are also expanded including variables set through the Bazel CLI with --define=SOME_VAR=SOME_VALUE.
-            See https://docs.bazel.build/versions/master/be/make-variables.html#custom_variables.
+            See https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables.
 
             Predefined genrule variables are not supported in this context.
 

--- a/internal/js_library/js_library.bzl
+++ b/internal/js_library/js_library.bzl
@@ -345,9 +345,9 @@ def js_library(
     - [JSModuleInfo](#jsmoduleinfo) so rules like bundlers can collect the transitive set of .js files
     - [JSNamedModuleInfo](#jsnamedmoduleinfo) for rules that expect named AMD or `goog.module` format JS
 
-    [OutputGroupInfo]: https://docs.bazel.build/versions/master/skylark/lib/OutputGroupInfo.html
-    [DefaultInfo]: https://docs.bazel.build/versions/master/skylark/lib/DefaultInfo.html
-    [output_group]: https://docs.bazel.build/versions/master/be/general.html#filegroup.output_group
+    [OutputGroupInfo]: https://docs.bazel.build/versions/main/skylark/lib/OutputGroupInfo.html
+    [DefaultInfo]: https://docs.bazel.build/versions/main/skylark/lib/DefaultInfo.html
+    [output_group]: https://docs.bazel.build/versions/main/be/general.html#filegroup.output_group
 
     Args:
         name: The name for the target

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -361,7 +361,7 @@ fi
                         # We need this call to the list of Files.
                         # Calling the .to_list() method may have some perfs hits,
                         # so we should be running this method only once per rule.
-                        # see: https://docs.bazel.build/versions/master/skylark/depsets.html#performance
+                        # see: https://docs.bazel.build/versions/main/skylark/depsets.html#performance
                         node_modules.to_list() + sources.to_list(),
                 collect_data = True,
             ),
@@ -373,7 +373,7 @@ fi
             pkgs = data,
         ),
         # indicates that the this binary should be instrumented by coverage
-        # see https://docs.bazel.build/versions/master/skylark/lib/coverage_common.html
+        # see https://docs.bazel.build/versions/main/skylark/lib/coverage_common.html
         # since this will be called from a nodejs_test, where the entrypoint is going to be the test file
         # we shouldn't add the entrypoint as a attribute to collect here
         coverage_common.instrumented_files_info(ctx, dependency_attributes = ["data"], extensions = ["js", "ts"]),
@@ -497,14 +497,14 @@ If source files need to be required then they can be copied to the bin_dir with 
         To pass a node startup option, prepend it with `--node_options=`, e.g.
         `--node_options=--preserve-symlinks`.
 
-Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/master/be/make-variables.html.
+Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/main/be/make-variables.html.
 
 1. Subject to predefined source/output path variables substitutions.
 
 The predefined variables `execpath`, `execpaths`, `rootpath`, `rootpaths`, `location`, and `locations` take
 label parameters (e.g. `$(execpath //foo:bar)`) and substitute the file paths denoted by that label.
 
-See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_label_variables for more info.
+See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_label_variables for more info.
 
 NB: This $(location) substition returns the manifest file path which differs from the *_binary & *_test
 args and genrule bazel substitions. This will be fixed in a future major release.
@@ -547,7 +547,7 @@ const some_file = runfiles.resolveWorkspaceRelative(args[0]);
 
 NB: Bazel will error if it sees the single dollar sign $(rlocation path) in `templated_args` as it will try to
 expand `$(rlocation)` since we now expand predefined & custom "make" variables such as `$(COMPILATION_MODE)`,
-`$(BINDIR)` & `$(TARGET_CPU)` using `ctx.expand_make_variables`. See https://docs.bazel.build/versions/master/be/make-variables.html.
+`$(BINDIR)` & `$(TARGET_CPU)` using `ctx.expand_make_variables`. See https://docs.bazel.build/versions/main/be/make-variables.html.
 
 To prevent expansion of `$(rlocation)` write it as `$$(rlocation)`. Bazel understands `$$` to be
 the string literal `$` and the expansion results in `$(rlocation)` being passed as an arg instead
@@ -563,10 +563,10 @@ need to update to `$$(rlocation)`. This may be changed in the future.
 2. Subject to predefined variables & custom variable substitutions.
 
 Predefined "Make" variables such as $(COMPILATION_MODE) and $(TARGET_CPU) are expanded.
-See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_variables.
+See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_variables.
 
 Custom variables are also expanded including variables set through the Bazel CLI with --define=SOME_VAR=SOME_VALUE.
-See https://docs.bazel.build/versions/master/be/make-variables.html#custom_variables.
+See https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables.
 
 Predefined genrule variables are not supported in this context.
 """,

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -15,7 +15,7 @@
 """Install NodeJS & Yarn
 
 This is a set of repository rules for setting up hermetic copies of NodeJS and Yarn.
-See https://docs.bazel.build/versions/master/skylark/repository_rules.html
+See https://docs.bazel.build/versions/main/skylark/repository_rules.html
 """
 
 load("//internal/common:check_bazel_version.bzl", "check_bazel_version")

--- a/internal/node/npm_package_bin.bzl
+++ b/internal/node/npm_package_bin.bzl
@@ -121,12 +121,12 @@ def npm_package_bin(
     Use the `chdir` attribute to change the working directory before the program runs.
 
     This is a great candidate to wrap with a macro, as documented:
-    https://docs.bazel.build/versions/master/skylark/macros.html#full-example
+    https://docs.bazel.build/versions/main/skylark/macros.html#full-example
 
     Args:
-        data: similar to [genrule.srcs](https://docs.bazel.build/versions/master/be/general.html#genrule.srcs)
+        data: similar to [genrule.srcs](https://docs.bazel.build/versions/main/be/general.html#genrule.srcs)
               may also include targets that produce or reference npm packages which are needed by the tool
-        outs: similar to [genrule.outs](https://docs.bazel.build/versions/master/be/general.html#genrule.outs)
+        outs: similar to [genrule.outs](https://docs.bazel.build/versions/main/be/general.html#genrule.outs)
         output_dir: set to True if you want the output to be a directory
                  Exactly one of `outs`, `output_dir` may be used.
                  If you output a directory, there can only be one output, which will be a directory named the same as the target.
@@ -140,11 +140,11 @@ def npm_package_bin(
 
         args: Command-line arguments to the tool.
 
-            Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/master/be/make-variables.html.
+            Subject to 'Make variable' substitution. See https://docs.bazel.build/versions/main/be/make-variables.html.
 
             1. Predefined source/output path substitions is applied first:
 
-            See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_label_variables.
+            See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_label_variables.
 
             Use $(execpath) $(execpaths) to expand labels to the execroot (where Bazel runs build actions).
 
@@ -160,7 +160,7 @@ def npm_package_bin(
             2. "Make" variables are expanded second:
 
             Predefined "Make" variables such as $(COMPILATION_MODE) and $(TARGET_CPU) are expanded.
-            See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_variables.
+            See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_variables.
 
             Like genrule, you may also use some syntax sugar for locations.
 
@@ -172,10 +172,10 @@ def npm_package_bin(
             - `$(RULEDIR)`: the root output directory of the rule, corresponding with its package
                 (can be used with output_dir=True or False)
 
-            See https://docs.bazel.build/versions/master/be/make-variables.html#predefined_genrule_variables.
+            See https://docs.bazel.build/versions/main/be/make-variables.html#predefined_genrule_variables.
 
             Custom variables are also expanded including variables set through the Bazel CLI with --define=SOME_VAR=SOME_VALUE.
-            See https://docs.bazel.build/versions/master/be/make-variables.html#custom_variables.
+            See https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables.
 
         package: an npm package whose binary to run, like "terser". Assumes your node_modules are installed in a workspace called "npm"
         package_bin: the "bin" entry from `package` that should be run. By default package_bin is the same string as `package`

--- a/internal/node/require_patch.js
+++ b/internal/node/require_patch.js
@@ -84,7 +84,7 @@ function resolveToModuleRoot(path) {
 
 /**
  * The runfiles manifest maps from short_path
- * https://docs.bazel.build/versions/master/skylark/lib/File.html#short_path
+ * https://docs.bazel.build/versions/main/skylark/lib/File.html#short_path
  * to the actual location on disk where the file can be read.
  *
  * In a sandboxed execution, it does not exist. In that case, runfiles must be

--- a/internal/runfiles/index.js
+++ b/internal/runfiles/index.js
@@ -110,7 +110,7 @@ class Runfiles {
     }
     /**
      * The runfiles manifest maps from short_path
-     * https://docs.bazel.build/versions/master/skylark/lib/File.html#short_path
+     * https://docs.bazel.build/versions/main/skylark/lib/File.html#short_path
      * to the actual location on disk where the file can be read.
      *
      * In a sandboxed execution, it does not exist. In that case, runfiles must be

--- a/packages/create/index.js
+++ b/packages/create/index.js
@@ -36,7 +36,7 @@ function validateWorkspaceName(name, error) {
   It should describe the project in reverse-DNS form, with elements separated by underscores.
   For example, if a project is hosted at example.com/some-project,
   you might use com_example_some_project as the workspace name.
-  From https://docs.bazel.build/versions/master/be/functions.html#workspace`);
+  From https://docs.bazel.build/versions/main/be/functions.html#workspace`);
 
   return false;
 }
@@ -104,7 +104,7 @@ function main(argv, error = console.error, log = console.log) {
     '@bazel/buildifier': 'latest',
   };
   let rootBuildContent = '# Add rules here to build your software\n' +
-      '# See https://docs.bazel.build/versions/master/build-ref.html#BUILD_files\n\n';
+      '# See https://docs.bazel.build/versions/main/build-ref.html#BUILD_files\n\n';
 
   if (args['typescript']) {
     devDependencies['@bazel/typescript'] = 'latest';
@@ -173,7 +173,7 @@ def fetch_dependencies():
   let workspaceContent = `# Bazel workspace created by @bazel/create 0.0.0-PLACEHOLDER
 
 # Declares that this directory is the root of a Bazel workspace.
-# See https://docs.bazel.build/versions/master/build-ref.html#workspace
+# See https://docs.bazel.build/versions/main/build-ref.html#workspace
 workspace(
     # How this workspace would be referenced with absolute labels from another workspace
     name = "${wkspName}",

--- a/packages/cypress/internal/toolchain/cypress_toolchain.bzl
+++ b/packages/cypress/internal/toolchain/cypress_toolchain.bzl
@@ -70,6 +70,6 @@ cypress_toolchain = rule(
     },
     doc = """Defines a cypress toolchain.
 
-For usage see https://docs.bazel.build/versions/master/toolchains.html#defining-toolchains.
+For usage see https://docs.bazel.build/versions/main/toolchains.html#defining-toolchains.
 """,
 )

--- a/packages/jasmine/jasmine_node_test.bzl
+++ b/packages/jasmine/jasmine_node_test.bzl
@@ -75,7 +75,7 @@ def jasmine_node_test(
 
     Detailed XML test results are found in the standard `bazel-testlogs`
     directory. This may be symlinked in your workspace.
-    See https://docs.bazel.build/versions/master/output_directories.html
+    See https://docs.bazel.build/versions/main/output_directories.html
 
     To debug the test, see debugging notes in `nodejs_test`.
 

--- a/packages/jasmine/jasmine_runner.js
+++ b/packages/jasmine/jasmine_runner.js
@@ -31,7 +31,7 @@ const BAZEL_EXIT_TESTS_FAILED = 3;
 const BAZEL_EXIT_NO_TESTS_FOUND = 4;
 
 // Test sharding support
-// See https://docs.bazel.build/versions/master/test-encyclopedia.html#role-of-the-test-runner
+// See https://docs.bazel.build/versions/main/test-encyclopedia.html#role-of-the-test-runner
 const TOTAL_SHARDS = Number(process.env['TEST_TOTAL_SHARDS']);
 const SHARD_INDEX = Number(process.env['TEST_SHARD_INDEX']);
 // Tell Bazel that this test runner supports sharding by updating the last modified date of the

--- a/packages/runfiles/runfiles.ts
+++ b/packages/runfiles/runfiles.ts
@@ -92,7 +92,7 @@ export class Runfiles {
 
   /**
    * The runfiles manifest maps from short_path
-   * https://docs.bazel.build/versions/master/skylark/lib/File.html#short_path
+   * https://docs.bazel.build/versions/main/skylark/lib/File.html#short_path
    * to the actual location on disk where the file can be read.
    *
    * In a sandboxed execution, it does not exist. In that case, runfiles must be

--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -556,7 +556,7 @@ def ts_project_macro(
         supports_workers: Experimental! Use only with caution.
 
             Allows you to enable the Bazel Persistent Workers strategy for this project.
-            See https://docs.bazel.build/versions/master/persistent-workers.html
+            See https://docs.bazel.build/versions/main/persistent-workers.html
 
             This requires that the tsc binary support a `--watch` option.
 

--- a/toolchains/node/node_toolchain.bzl
+++ b/toolchains/node/node_toolchain.bzl
@@ -53,7 +53,7 @@ def _node_toolchain_impl(ctx):
             ),
         ),
         # Make the $(NODE_PATH) variable available in places like genrules.
-        # See https://docs.bazel.build/versions/master/be/make-variables.html#custom_variables
+        # See https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables
         platform_common.TemplateVariableInfo({
             "NODE_PATH": target_tool_path,
         }),
@@ -74,6 +74,6 @@ node_toolchain = rule(
     },
     doc = """Defines a node toolchain.
 
-For usage see https://docs.bazel.build/versions/master/toolchains.html#defining-toolchains.
+For usage see https://docs.bazel.build/versions/main/toolchains.html#defining-toolchains.
 """,
 )


### PR DESCRIPTION
Updates all bazel.build links to point to `main` rather than `master` URL segment