### PR TITLE
chore: remove version checking from @bazel/worker

### DIFF
--- a/packages/worker/BUILD.bazel
+++ b/packages/worker/BUILD.bazel
@@ -45,12 +45,6 @@ copy_file(
     out = "%s/worker_protocol.proto" % _worker_proto_dir,
 )
 
-copy_file(
-    name = "npm_version_check",
-    src = "//internal:npm_version_check.js",
-    out = ":npm_version_check.js",
-)
-
 pkg_npm(
     name = "npm_package",
     srcs = [
@@ -70,6 +64,5 @@ pkg_npm(
         ":copy_worker_dts",
         ":copy_worker_js",
         ":copy_worker_proto",
-        ":npm_version_check",
     ],
 )

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -16,8 +16,5 @@
     },
     "keywords": [
         "bazel"
-    ],
-    "scripts": {
-      "postinstall": "node npm_version_check.js"
-    }
+    ]
 }


### PR DESCRIPTION
This package is meant to be a utility required by code outside our repo, on its own release cadence.
For example, rules_sass has a sass worker program that depends on @bazel/worker.

This means that new major releases of rules_nodejs will likely be used with an older version of @bazel/worker.
We intend for the worker package to be quite stable across releases, so the check for matching major versions just makes upgrades very difficult, with no benefit.

Fixes #2807
