### PR TITLE
Don't use false as a no-error value

### DIFF
--- a/internal/node/node_patches.js
+++ b/internal/node/node_patches.js
@@ -102,7 +102,7 @@ const patcher = (fs = fs__default['default'], roots) => {
                 return origReadlink(args[0], (err, str) => {
                     if (err) {
                         if (err.code === 'ENOENT') {
-                            return cb(false, stats);
+                            return cb(null, stats);
                         }
                         else if (err.code === 'EINVAL') {
                             // readlink only returns einval when the target is not a link.
@@ -128,7 +128,7 @@ const patcher = (fs = fs__default['default'], roots) => {
                         });
                     }
                     // its a symlink and its inside of the root.
-                    cb(false, stats);
+                    cb(null, stats);
                 });
             };
         }
@@ -143,10 +143,10 @@ const patcher = (fs = fs__default['default'], roots) => {
                 if (err)
                     return cb(err);
                 if (isEscape(str, args[0])) {
-                    cb(false, path__default['default'].resolve(args[0]));
+                    cb(null, path__default['default'].resolve(args[0]));
                 }
                 else {
-                    cb(false, str);
+                    cb(null, str);
                 }
             };
         }
@@ -161,10 +161,10 @@ const patcher = (fs = fs__default['default'], roots) => {
                     if (err)
                         return cb(err);
                     if (isEscape(str, args[0])) {
-                        cb(false, path__default['default'].resolve(args[0]));
+                        cb(null, path__default['default'].resolve(args[0]));
                     }
                     else {
-                        cb(false, str);
+                        cb(null, str);
                     }
                 };
             }
@@ -188,7 +188,7 @@ const patcher = (fs = fs__default['default'], roots) => {
                     // if its not supposed to be a link we have to trigger an EINVAL error.
                     return cb(e);
                 }
-                cb(false, str);
+                cb(null, str);
             };
         }
         origReadlink(...args);

--- a/packages/node-patches/src/fs.ts
+++ b/packages/node-patches/src/fs.ts
@@ -79,7 +79,7 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
         return origReadlink(args[0], (err: Error&{code: string}, str: string) => {
           if (err) {
             if (err.code === 'ENOENT') {
-              return cb(false, stats);
+              return cb(null, stats);
             } else if (err.code === 'EINVAL') {
               // readlink only returns einval when the target is not a link.
               // so if we found a link and it's no longer a link someone raced file system
@@ -105,7 +105,7 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
             });
           }
           // its a symlink and its inside of the root.
-          cb(false, stats);
+          cb(null, stats);
         });
       };
     }
@@ -120,9 +120,9 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
       args[args.length - 1] = (err: Error, str: string) => {
         if (err) return cb(err);
         if (isEscape(str, args[0])) {
-          cb(false, path.resolve(args[0]));
+          cb(null, path.resolve(args[0]));
         } else {
-          cb(false, str);
+          cb(null, str);
         }
       };
     }
@@ -137,9 +137,9 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
           args[args.length - 1] = (err: Error, str: string) => {
             if (err) return cb(err);
             if (isEscape(str, args[0])) {
-              cb(false, path.resolve(args[0]));
+              cb(null, path.resolve(args[0]));
             } else {
-              cb(false, str);
+              cb(null, str);
             }
           };
         }
@@ -164,7 +164,7 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
               // if its not supposed to be a link we have to trigger an EINVAL error.
               return cb(e);
             }
-            cb(false, str);
+            cb(null, str);
           };
         }
         origReadlink(...args);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Use `null` as the non-error value for the wrapped callbacks instead of `false`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The convention is to use `null` when calling back with no error, and
this convention is being enforced in `universalify` since
version 2.0.0.

`fs-extras` uses `universalify` to build `Promises` from the callbacks,
and the wrapper in `node_patches.js` breaks this integration.

