### PR TITLE
feat: add link_root & source_directories attributes to js_library

### DIFF
--- a/internal/linker/test/integration/BUILD.bazel
+++ b/internal/linker/test/integration/BUILD.bazel
@@ -67,6 +67,7 @@ linked(
         "//internal/linker/test/integration/dynamic_linked_pkg",
         "//internal/linker/test/integration/dynamic_linked_scoped_pkg",
         "@npm//semver",
+        "@npm//semver-alias",
     ],
 )
 
@@ -98,6 +99,7 @@ linked(
         "//internal/linker/test/integration/dynamic_linked_pkg",
         "//internal/linker/test/integration/dynamic_linked_scoped_pkg",
         "@npm//semver",
+        "@npm//semver-alias",
     ],
 )
 
@@ -125,6 +127,7 @@ linked(
         "//internal/linker/test/integration/dynamic_linked_pkg",
         "//internal/linker/test/integration/dynamic_linked_scoped_pkg",
         "@npm//semver",
+        "@npm//semver-alias",
     ],
 )
 

--- a/internal/linker/test/integration/program.js
+++ b/internal/linker/test/integration/program.js
@@ -1,3 +1,5 @@
+const assert = require('assert')
+
 // First-party "static linked" packages
 // they should get resolved through runfiles
 const a = require('static_linked');
@@ -23,7 +25,17 @@ try {
 }
 
 // Third-party package installed in the root node_modules
-const semver = require('semver');
+const semver = require('semver-alias');
+
+const semverVersion = require(require.resolve('semver/package.json')).version;
+assert.ok(
+  semver.gte(semverVersion, '5.0.0'),
+  `expected semverVersion to be the root @npm version >= 5.0.0`)
+
+const semverAliasVersion = require(require.resolve('semver-alias/package.json')).version;
+assert.ok(
+  semver.gte(semverAliasVersion, '5.0.0'),
+  `expected semverAliasVersion to be the root @npm version >= 5.0.0`)
 
 // This output should match what's in the golden.txt file
 console.log(t.addT(e.addE(d.addD(c.addC(b.addB(a.addA(semver.clean(' =v1.2.3 '))))))));

--- a/internal/npm_install/generate_build_file.ts
+++ b/internal/npm_install/generate_build_file.ts
@@ -49,6 +49,7 @@ function log_verbose(...m: any[]) {
 
 const PUBLIC_VISIBILITY = '//visibility:public';
 
+// Special value for package_name to let js_library know this is an external npm package
 let NODE_MODULES_PACKAGE_NAME = '$node_modules$';
 
 // Default values for unit testing; overridden in main()
@@ -114,10 +115,6 @@ function createFileSymlinkSync(target: string, p: string) {
 export function main() {
   config = require('./generate_config.json')
   config.limited_visibility = `@${config.workspace}//:__subpackages__`;
-
-  if (config.exports_directories_only) {
-    NODE_MODULES_PACKAGE_NAME = '$node_modules_dir$';
-  }
 
   // get a set of all the direct dependencies for visibility
   const deps = getDirectDependencySet(config.package_json);
@@ -226,7 +223,9 @@ ${exportsStarlark}])
 js_library(
     name = "node_modules",
     package_name = "${NODE_MODULES_PACKAGE_NAME}",
-    package_path = "${config.package_path}",${pkgFilesStarlark}${depsStarlark}
+    package_path = "${config.package_path}",
+    source_directories = ${config.exports_directories_only ? "True" : "False"},
+    ${pkgFilesStarlark}${depsStarlark}
 )
 
 `
@@ -995,6 +994,7 @@ js_library(
     name = "${pkg._name}",
     package_name = "${NODE_MODULES_PACKAGE_NAME}",
     package_path = "${config.package_path}",
+    source_directories = ${config.exports_directories_only ? "True" : "False"},
     # direct sources listed for strict deps support
     srcs = [":${pkg._name}__files"],
     # nested node_modules for this package plus flattened list of direct and transitive dependencies
@@ -1009,6 +1009,7 @@ js_library(
     name = "${pkg._name}__contents",
     package_name = "${NODE_MODULES_PACKAGE_NAME}",
     package_path = "${config.package_path}",
+    source_directories = ${config.exports_directories_only ? "True" : "False"},
     srcs = [":${pkg._name}__files"],
     visibility = ["//:__subpackages__"],
 )
@@ -1139,6 +1140,7 @@ js_library(
     name = "${pkg._name}",
     package_name = "${NODE_MODULES_PACKAGE_NAME}",
     package_path = "${config.package_path}",
+    source_directories = ${config.exports_directories_only ? "True" : "False"},
     # direct sources listed for strict deps support
     srcs = [":${pkg._name}__files"],
     # nested node_modules for this package plus flattened list of direct and transitive dependencies
@@ -1153,6 +1155,7 @@ js_library(
     name = "${pkg._name}__contents",
     package_name = "${NODE_MODULES_PACKAGE_NAME}",
     package_path = "${config.package_path}",
+    source_directories = ${config.exports_directories_only ? "True" : "False"},
     srcs = [":${pkg._name}__files", ":${pkg._name}__nested_node_modules"],${namedSourcesStarlark}
     visibility = ["//:__subpackages__"],
 )
@@ -1161,7 +1164,9 @@ js_library(
 js_library(
     name = "${pkg._name}__typings",
     package_name = "${NODE_MODULES_PACKAGE_NAME}",
-    package_path = "${config.package_path}",${dtsStarlark}
+    package_path = "${config.package_path}",
+    source_directories = ${config.exports_directories_only ? "True" : "False"},
+    ${dtsStarlark}
 )
 
 `;
@@ -1364,7 +1369,9 @@ function printScope(scope: string, pkgs: Dep[]) {
 js_library(
     name = "${scope}",
     package_name = "${NODE_MODULES_PACKAGE_NAME}",
-    package_path = "${config.package_path}",${pkgFilesStarlark}${depsStarlark}
+    package_path = "${config.package_path}",
+    source_directories = ${config.exports_directories_only ? "True" : "False"},
+    ${pkgFilesStarlark}${depsStarlark}
 )
 
 `;

--- a/internal/npm_install/index.js
+++ b/internal/npm_install/index.js
@@ -51,9 +51,6 @@ function createFileSymlinkSync(target, p) {
 function main() {
     config = require('./generate_config.json');
     config.limited_visibility = `@${config.workspace}//:__subpackages__`;
-    if (config.exports_directories_only) {
-        NODE_MODULES_PACKAGE_NAME = '$node_modules_dir$';
-    }
     const deps = getDirectDependencySet(config.package_json);
     const pkgs = findPackages('node_modules', deps);
     flattenDependencies(pkgs);
@@ -135,7 +132,9 @@ ${exportsStarlark}])
 js_library(
     name = "node_modules",
     package_name = "${NODE_MODULES_PACKAGE_NAME}",
-    package_path = "${config.package_path}",${pkgFilesStarlark}${depsStarlark}
+    package_path = "${config.package_path}",
+    source_directories = ${config.exports_directories_only ? "True" : "False"},
+    ${pkgFilesStarlark}${depsStarlark}
 )
 
 `;
@@ -576,6 +575,7 @@ js_library(
     name = "${pkg._name}",
     package_name = "${NODE_MODULES_PACKAGE_NAME}",
     package_path = "${config.package_path}",
+    source_directories = ${config.exports_directories_only ? "True" : "False"},
     # direct sources listed for strict deps support
     srcs = [":${pkg._name}__files"],
     # nested node_modules for this package plus flattened list of direct and transitive dependencies
@@ -590,6 +590,7 @@ js_library(
     name = "${pkg._name}__contents",
     package_name = "${NODE_MODULES_PACKAGE_NAME}",
     package_path = "${config.package_path}",
+    source_directories = ${config.exports_directories_only ? "True" : "False"},
     srcs = [":${pkg._name}__files"],
     visibility = ["//:__subpackages__"],
 )
@@ -681,6 +682,7 @@ js_library(
     name = "${pkg._name}",
     package_name = "${NODE_MODULES_PACKAGE_NAME}",
     package_path = "${config.package_path}",
+    source_directories = ${config.exports_directories_only ? "True" : "False"},
     # direct sources listed for strict deps support
     srcs = [":${pkg._name}__files"],
     # nested node_modules for this package plus flattened list of direct and transitive dependencies
@@ -695,6 +697,7 @@ js_library(
     name = "${pkg._name}__contents",
     package_name = "${NODE_MODULES_PACKAGE_NAME}",
     package_path = "${config.package_path}",
+    source_directories = ${config.exports_directories_only ? "True" : "False"},
     srcs = [":${pkg._name}__files", ":${pkg._name}__nested_node_modules"],${namedSourcesStarlark}
     visibility = ["//:__subpackages__"],
 )
@@ -703,7 +706,9 @@ js_library(
 js_library(
     name = "${pkg._name}__typings",
     package_name = "${NODE_MODULES_PACKAGE_NAME}",
-    package_path = "${config.package_path}",${dtsStarlark}
+    package_path = "${config.package_path}",
+    source_directories = ${config.exports_directories_only ? "True" : "False"},
+    ${dtsStarlark}
 )
 
 `;
@@ -860,7 +865,9 @@ function printScope(scope, pkgs) {
 js_library(
     name = "${scope}",
     package_name = "${NODE_MODULES_PACKAGE_NAME}",
-    package_path = "${config.package_path}",${pkgFilesStarlark}${depsStarlark}
+    package_path = "${config.package_path}",
+    source_directories = ${config.exports_directories_only ? "True" : "False"},
+    ${pkgFilesStarlark}${depsStarlark}
 )
 
 `;

--- a/internal/npm_install/test/BUILD.bazel
+++ b/internal/npm_install/test/BUILD.bazel
@@ -121,6 +121,7 @@ sh_test(
         "coarse.spec.js",
         "common.spec.js",
         "@fine_grained_deps_%s//:node_modules" % pkgmgr,
+        "@fine_grained_deps_%s//semver-alias" % pkgmgr,
     ],
     tags = ["no-local-jasmine-deps"],
     # TODO: get this test running with just linker: failing under --config=no-runfiles
@@ -155,6 +156,8 @@ sh_test(
         "@fine_grained_deps_%s//local-module" % pkgmgr,
         "@fine_grained_deps_%s//typescript" % pkgmgr,
         "@fine_grained_deps_%s//rxjs" % pkgmgr,
+        "@fine_grained_deps_%s//semver" % pkgmgr,
+        "@fine_grained_deps_%s//semver-alias" % pkgmgr,
         # Note, test-b depends on test-a@0.0.1 which should be
         # layed out at node_modules/test-b/node_modules/test-a
         "@fine_grained_deps_%s//@gregmagolan/test-b" % pkgmgr,

--- a/internal/npm_install/test/common.spec.js
+++ b/internal/npm_install/test/common.spec.js
@@ -19,6 +19,18 @@ describe('dependencies', () => {
     require('local-module');
   });
 
+  it(`should resolve semver`, () => {
+    require('semver');
+    const semverVersion = require(require.resolve('semver/package.json')).version;
+    expect(semverVersion).toBe('5.6.0');
+  });
+
+  it(`should resolve semver-alias`, () => {
+    require('semver-alias');
+    const semverVersion = require(require.resolve('semver-alias/package.json')).version;
+    expect(semverVersion).toBe('5.6.0');
+  });
+
   it(`should resolve rxjs/src/tsconfig.json`, () => {
     // the BUILD.bazel file in rxjs/src should have been
     // deleted by fine grained deps and rxjs/src/tsconfig.json

--- a/internal/npm_install/test/golden/@angular/core/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/@angular/core/BUILD.bazel.golden
@@ -682,6 +682,7 @@ js_library(
     name = "core",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":core__files"],
     deps = [
         "//@angular/core:core__contents",
@@ -694,6 +695,7 @@ js_library(
     name = "core__contents",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":core__files", ":core__nested_node_modules"],
     named_module_srcs = [
         "//:node_modules/@angular/core/bundles/core-testing.umd.js",
@@ -705,6 +707,8 @@ js_library(
     name = "core__typings",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
+    
     srcs = [
         "//:node_modules/@angular/core/core.d.ts",
         "//:node_modules/@angular/core/schematics/migrations/missing-injectable/import_manager.d.ts",

--- a/internal/npm_install/test/golden/@gregmagolan/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/@gregmagolan/BUILD.bazel.golden
@@ -5,6 +5,8 @@ js_library(
     name = "@gregmagolan",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
+    
     srcs = [
         "//@gregmagolan/test-a:test-a__files",
         "//@gregmagolan/test-b:test-b__files",

--- a/internal/npm_install/test/golden/@gregmagolan/test-a/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/@gregmagolan/test-a/BUILD.bazel.golden
@@ -29,6 +29,7 @@ js_library(
     name = "test-a",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":test-a__files"],
     deps = [
         "//@gregmagolan/test-a:test-a__contents",
@@ -38,6 +39,7 @@ js_library(
     name = "test-a__contents",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":test-a__files", ":test-a__nested_node_modules"],
     visibility = ["//:__subpackages__"],
 )
@@ -45,6 +47,8 @@ js_library(
     name = "test-a__typings",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
+    
 )
 load("@build_bazel_rules_nodejs//internal/npm_install:npm_umd_bundle.bzl", "npm_umd_bundle")
 npm_umd_bundle(

--- a/internal/npm_install/test/golden/@gregmagolan/test-b/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/@gregmagolan/test-b/BUILD.bazel.golden
@@ -28,6 +28,7 @@ js_library(
     name = "test-b",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":test-b__files"],
     deps = [
         "//@gregmagolan/test-b:test-b__contents",
@@ -37,6 +38,7 @@ js_library(
     name = "test-b__contents",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":test-b__files", ":test-b__nested_node_modules"],
     visibility = ["//:__subpackages__"],
 )
@@ -44,6 +46,8 @@ js_library(
     name = "test-b__typings",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
+    
 )
 load("@build_bazel_rules_nodejs//internal/npm_install:npm_umd_bundle.bzl", "npm_umd_bundle")
 npm_umd_bundle(

--- a/internal/npm_install/test/golden/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/BUILD.bazel.golden
@@ -4728,6 +4728,8 @@ js_library(
     name = "node_modules",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
+    
     srcs = [
         "//ajv:ajv__files",
         "//balanced-match:balanced-match__files",

--- a/internal/npm_install/test/golden/ajv/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/ajv/BUILD.bazel.golden
@@ -112,6 +112,7 @@ js_library(
     name = "ajv",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":ajv__files"],
     deps = [
         "//ajv:ajv__contents",
@@ -125,6 +126,7 @@ js_library(
     name = "ajv__contents",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":ajv__files", ":ajv__nested_node_modules"],
     visibility = ["//:__subpackages__"],
 )
@@ -132,6 +134,8 @@ js_library(
     name = "ajv__typings",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
+    
     srcs = [
         "//:node_modules/ajv/lib/ajv.d.ts",
     ],

--- a/internal/npm_install/test/golden/jasmine/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/jasmine/BUILD.bazel.golden
@@ -59,6 +59,7 @@ js_library(
     name = "jasmine",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":jasmine__files"],
     deps = [
         "//jasmine:jasmine__contents",
@@ -79,6 +80,7 @@ js_library(
     name = "jasmine__contents",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":jasmine__files", ":jasmine__nested_node_modules"],
     visibility = ["//:__subpackages__"],
 )
@@ -86,6 +88,8 @@ js_library(
     name = "jasmine__typings",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
+    
 )
 load("@build_bazel_rules_nodejs//internal/npm_install:npm_umd_bundle.bzl", "npm_umd_bundle")
 npm_umd_bundle(

--- a/internal/npm_install/test/golden/rxjs/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/rxjs/BUILD.bazel.golden
@@ -3631,6 +3631,7 @@ js_library(
     name = "rxjs",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":rxjs__files"],
     deps = [
         "//rxjs:rxjs__contents",
@@ -3641,6 +3642,7 @@ js_library(
     name = "rxjs__contents",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":rxjs__files", ":rxjs__nested_node_modules"],
     visibility = ["//:__subpackages__"],
 )
@@ -3648,6 +3650,8 @@ js_library(
     name = "rxjs__typings",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
+    
     srcs = [
         "//:node_modules/rxjs/AsyncSubject.d.ts",
         "//:node_modules/rxjs/BehaviorSubject.d.ts",

--- a/internal/npm_install/test/golden/unidiff/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/unidiff/BUILD.bazel.golden
@@ -34,6 +34,7 @@ js_library(
     name = "unidiff",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":unidiff__files"],
     deps = [
         "//unidiff:unidiff__contents",
@@ -44,6 +45,7 @@ js_library(
     name = "unidiff__contents",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":unidiff__files", ":unidiff__nested_node_modules"],
     visibility = ["//:__subpackages__"],
 )
@@ -51,6 +53,8 @@ js_library(
     name = "unidiff__typings",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
+    
 )
 load("@build_bazel_rules_nodejs//internal/npm_install:npm_umd_bundle.bzl", "npm_umd_bundle")
 npm_umd_bundle(

--- a/internal/npm_install/test/golden/zone.js/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden/zone.js/BUILD.bazel.golden
@@ -152,6 +152,7 @@ js_library(
     name = "zone.js",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":zone.js__files"],
     deps = [
         "//zone.js:zone.js__contents",
@@ -161,6 +162,7 @@ js_library(
     name = "zone.js__contents",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
     srcs = [":zone.js__files", ":zone.js__nested_node_modules"],
     visibility = ["//:__subpackages__"],
 )
@@ -168,6 +170,8 @@ js_library(
     name = "zone.js__typings",
     package_name = "$node_modules$",
     package_path = "",
+    source_directories = False,
+    
     srcs = [
         "//:node_modules/zone.js/dist/zone.js.d.ts",
     ],

--- a/internal/npm_install/test/golden_directory_artifacts/@angular/core/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_directory_artifacts/@angular/core/BUILD.bazel.golden
@@ -7,8 +7,9 @@ filegroup(
 )
 js_library(
     name = "core",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":core__files"],
     deps = [
         "//@angular/core:core__contents",
@@ -19,8 +20,9 @@ js_library(
 )
 js_library(
     name = "core__contents",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":core__files"],
     visibility = ["//:__subpackages__"],
 )

--- a/internal/npm_install/test/golden_directory_artifacts/@gregmagolan/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_directory_artifacts/@gregmagolan/BUILD.bazel.golden
@@ -3,8 +3,10 @@ package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
 js_library(
     name = "@gregmagolan",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
+    
     srcs = [
         "//@gregmagolan/test-a:test-a__files",
         "//@gregmagolan/test-b:test-b__files",

--- a/internal/npm_install/test/golden_directory_artifacts/@gregmagolan/test-a/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_directory_artifacts/@gregmagolan/test-a/BUILD.bazel.golden
@@ -7,8 +7,9 @@ filegroup(
 )
 js_library(
     name = "test-a",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":test-a__files"],
     deps = [
         "//@gregmagolan/test-a:test-a__contents",
@@ -16,8 +17,9 @@ js_library(
 )
 js_library(
     name = "test-a__contents",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":test-a__files"],
     visibility = ["//:__subpackages__"],
 )

--- a/internal/npm_install/test/golden_directory_artifacts/@gregmagolan/test-b/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_directory_artifacts/@gregmagolan/test-b/BUILD.bazel.golden
@@ -7,8 +7,9 @@ filegroup(
 )
 js_library(
     name = "test-b",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":test-b__files"],
     deps = [
         "//@gregmagolan/test-b:test-b__contents",
@@ -16,8 +17,9 @@ js_library(
 )
 js_library(
     name = "test-b__contents",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":test-b__files"],
     visibility = ["//:__subpackages__"],
 )

--- a/internal/npm_install/test/golden_directory_artifacts/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_directory_artifacts/BUILD.bazel.golden
@@ -31,8 +31,10 @@ exports_files([
 ])
 js_library(
     name = "node_modules",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
+    
     srcs = [
         "//ajv:ajv__files",
         "//balanced-match:balanced-match__files",

--- a/internal/npm_install/test/golden_directory_artifacts/ajv/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_directory_artifacts/ajv/BUILD.bazel.golden
@@ -7,8 +7,9 @@ filegroup(
 )
 js_library(
     name = "ajv",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":ajv__files"],
     deps = [
         "//ajv:ajv__contents",
@@ -20,8 +21,9 @@ js_library(
 )
 js_library(
     name = "ajv__contents",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":ajv__files"],
     visibility = ["//:__subpackages__"],
 )

--- a/internal/npm_install/test/golden_directory_artifacts/jasmine/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_directory_artifacts/jasmine/BUILD.bazel.golden
@@ -7,8 +7,9 @@ filegroup(
 )
 js_library(
     name = "jasmine",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":jasmine__files"],
     deps = [
         "//jasmine:jasmine__contents",
@@ -27,8 +28,9 @@ js_library(
 )
 js_library(
     name = "jasmine__contents",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":jasmine__files"],
     visibility = ["//:__subpackages__"],
 )

--- a/internal/npm_install/test/golden_directory_artifacts/rxjs/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_directory_artifacts/rxjs/BUILD.bazel.golden
@@ -7,8 +7,9 @@ filegroup(
 )
 js_library(
     name = "rxjs",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":rxjs__files"],
     deps = [
         "//rxjs:rxjs__contents",
@@ -17,8 +18,9 @@ js_library(
 )
 js_library(
     name = "rxjs__contents",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":rxjs__files"],
     visibility = ["//:__subpackages__"],
 )

--- a/internal/npm_install/test/golden_directory_artifacts/unidiff/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_directory_artifacts/unidiff/BUILD.bazel.golden
@@ -7,8 +7,9 @@ filegroup(
 )
 js_library(
     name = "unidiff",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":unidiff__files"],
     deps = [
         "//unidiff:unidiff__contents",
@@ -17,8 +18,9 @@ js_library(
 )
 js_library(
     name = "unidiff__contents",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":unidiff__files"],
     visibility = ["//:__subpackages__"],
 )

--- a/internal/npm_install/test/golden_directory_artifacts/zone.js/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_directory_artifacts/zone.js/BUILD.bazel.golden
@@ -7,8 +7,9 @@ filegroup(
 )
 js_library(
     name = "zone.js",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":zone.js__files"],
     deps = [
         "//zone.js:zone.js__contents",
@@ -16,8 +17,9 @@ js_library(
 )
 js_library(
     name = "zone.js__contents",
-    package_name = "$node_modules_dir$",
+    package_name = "$node_modules$",
     package_path = "",
+    source_directories = True,
     srcs = [":zone.js__files"],
     visibility = ["//:__subpackages__"],
 )

--- a/internal/npm_install/test/golden_multi_linked/@angular/core/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_multi_linked/@angular/core/BUILD.bazel.golden
@@ -682,6 +682,7 @@ js_library(
     name = "core",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":core__files"],
     deps = [
         "//@angular/core:core__contents",
@@ -694,6 +695,7 @@ js_library(
     name = "core__contents",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":core__files", ":core__nested_node_modules"],
     named_module_srcs = [
         "//:node_modules/@angular/core/bundles/core-testing.umd.js",
@@ -705,6 +707,8 @@ js_library(
     name = "core__typings",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
+    
     srcs = [
         "//:node_modules/@angular/core/core.d.ts",
         "//:node_modules/@angular/core/schematics/migrations/missing-injectable/import_manager.d.ts",

--- a/internal/npm_install/test/golden_multi_linked/@gregmagolan/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_multi_linked/@gregmagolan/BUILD.bazel.golden
@@ -5,6 +5,8 @@ js_library(
     name = "@gregmagolan",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
+    
     srcs = [
         "//@gregmagolan/test-a:test-a__files",
         "//@gregmagolan/test-b:test-b__files",

--- a/internal/npm_install/test/golden_multi_linked/@gregmagolan/test-a/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_multi_linked/@gregmagolan/test-a/BUILD.bazel.golden
@@ -29,6 +29,7 @@ js_library(
     name = "test-a",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":test-a__files"],
     deps = [
         "//@gregmagolan/test-a:test-a__contents",
@@ -38,6 +39,7 @@ js_library(
     name = "test-a__contents",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":test-a__files", ":test-a__nested_node_modules"],
     visibility = ["//:__subpackages__"],
 )
@@ -45,6 +47,8 @@ js_library(
     name = "test-a__typings",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
+    
 )
 load("@build_bazel_rules_nodejs//internal/npm_install:npm_umd_bundle.bzl", "npm_umd_bundle")
 npm_umd_bundle(

--- a/internal/npm_install/test/golden_multi_linked/@gregmagolan/test-b/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_multi_linked/@gregmagolan/test-b/BUILD.bazel.golden
@@ -28,6 +28,7 @@ js_library(
     name = "test-b",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":test-b__files"],
     deps = [
         "//@gregmagolan/test-b:test-b__contents",
@@ -37,6 +38,7 @@ js_library(
     name = "test-b__contents",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":test-b__files", ":test-b__nested_node_modules"],
     visibility = ["//:__subpackages__"],
 )
@@ -44,6 +46,8 @@ js_library(
     name = "test-b__typings",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
+    
 )
 load("@build_bazel_rules_nodejs//internal/npm_install:npm_umd_bundle.bzl", "npm_umd_bundle")
 npm_umd_bundle(

--- a/internal/npm_install/test/golden_multi_linked/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_multi_linked/BUILD.bazel.golden
@@ -4728,6 +4728,8 @@ js_library(
     name = "node_modules",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
+    
     srcs = [
         "//ajv:ajv__files",
         "//balanced-match:balanced-match__files",

--- a/internal/npm_install/test/golden_multi_linked/ajv/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_multi_linked/ajv/BUILD.bazel.golden
@@ -112,6 +112,7 @@ js_library(
     name = "ajv",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":ajv__files"],
     deps = [
         "//ajv:ajv__contents",
@@ -125,6 +126,7 @@ js_library(
     name = "ajv__contents",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":ajv__files", ":ajv__nested_node_modules"],
     visibility = ["//:__subpackages__"],
 )
@@ -132,6 +134,8 @@ js_library(
     name = "ajv__typings",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
+    
     srcs = [
         "//:node_modules/ajv/lib/ajv.d.ts",
     ],

--- a/internal/npm_install/test/golden_multi_linked/jasmine/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_multi_linked/jasmine/BUILD.bazel.golden
@@ -59,6 +59,7 @@ js_library(
     name = "jasmine",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":jasmine__files"],
     deps = [
         "//jasmine:jasmine__contents",
@@ -79,6 +80,7 @@ js_library(
     name = "jasmine__contents",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":jasmine__files", ":jasmine__nested_node_modules"],
     visibility = ["//:__subpackages__"],
 )
@@ -86,6 +88,8 @@ js_library(
     name = "jasmine__typings",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
+    
 )
 load("@build_bazel_rules_nodejs//internal/npm_install:npm_umd_bundle.bzl", "npm_umd_bundle")
 npm_umd_bundle(

--- a/internal/npm_install/test/golden_multi_linked/rxjs/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_multi_linked/rxjs/BUILD.bazel.golden
@@ -3631,6 +3631,7 @@ js_library(
     name = "rxjs",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":rxjs__files"],
     deps = [
         "//rxjs:rxjs__contents",
@@ -3641,6 +3642,7 @@ js_library(
     name = "rxjs__contents",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":rxjs__files", ":rxjs__nested_node_modules"],
     visibility = ["//:__subpackages__"],
 )
@@ -3648,6 +3650,8 @@ js_library(
     name = "rxjs__typings",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
+    
     srcs = [
         "//:node_modules/rxjs/AsyncSubject.d.ts",
         "//:node_modules/rxjs/BehaviorSubject.d.ts",

--- a/internal/npm_install/test/golden_multi_linked/unidiff/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_multi_linked/unidiff/BUILD.bazel.golden
@@ -34,6 +34,7 @@ js_library(
     name = "unidiff",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":unidiff__files"],
     deps = [
         "//unidiff:unidiff__contents",
@@ -44,6 +45,7 @@ js_library(
     name = "unidiff__contents",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":unidiff__files", ":unidiff__nested_node_modules"],
     visibility = ["//:__subpackages__"],
 )
@@ -51,6 +53,8 @@ js_library(
     name = "unidiff__typings",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
+    
 )
 load("@build_bazel_rules_nodejs//internal/npm_install:npm_umd_bundle.bzl", "npm_umd_bundle")
 npm_umd_bundle(

--- a/internal/npm_install/test/golden_multi_linked/zone.js/BUILD.bazel.golden
+++ b/internal/npm_install/test/golden_multi_linked/zone.js/BUILD.bazel.golden
@@ -152,6 +152,7 @@ js_library(
     name = "zone.js",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":zone.js__files"],
     deps = [
         "//zone.js:zone.js__contents",
@@ -161,6 +162,7 @@ js_library(
     name = "zone.js__contents",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
     srcs = [":zone.js__files", ":zone.js__nested_node_modules"],
     visibility = ["//:__subpackages__"],
 )
@@ -168,6 +170,8 @@ js_library(
     name = "zone.js__typings",
     package_name = "$node_modules$",
     package_path = "tools/fine_grained_goldens",
+    source_directories = False,
+    
     srcs = [
         "//:node_modules/zone.js/dist/zone.js.d.ts",
     ],

--- a/npm_deps.bzl
+++ b/npm_deps.bzl
@@ -44,9 +44,24 @@ def npm_deps():
             "@test_multi_linker/lib-c2": "@build_bazel_rules_nodejs//internal/linker/test/multi_linker/lib_c",
             "@test_multi_linker/lib-d": "@build_bazel_rules_nodejs//internal/linker/test/multi_linker/lib_d",
             "@test_multi_linker/lib-d2": "@build_bazel_rules_nodejs//internal/linker/test/multi_linker/lib_d",
+            "semver-alias": "@npm//:semver-alias",
         },
         package_json = "//:package.json",
         yarn_lock = "//:yarn.lock",
+        manual_build_file_contents = """
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+js_library(
+    name = "semver-alias",
+    package_name = "semver-alias",
+    srcs = [
+        "node_modules/semver/package.json",
+        "node_modules/semver/semver.js",
+        "node_modules/semver/bin/semver",
+    ],
+    link_root = "node_modules/semver",
+    visibility = ["//semver-alias:__pkg__"],
+)
+""",
     )
 
     yarn_install(
@@ -88,11 +103,23 @@ def npm_deps():
             "@test_multi_linker/lib-c2": "@build_bazel_rules_nodejs//internal/linker/test/multi_linker/lib_c",
             "@test_multi_linker/lib-d": "@build_bazel_rules_nodejs//internal/linker/test/multi_linker/lib_d",
             "@test_multi_linker/lib-d2": "@build_bazel_rules_nodejs//internal/linker/test/multi_linker/lib_d",
+            "semver-alias": "@npm_directory_artifacts//:semver-alias",
         },
         symlink_node_modules = False,
         exports_directories_only = True,
         package_json = "//:package.json",
         yarn_lock = "//:yarn.lock",
+        manual_build_file_contents = """
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+js_library(
+    name = "semver-alias",
+    package_name = "semver-alias",
+    srcs = ["node_modules/semver"],
+    link_root = "node_modules/semver",
+    visibility = ["//semver-alias:__pkg__"],
+    source_directories = True,
+)
+""",
     )
 
     yarn_install(
@@ -244,6 +271,23 @@ def npm_deps():
         package_json = "//:tools/fine_grained_deps_yarn/package.json",
         symlink_node_modules = False,
         yarn_lock = "//:tools/fine_grained_deps_yarn/yarn.lock",
+        links = {
+            "semver-alias": "@fine_grained_deps_yarn//:semver-alias",
+        },
+        manual_build_file_contents = """
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+js_library(
+    name = "semver-alias",
+    package_name = "semver-alias",
+    srcs = [
+        "node_modules/semver/package.json",
+        "node_modules/semver/semver.js",
+        "node_modules/semver/bin/semver",
+    ],
+    link_root = "node_modules/semver",
+    visibility = ["//semver-alias:__pkg__"],
+)
+""",
     )
 
     npm_install(
@@ -269,6 +313,23 @@ def npm_deps():
         package_json = "//:tools/fine_grained_deps_npm/package.json",
         package_lock_json = "//:tools/fine_grained_deps_npm/package-lock.json",
         symlink_node_modules = False,
+        links = {
+            "semver-alias": "@fine_grained_deps_npm//:semver-alias",
+        },
+        manual_build_file_contents = """
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+js_library(
+    name = "semver-alias",
+    package_name = "semver-alias",
+    srcs = [
+        "node_modules/semver/package.json",
+        "node_modules/semver/semver.js",
+        "node_modules/semver/bin/semver",
+    ],
+    link_root = "node_modules/semver",
+    visibility = ["//semver-alias:__pkg__"],
+)
+""",
     )
 
     yarn_install(
@@ -285,6 +346,20 @@ def npm_deps():
         package_json = "//:tools/fine_grained_deps_yarn/package.json",
         symlink_node_modules = False,
         yarn_lock = "//:tools/fine_grained_deps_yarn/yarn.lock",
+        links = {
+            "semver-alias": "@fine_grained_deps_yarn_directory_artifacts//:semver-alias",
+        },
+        manual_build_file_contents = """
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+js_library(
+    name = "semver-alias",
+    package_name = "semver-alias",
+    srcs = ["node_modules/semver"],
+    link_root = "node_modules/semver",
+    visibility = ["//semver-alias:__pkg__"],
+    source_directories = True,
+)
+""",
     )
 
     npm_install(
@@ -302,6 +377,20 @@ def npm_deps():
         package_json = "//:tools/fine_grained_deps_npm/package.json",
         package_lock_json = "//:tools/fine_grained_deps_npm/package-lock.json",
         symlink_node_modules = False,
+        links = {
+            "semver-alias": "@fine_grained_deps_npm_directory_artifacts//:semver-alias",
+        },
+        manual_build_file_contents = """
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+js_library(
+    name = "semver-alias",
+    package_name = "semver-alias",
+    srcs = ["node_modules/semver"],
+    link_root = "node_modules/semver",
+    visibility = ["//semver-alias:__pkg__"],
+    source_directories = True,
+)
+""",
     )
 
     yarn_install(

--- a/tools/fine_grained_deps_npm/package-lock.json
+++ b/tools/fine_grained_deps_npm/package-lock.json
@@ -1617,6 +1617,11 @@
         "ret": "~0.1.10"
       }
     },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+    },
     "set-value": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",

--- a/tools/fine_grained_deps_npm/package.json
+++ b/tools/fine_grained_deps_npm/package.json
@@ -13,7 +13,8 @@
     "http-server": "github:alexeagle/http-server#97205e945b69091606ed83aa0c8489e9ce65d282",
     "klaw": "1.3.1",
     "local-module": "file:../../tools/npm_packages/local_module/npm",
-    "rxjs": "6.5.0"
+    "rxjs": "6.5.0",
+    "semver": "5.6.0"
   },
   "scripts": {
     "postinstall": "node ../../internal/npm_install/test/postinstall.js"

--- a/tools/fine_grained_deps_yarn/package.json
+++ b/tools/fine_grained_deps_yarn/package.json
@@ -13,7 +13,8 @@
     "http-server": "github:alexeagle/http-server#97205e945b69091606ed83aa0c8489e9ce65d282",
     "klaw": "1.3.1",
     "local-module": "link:../../tools/npm_packages/local_module/yarn",
-    "rxjs": "6.5.0"
+    "rxjs": "6.5.0",
+    "semver": "5.6.0"
   },
   "scripts": {
     "postinstall": "node ../../internal/npm_install/test/postinstall.js"

--- a/tools/fine_grained_deps_yarn/yarn.lock
+++ b/tools/fine_grained_deps_yarn/yarn.lock
@@ -1154,6 +1154,11 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
+semver@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
 semver@^5.3.0:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"

--- a/tools/npm_packages/local_module/npm/BUILD.bazel
+++ b/tools/npm_packages/local_module/npm/BUILD.bazel
@@ -14,6 +14,7 @@ filegroup(
 
 js_library(
     name = "local-module",
+    package_name = "$node_modules$",
     srcs = [":local-module__files"],
     deps = [
         ":local-module__contents",
@@ -22,6 +23,7 @@ js_library(
 
 js_library(
     name = "local-module__contents",
+    package_name = "$node_modules$",
     srcs = [
         ":local-module__files",
         ":local-module__nested_node_modules",

--- a/tools/npm_packages/local_module/yarn/BUILD.bazel
+++ b/tools/npm_packages/local_module/yarn/BUILD.bazel
@@ -14,6 +14,7 @@ filegroup(
 
 js_library(
     name = "local-module",
+    package_name = "$node_modules$",
     srcs = [":local-module__files"],
     deps = [
         ":local-module__contents",
@@ -22,6 +23,7 @@ js_library(
 
 js_library(
     name = "local-module__contents",
+    package_name = "$node_modules$",
     srcs = [
         ":local-module__files",
         ":local-module__nested_node_modules",


### PR DESCRIPTION
`link_root`: 
```
Path to link to from the root of the workspace.
        
If unset, the target's package name is used.
```

`source_directories`:
```
A hint that srcs have directories since this cannot be detected in the rule context.

If True, all srcs and deps should be source files so that the linker can link to the source tree.

When set, DeclarationInfo is always exported since we can't scan into directory sources for file extensions. In the future,
if we can detect that a source is a directory this can be removed.
```

These two attributes allow for more control over js_library targets including the ability to make an an npm package alias to a 3rd party npm package with exports_directories_only True or False with a `js_library` in `npm_install` or `yarn_install` `manual_build_file_contents`. See `npm_deps.bzl` for examples,

```
        links = {
            "semver-alias": "@fine_grained_deps_yarn//:semver-alias",
        },
        manual_build_file_contents = """
load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
js_library(
    name = "semver-alias",
    package_name = "semver-alias",
    srcs = [
        "node_modules/semver/package.json",
        "node_modules/semver/semver.js",
        "node_modules/semver/bin/semver",
    ],
    link_root = "node_modules/semver",
    visibility = ["//semver-alias:__pkg__"],
)
""",
```

```
        links = {
            "semver-alias": "@fine_grained_deps_yarn_directory_artifacts//:semver-alias",
        },
        manual_build_file_contents = """
load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
js_library(
    name = "semver-alias",
    package_name = "semver-alias",
    srcs = ["node_modules/semver"],
    link_root = "node_modules/semver",
    visibility = ["//semver-alias:__pkg__"],
    source_directories = True,
)
""",
```



and other fixes...

- `$node_modules_dir$` removed in favor of using `source_directories = True`
- if `source_directories = True` then `js_library` will like to sources (same as it does when `$node_modules$` is set)
- if `source_directories = True` or output directories detected then `js_library` will provide a `DeclarationInfo` (since we can't detect if there are .d.ts files within in directory) so it can be used as a dep to `ts_project`
- fix to `strip_prefix` contained files check to allow `strip_prefix` to work for `js_library` targets in external repositories