### PR TITLE
build: disable the angular architect example on Ubuntu

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -110,7 +110,7 @@ tasks:
     # We control Bazel version in integration tests, so we don't need USE_BAZEL_VERSION for tests.
     skip_use_bazel_version_for_test: true
     test_flags:
-    - "--test_tag_filters=examples,-cypress"
+    - "--test_tag_filters=examples,-cypress,-no-bazelci-ubuntu"
     - "--local_ram_resources=792"
     # test_args will be passed to the nested bazel process
     - "--test_arg=--local_ram_resources=13288"

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -275,6 +275,10 @@ example_integration_test(
         "test ...",
     ],
     owners = ["@alan-agius4"],
+    tags = [
+        # TODO(mattem): This example timesout each time on Ubuntu
+        "no-bazelci-ubuntu",
+    ],
 )
 
 example_integration_test(


### PR DESCRIPTION
Not sure what introduced the slowness, and it's reasonable when run locally, not sure what's going on here.

This is the first build where it went slow and red, but the commit is unrelated
https://buildkite.com/bazel/rules-nodejs-nodejs/builds/10103