### PR TITLE
fix(builtin): correctly calculate pkg._directDependency when a mapped node_module is used

### DIFF
--- a/internal/npm_install/generate_build_file.ts
+++ b/internal/npm_install/generate_build_file.ts
@@ -661,7 +661,7 @@ export function parsePackage(p: string, dependencies: Set<string> = new Set()): 
 
   // set if this is a direct dependency of the root package.json file
   // which is later used to determine the generated rules visibility
-  pkg._directDependency = dependencies.has(pkg._moduleName) || dependencies.has(pkg._name);
+  pkg._directDependency = dependencies.has(pkg._moduleName) || dependencies.has(pkg._name) || dependencies.has(pkg._dir);
 
   return pkg;
 }

--- a/internal/npm_install/index.js
+++ b/internal/npm_install/index.js
@@ -387,7 +387,7 @@ function parsePackage(p, dependencies = new Set()) {
     pkg._files = listFiles(p);
     pkg._runfiles = pkg._files.filter((f) => !/[^\x21-\x7E]/.test(f));
     pkg._dependencies = [];
-    pkg._directDependency = dependencies.has(pkg._moduleName) || dependencies.has(pkg._name);
+    pkg._directDependency = dependencies.has(pkg._moduleName) || dependencies.has(pkg._name) || dependencies.has(pkg._dir);
     return pkg;
 }
 exports.parsePackage = parsePackage;


### PR DESCRIPTION
In a `package.json` we can declare something close to a mapped package like `"x": "npm:x-canary@^2.0.0-canary.14",` which will actually create `node_modules/x` but the node_module pkg name will be `x-canary`. Due to the latter, the current logic will not consider the pkg to be a `direct dependency` and as such will mark its visibility as being restricted when `strict_visibilty = True` is set. 

That PR also marks a given pkg as a `direct dependency` if the `pkg._dir` could be found listed as a dependency in the `package.json`

