### PR TITLE
Add Cookies to adopters list

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Organizations:
 - [LogiOcean](https://www.logiocean.com)
 - [Spica](https://spicaengine.com)
 - [Domino Data Lab](https://www.dominodatalab.com/)
+- [Cookies](https://cookies.co/)
 
 Not on this list? [Send a PR](https://github.com/bazelbuild/rules_nodejs/edit/stable/README.md) to add your repo or organization!
 


### PR DESCRIPTION
At [Cookies](https://cookies.co) we are very proud to be adopters of `rules_nodejs`. We were recently named one of [America's Hottest Brands of 2021](https://adage.com/HottestBrands2021) and we're excited to brag about how Bazel helped us get there.