### PR TITLE
fix: update Skylib hash

### DIFF
--- a/packages/create/index.js
+++ b/packages/create/index.js
@@ -159,16 +159,6 @@ def fetch_dependencies():
         name = "build_bazel_rules_nodejs",
         sha256 = "275744d287af4c3a78d7c9891f2d970b7bc7eca8cfc0e9a671fe6258d09ff217",
         urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.0.0-rc.1/rules_nodejs-4.0.0-rc.1.tar.gz"],
-    )
-
-    # rules_nodejs doesn't depend on skylib, but it's a useful dependency anyway.
-    http_archive(
-        name = "bazel_skylib",
-        urls = [
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-        ],
-        sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
     )`
   let workspaceContent = `# Bazel workspace created by @bazel/create 0.0.0-PLACEHOLDER
 

--- a/packages/create/index.js
+++ b/packages/create/index.js
@@ -168,7 +168,7 @@ def fetch_dependencies():
             "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
         ],
-        sha256 = "275744d287af4c3a78d7c9891f2d970b7bc7eca8cfc0e9a671fe6258d09ff217",
+        sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
     )`
   let workspaceContent = `# Bazel workspace created by @bazel/create 0.0.0-PLACEHOLDER
 


### PR DESCRIPTION
Skylib appears to be using the same hash as `rules_nodejs`, which definitely isn't right. Updated to use the hash referenced in [Skylib's 1.0.3 release notes](https://github.com/bazelbuild/bazel-skylib/releases/tag/1.0.3).

Without this change, Skylib is not usable when creating a new project.

```
dparker@Gryphon (~/Source)
[21-08-21 19:57:06]$ npx @bazel/create@4.0.0-rc.1 skylib_test
npx: installed 2 in 1.448s
Creating Bazel workspace skylib_test...
Successfully created new Bazel workspace at /home/dparker/Source/skylib_test
Next steps:
  1. cd skylib_test
  2. npm install
  3. npm run build
     Note that there is nothing to build, so this trivially succeeds.
  4. Add contents to the BUILD.bazel file or create a new BUILD.bazel in a subdirectory.

dparker@Gryphon (~/Source)
[21-08-21 20:05:53]$ cd skylib_test
dparker@Gryphon (~/Source/skylib_test)
[21-08-21 20:06:00]$ npm install
npm notice created a lockfile as package-lock.json. You should commit this file.
added 3 packages from 22 contributors and audited 3 packages in 1.603s
found 0 vulnerabilities

dparker@Gryphon (~/Source/skylib_test)
[21-08-21 20:06:04]$ bazel test //...
Starting local Bazel server and connecting to it...
INFO: Invocation ID: f88f4386-aa70-4e02-a59a-f26f4ad63613
INFO: Analyzed 0 targets (2 packages loaded, 0 targets configured).
INFO: Found 0 test targets...
INFO: Elapsed time: 2.585s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
dparker@Gryphon (~/Source/skylib_test)
[21-08-21 20:06:09]$ bazel query @bazel_skylib//...
ERROR: error loading package '@bazel_skylib//internal/common': in /home/dparker/.cache/bazel/_bazel_dparker/d97d4b7d58dec10e441bd910061abff9/external/bazel_skylib/internal/common/check_version_test.bzl: Label '@bazel_skylib//lib:unittest.bzl' is invalid because 'lib' is not a package; perhaps you meant to put the colon here: '@bazel_skylib//:lib/unittest.bzl'?
Loading: 7 packages loaded
    currently loading: @bazel_skylib// ... (14 packages)
```

I would guess this is confusing Bazel into using the `rules_nodejs` package for Skylib, but that doesn't seem to be the case. It seems to somehow use an older version of Skylib, and I don't fully understand why that would happen.

Updating the hash to `1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c` in `tools/bazel_deps.bzl` fixes the error:

```
$ bazel query @bazel_skylib//...
@bazel_skylib//toolchains/unittest:cmd_toolchain
@bazel_skylib//toolchains/unittest:cmd
@bazel_skylib//toolchains/unittest:bash_toolchain
@bazel_skylib//toolchains/unittest:toolchain_type
@bazel_skylib//toolchains/unittest:bash
@bazel_skylib//rules/private:maprule_util
# snip...
```

I also noticed that this hash was updated in the [release commit for `4.0.0-rc.1`](https://github.com/bazelbuild/rules_nodejs/commit/44b32d527d48d41bd5260699a864b717f0fcb30d), so there may be an issue with release tooling which is updating the wrong hash? I'm not sure if that is just doing "replace old `rules_nodejs` hash with new hash", which would be fixed by this PR, or if it is doing something else which causes it to change the wrong value.

[Skylib's release notes](https://github.com/bazelbuild/bazel-skylib/releases/tag/1.0.3) also say that you should include:

```starlark
load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
bazel_skylib_workspace()
```

Though this doesn't seem to always be necessary. I left that out of this PR as that seems like a separate issue, but figured I'd mention it since I noticed that.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Skylib is not usable in generated projects.


## What is the new behavior?

Skylib can now be used in generated projects.

## Does this PR introduce a breaking change?

- [X] No