### PR TITLE
feat: add package_json_remove and package_json_replace attributes to yarn_install & npm_install

### DIFF
--- a/docs/Built-ins.md
+++ b/docs/Built-ins.md
@@ -726,9 +726,9 @@ Defaults to `[]`
 <pre>
 npm_install(<a href="#npm_install-name">name</a>, <a href="#npm_install-args">args</a>, <a href="#npm_install-data">data</a>, <a href="#npm_install-environment">environment</a>, <a href="#npm_install-exports_directories_only">exports_directories_only</a>,
             <a href="#npm_install-generate_local_modules_build_files">generate_local_modules_build_files</a>, <a href="#npm_install-included_files">included_files</a>, <a href="#npm_install-links">links</a>, <a href="#npm_install-manual_build_file_contents">manual_build_file_contents</a>,
-            <a href="#npm_install-npm_command">npm_command</a>, <a href="#npm_install-package_json">package_json</a>, <a href="#npm_install-package_lock_json">package_lock_json</a>, <a href="#npm_install-package_path">package_path</a>, <a href="#npm_install-patch_args">patch_args</a>, <a href="#npm_install-patch_tool">patch_tool</a>,
-            <a href="#npm_install-post_install_patches">post_install_patches</a>, <a href="#npm_install-pre_install_patches">pre_install_patches</a>, <a href="#npm_install-quiet">quiet</a>, <a href="#npm_install-repo_mapping">repo_mapping</a>, <a href="#npm_install-strict_visibility">strict_visibility</a>,
-            <a href="#npm_install-symlink_node_modules">symlink_node_modules</a>, <a href="#npm_install-timeout">timeout</a>)
+            <a href="#npm_install-npm_command">npm_command</a>, <a href="#npm_install-package_json">package_json</a>, <a href="#npm_install-package_json_remove">package_json_remove</a>, <a href="#npm_install-package_json_replace">package_json_replace</a>, <a href="#npm_install-package_lock_json">package_lock_json</a>,
+            <a href="#npm_install-package_path">package_path</a>, <a href="#npm_install-patch_args">patch_args</a>, <a href="#npm_install-patch_tool">patch_tool</a>, <a href="#npm_install-post_install_patches">post_install_patches</a>, <a href="#npm_install-pre_install_patches">pre_install_patches</a>, <a href="#npm_install-quiet">quiet</a>,
+            <a href="#npm_install-repo_mapping">repo_mapping</a>, <a href="#npm_install-strict_visibility">strict_visibility</a>, <a href="#npm_install-symlink_node_modules">symlink_node_modules</a>, <a href="#npm_install-timeout">timeout</a>)
 </pre>
 
 Runs npm install during workspace setup.
@@ -971,6 +971,52 @@ Defaults to `"ci"`
 
 (*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>, mandatory*)
 
+
+<h4 id="npm_install-package_json_remove">package_json_remove</h4>
+
+(*List of strings*): List of `package.json` keys to remove before running the package manager.
+
+Keys are '.' separated. For example, a key of `dependencies.my-dep` in the list corresponds to the `package.json`
+entry,
+
+```
+{
+    "dependencies": {
+        "my-dep": "..."
+    }
+}
+```
+
+This can be used, for example, during a migration to remove first party file: deps that are required
+for the non-bazel build but should not be installed via the package manager in the bazel build since
+they will be reference as bazel targets instead.
+
+NB: removals specified are performed after preinstall_patches so if you are using both then the patch file should be relative
+to the source `package.json`. Non-existant keys are silently ignored.
+
+Defaults to `[]`
+
+<h4 id="npm_install-package_json_replace">package_json_replace</h4>
+
+(*<a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a>*): Map of `package.json` keys to values to replace or create before running the package mangager.
+
+Keys are '.' separated. For example, a key of `scripts.postinstall` corresponds to the `package.json`
+entry,
+
+```
+{
+    "scripts": {
+        "postinstall": "..."
+    }
+}
+```
+
+This can be used, for example, during a migration to override npm scripts such as preinstall & postinstall.
+
+NB: replaces specified are performed after preinstall_patches so if you are using both then the patch file should be relative
+to the source `package.json`.
+
+Defaults to `{}`
 
 <h4 id="npm_install-package_lock_json">package_lock_json</h4>
 
@@ -1320,9 +1366,9 @@ Defaults to `{}`
 <pre>
 yarn_install(<a href="#yarn_install-name">name</a>, <a href="#yarn_install-args">args</a>, <a href="#yarn_install-data">data</a>, <a href="#yarn_install-environment">environment</a>, <a href="#yarn_install-exports_directories_only">exports_directories_only</a>, <a href="#yarn_install-frozen_lockfile">frozen_lockfile</a>,
              <a href="#yarn_install-generate_local_modules_build_files">generate_local_modules_build_files</a>, <a href="#yarn_install-included_files">included_files</a>, <a href="#yarn_install-links">links</a>, <a href="#yarn_install-manual_build_file_contents">manual_build_file_contents</a>,
-             <a href="#yarn_install-package_json">package_json</a>, <a href="#yarn_install-package_path">package_path</a>, <a href="#yarn_install-patch_args">patch_args</a>, <a href="#yarn_install-patch_tool">patch_tool</a>, <a href="#yarn_install-post_install_patches">post_install_patches</a>,
-             <a href="#yarn_install-pre_install_patches">pre_install_patches</a>, <a href="#yarn_install-quiet">quiet</a>, <a href="#yarn_install-repo_mapping">repo_mapping</a>, <a href="#yarn_install-strict_visibility">strict_visibility</a>, <a href="#yarn_install-symlink_node_modules">symlink_node_modules</a>,
-             <a href="#yarn_install-timeout">timeout</a>, <a href="#yarn_install-use_global_yarn_cache">use_global_yarn_cache</a>, <a href="#yarn_install-yarn_lock">yarn_lock</a>)
+             <a href="#yarn_install-package_json">package_json</a>, <a href="#yarn_install-package_json_remove">package_json_remove</a>, <a href="#yarn_install-package_json_replace">package_json_replace</a>, <a href="#yarn_install-package_path">package_path</a>, <a href="#yarn_install-patch_args">patch_args</a>,
+             <a href="#yarn_install-patch_tool">patch_tool</a>, <a href="#yarn_install-post_install_patches">post_install_patches</a>, <a href="#yarn_install-pre_install_patches">pre_install_patches</a>, <a href="#yarn_install-quiet">quiet</a>, <a href="#yarn_install-repo_mapping">repo_mapping</a>,
+             <a href="#yarn_install-strict_visibility">strict_visibility</a>, <a href="#yarn_install-symlink_node_modules">symlink_node_modules</a>, <a href="#yarn_install-timeout">timeout</a>, <a href="#yarn_install-use_global_yarn_cache">use_global_yarn_cache</a>, <a href="#yarn_install-yarn_lock">yarn_lock</a>)
 </pre>
 
 Runs yarn install during workspace setup.
@@ -1569,6 +1615,52 @@ Defaults to `""`
 
 (*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>, mandatory*)
 
+
+<h4 id="yarn_install-package_json_remove">package_json_remove</h4>
+
+(*List of strings*): List of `package.json` keys to remove before running the package manager.
+
+Keys are '.' separated. For example, a key of `dependencies.my-dep` in the list corresponds to the `package.json`
+entry,
+
+```
+{
+    "dependencies": {
+        "my-dep": "..."
+    }
+}
+```
+
+This can be used, for example, during a migration to remove first party file: deps that are required
+for the non-bazel build but should not be installed via the package manager in the bazel build since
+they will be reference as bazel targets instead.
+
+NB: removals specified are performed after preinstall_patches so if you are using both then the patch file should be relative
+to the source `package.json`. Non-existant keys are silently ignored.
+
+Defaults to `[]`
+
+<h4 id="yarn_install-package_json_replace">package_json_replace</h4>
+
+(*<a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a>*): Map of `package.json` keys to values to replace or create before running the package mangager.
+
+Keys are '.' separated. For example, a key of `scripts.postinstall` corresponds to the `package.json`
+entry,
+
+```
+{
+    "scripts": {
+        "postinstall": "..."
+    }
+}
+```
+
+This can be used, for example, during a migration to override npm scripts such as preinstall & postinstall.
+
+NB: replaces specified are performed after preinstall_patches so if you are using both then the patch file should be relative
+to the source `package.json`.
+
+Defaults to `{}`
 
 <h4 id="yarn_install-package_path">package_path</h4>
 

--- a/examples/angular/WORKSPACE
+++ b/examples/angular/WORKSPACE
@@ -36,12 +36,12 @@ http_archive(
 # Fetch sass rules for compiling sass files
 http_archive(
     name = "io_bazel_rules_sass",
-    sha256 = "5313032124ff191eed68efcfbdc6ee9b5198093b2b80a8e640ea34feabbffc69",
     patch_args = ["-p1"],
     patches = [
         # Updates @bazel/work dep to 4.0.0 inside rules_sass so it is compatible
         "//:io_bazel_rules_sass.patch",
     ],
+    sha256 = "5313032124ff191eed68efcfbdc6ee9b5198093b2b80a8e640ea34feabbffc69",
     strip_prefix = "rules_sass-1.34.0",
     urls = [
         "https://github.com/bazelbuild/rules_sass/archive/1.34.0.zip",

--- a/examples/angular_view_engine/WORKSPACE
+++ b/examples/angular_view_engine/WORKSPACE
@@ -23,12 +23,12 @@ http_archive(
 # Fetch sass rules for compiling sass files
 http_archive(
     name = "io_bazel_rules_sass",
-    sha256 = "5313032124ff191eed68efcfbdc6ee9b5198093b2b80a8e640ea34feabbffc69",
     patch_args = ["-p1"],
     patches = [
         # Updates @bazel/work dep to 4.0.0 inside rules_sass so it is compatible
         "//:io_bazel_rules_sass.patch",
     ],
+    sha256 = "5313032124ff191eed68efcfbdc6ee9b5198093b2b80a8e640ea34feabbffc69",
     strip_prefix = "rules_sass-1.34.0",
     urls = [
         "https://github.com/bazelbuild/rules_sass/archive/1.34.0.zip",

--- a/internal/npm_install/test/patches_npm/BUILD.bazel
+++ b/internal/npm_install/test/patches_npm/BUILD.bazel
@@ -3,6 +3,7 @@ load("//:index.bzl", "nodejs_test")
 nodejs_test(
     name = "test",
     data = [
+        "@internal_npm_install_test_patches_npm//:_/internal/npm_install/test/patches_npm/package.json",
         "@internal_npm_install_test_patches_npm//semver",
     ],
     entry_point = "test.js",

--- a/internal/npm_install/test/patches_npm/package.json
+++ b/internal/npm_install/test/patches_npm/package.json
@@ -1,6 +1,11 @@
 {
+  "version": "0.0.1",
   "dependencies": {
     "__invalid_dependency__": "removed by pre_install_patches",
+    "__other_invalid_dependency__": "removed by package_json_replace",
     "semver": "1.0.0"
+  },
+  "scripts": {
+    "replace_me": "not yet replaced"
   }
 }

--- a/internal/npm_install/test/patches_npm/package_json.patch
+++ b/internal/npm_install/test/patches_npm/package_json.patch
@@ -1,9 +1,10 @@
 --- internal/npm_install/test/patches_npm/package.json
 +++ internal/npm_install/test/patches_npm/package.json
-@@ -1,6 +1,5 @@
+@@ -1,7 +1,6 @@
  {
+   "version": "0.0.1",
    "dependencies": {
 -    "__invalid_dependency__": "removed by pre_install_patches",
+     "__other_invalid_dependency__": "removed by package_json_replace",
      "semver": "1.0.0"
-   }
- }
+   },

--- a/internal/npm_install/test/patches_npm/test.js
+++ b/internal/npm_install/test/patches_npm/test.js
@@ -3,3 +3,22 @@ if (!semver.patched) {
   console.error('Expected semver to be patched');
   process.exitCode = 1;
 }
+
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
+const packageJson = require(runfiles.resolve('internal_npm_install_test_patches_npm/_/internal/npm_install/test/patches_npm/package.json'))
+if (packageJson.dependencies.__other_invalid_dependency__) {
+  console.error('expected package.json __other_invalid_dependency__ to have been removed');
+  process.exitCode = 1;
+}
+if (packageJson.version != '1.0.0') {
+  console.error('expected package.json version to be 1.0.0');
+  process.exitCode = 1;
+}
+if (packageJson.scripts.replace_me != 'replaced') {
+  console.error('expected package.json scripts.replace_me to be replaced');
+  process.exitCode = 1;
+}
+if (packageJson.scripts.new != 'added') {
+  console.error('expected package.json scripts.new to be added');
+  process.exitCode = 1;
+}

--- a/internal/npm_install/test/patches_yarn/BUILD.bazel
+++ b/internal/npm_install/test/patches_yarn/BUILD.bazel
@@ -3,6 +3,7 @@ load("//:index.bzl", "nodejs_test")
 nodejs_test(
     name = "test",
     data = [
+        "@internal_npm_install_test_patches_yarn//:_/internal/npm_install/test/patches_yarn/package.json",
         "@internal_npm_install_test_patches_yarn//semver",
     ],
     entry_point = "test.js",

--- a/internal/npm_install/test/patches_yarn/package.json
+++ b/internal/npm_install/test/patches_yarn/package.json
@@ -1,6 +1,11 @@
 {
+  "version": "0.0.1",
   "dependencies": {
     "__invalid_dependency__": "removed by pre_install_patches",
+    "__other_invalid_dependency__": "removed by package_json_replace",
     "semver": "1.0.0"
+  },
+  "scripts": {
+    "replace_me": "not yet replaced"
   }
 }

--- a/internal/npm_install/test/patches_yarn/package_json.patch
+++ b/internal/npm_install/test/patches_yarn/package_json.patch
@@ -1,9 +1,10 @@
 --- internal/npm_install/test/patches_yarn/package.json
 +++ internal/npm_install/test/patches_yarn/package.json
-@@ -1,6 +1,5 @@
+@@ -1,7 +1,6 @@
  {
+   "version": "0.0.1",
    "dependencies": {
 -    "__invalid_dependency__": "removed by pre_install_patches",
+     "__other_invalid_dependency__": "removed by package_json_replace",
      "semver": "1.0.0"
-   }
- }
+   },

--- a/internal/npm_install/test/patches_yarn/test.js
+++ b/internal/npm_install/test/patches_yarn/test.js
@@ -3,3 +3,22 @@ if (!semver.patched) {
   console.error('Expected semver to be patched');
   process.exitCode = 1;
 }
+
+const runfiles = require(process.env['BAZEL_NODE_RUNFILES_HELPER']);
+const packageJson = require(runfiles.resolve('internal_npm_install_test_patches_yarn/_/internal/npm_install/test/patches_yarn/package.json'))
+if (packageJson.dependencies.__other_invalid_dependency__) {
+  console.error('expected package.json __other_invalid_dependency__ to have been removed');
+  process.exitCode = 1;
+}
+if (packageJson.version != '1.0.0') {
+  console.error('expected package.json version to be 1.0.0');
+  process.exitCode = 1;
+}
+if (packageJson.scripts.replace_me != 'replaced') {
+  console.error('expected package.json scripts.replace_me to be replaced');
+  process.exitCode = 1;
+}
+if (packageJson.scripts.new != 'added') {
+  console.error('expected package.json scripts.new to be added');
+  process.exitCode = 1;
+}

--- a/npm_deps.bzl
+++ b/npm_deps.bzl
@@ -408,9 +408,22 @@ filegroup(
         patch_tool = "patch",
         post_install_patches = ["//internal/npm_install/test/patches_yarn:semver+1.0.0.patch"],
         pre_install_patches = ["//internal/npm_install/test/patches_yarn:package_json.patch"],
+        package_json_remove = [
+            "dependencies.__other_invalid_dependency__",
+            "dependencies.ignored_doesnt_exist",
+        ],
+        package_json_replace = {
+            # modify version
+            "version": "1.0.0",
+            # modify scripts.replace_me
+            "scripts.replace_me": "replaced",
+            # add scripts.new
+            "scripts.new": "added",
+        },
         symlink_node_modules = False,
         yarn_lock = "//internal/npm_install/test/patches_yarn:yarn.lock",
         quiet = False,
+        manual_build_file_contents = """exports_files(["_/internal/npm_install/test/patches_yarn/package.json"])""",
     )
 
     npm_install(
@@ -422,8 +435,21 @@ filegroup(
         patch_tool = "patch",
         post_install_patches = ["//internal/npm_install/test/patches_npm:semver+1.0.0.patch"],
         pre_install_patches = ["//internal/npm_install/test/patches_npm:package_json.patch"],
+        package_json_remove = [
+            "dependencies.__other_invalid_dependency__",
+            "dependencies.ignored_doesnt_exist",
+        ],
+        package_json_replace = {
+            # modify version
+            "version": "1.0.0",
+            # modify scripts.replace_me
+            "scripts.replace_me": "replaced",
+            # add scripts.new
+            "scripts.new": "added",
+        },
         symlink_node_modules = False,
         quiet = False,
+        manual_build_file_contents = """exports_files(["_/internal/npm_install/test/patches_npm/package.json"])""",
     )
 
     yarn_install(


### PR DESCRIPTION
For easier modification of package.json over pre_install_patches.

Targetting 4.x as this uses json.encode & json.decode which is only available in bazel 4.0.0+.

Tests added. Docstrings are:

```
    "package_json_remove": attr.string_list(
        doc = """List of `package.json` keys to remove before running the package manager.

Keys are '.' separated. For example, a key of `dependencies.my-dep` in the list corresponds to the `package.json`
entry,

{
    "dependencies": {
        "my-dep": "..."
    }
}

This can be used, for example, during a migration to remove first party file: deps that are required
for the non-bazel build but should not be installed via the package manager in the bazel build since
they will be reference as bazel targets instead.

NB: removals specified are performed after preinstall_patches so if you are using both then the patch file should be relative
to the source `package.json`. Non-existant keys are silently ignored.""",
    ),
    "package_json_replace": attr.string_dict(
        doc = """Map of `package.json` keys to values to replace or create before running the package mangager.

Keys are '.' separated. For example, a key of `scripts.postinstall` corresponds to the `package.json`
entry,

{
    "scripts": {
        "postinstall": "..."
    }
}

This can be used, for example, during a migration to override npm scripts such as preinstall & postinstall.

NB: replaces specified are performed after preinstall_patches so if you are using both then the patch file should be relative
to the source `package.json`.""",
    ),
```