### PR TITLE
fix: update usages of `ExternalNpmPackageInfo.path` to be safe and default to empty string

### DIFF
--- a/internal/linker/link_node_modules.bzl
+++ b/internal/linker/link_node_modules.bzl
@@ -81,7 +81,7 @@ def write_node_modules_manifest(ctx, extra_data = [], mnemonic = None, link_work
     # we'll symlink local "node_modules" to them
     for dep in extra_data + getattr(ctx.attr, "data", []) + getattr(ctx.attr, "deps", []):
         if ExternalNpmPackageInfo in dep:
-            path = dep[ExternalNpmPackageInfo].path
+            path = getattr(dep[ExternalNpmPackageInfo], "path", "")
             workspace = dep[ExternalNpmPackageInfo].workspace
             if path in node_modules_roots:
                 other_workspace = node_modules_roots[path]

--- a/internal/linker/test/default_path/BUILD.bazel
+++ b/internal/linker/test/default_path/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//:index.bzl", "generated_file_test", "nodejs_binary", "npm_package_bin")
+load(
+    ":custom_external_npm_package_info.bzl",
+    "custom_external_npm_package_info",
+)
+
+package(default_testonly = True)
+
+# Custom target returning `ExternalNpmPackageInfo` without a `path` field.
+custom_external_npm_package_info(
+    name = "external_npm_package_info",
+)
+
+nodejs_binary(
+    name = "binary",
+    data = [":external_npm_package_info"],
+    entry_point = "default_path.js",
+)
+
+npm_package_bin(
+    name = "generated",
+    stdout = "generated.txt",
+    tool = ":binary",
+)
+
+generated_file_test(
+    name = "test",
+    src = "golden.txt",
+    generated = "generated.txt",
+)

--- a/internal/linker/test/default_path/custom_external_npm_package_info.bzl
+++ b/internal/linker/test/default_path/custom_external_npm_package_info.bzl
@@ -1,0 +1,30 @@
+"""Custom `ExternalNpmPackageInfo` target without a `path` attribute."""
+
+load(
+    "//internal/providers:external_npm_package_info.bzl",
+    "ExternalNpmPackageInfo",
+)
+
+def _custom_external_npm_package_info_impl(ctx):
+    return ExternalNpmPackageInfo(
+        direct_sources = depset([], transitive = ctx.files.deps),
+        sources = depset(ctx.files.srcs, transitive = ctx.files.deps),
+        has_directories = False,
+        workspace = "npm",
+        # `path` is intentionally **not** provided.
+        # Historical note: `ExternalNpmPackageInfo` was publicly exported prior
+        # to the `path` attribute's introduction. This means that we cannot
+        # assume an `ExternalNpmPackageInfo` has a `path`, and must safely check
+        # it each time.
+    )
+
+custom_external_npm_package_info = rule(
+    implementation = _custom_external_npm_package_info_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = True,
+            default = [],
+        ),
+        "deps": attr.label_list(default = []),
+    },
+)

--- a/internal/linker/test/default_path/default_path.js
+++ b/internal/linker/test/default_path/default_path.js
@@ -1,0 +1,1 @@
+console.log('ExternalNpmPackageInfo with no path works!');

--- a/internal/linker/test/default_path/golden.txt
+++ b/internal/linker/test/default_path/golden.txt
@@ -1,0 +1,1 @@
+ExternalNpmPackageInfo with no path works!

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -48,7 +48,7 @@ def _compute_node_modules_roots(ctx):
     # Add in roots from third-party deps
     for d in ctx.attr.data:
         if ExternalNpmPackageInfo in d:
-            path = d[ExternalNpmPackageInfo].path
+            path = getattr(d[ExternalNpmPackageInfo], "path", "")
             workspace = d[ExternalNpmPackageInfo].workspace
             if path in node_modules_roots:
                 other_workspace = node_modules_roots[path]

--- a/internal/providers/external_npm_package_info.bzl
+++ b/internal/providers/external_npm_package_info.bzl
@@ -45,7 +45,7 @@ def _node_modules_aspect_impl(target, ctx):
         for dep in ctx.rule.attr.deps:
             if ExternalNpmPackageInfo in dep:
                 has_directories = has_directories or dep[ExternalNpmPackageInfo].has_directories
-                path = dep[ExternalNpmPackageInfo].path
+                path = getattr(dep[ExternalNpmPackageInfo], "path", "")
                 workspace = dep[ExternalNpmPackageInfo].workspace
                 sources_depsets = []
                 if path in paths:

--- a/internal/providers/node_runtime_deps_info.bzl
+++ b/internal/providers/node_runtime_deps_info.bzl
@@ -50,7 +50,7 @@ def _compute_node_modules_roots(ctx):
         deps += ctx.attr.deps
     for d in deps:
         if ExternalNpmPackageInfo in d:
-            path = d[ExternalNpmPackageInfo].path
+            path = getattr(d[ExternalNpmPackageInfo], "path", "")
             workspace = d[ExternalNpmPackageInfo].workspace
             if path in node_modules_roots:
                 other_workspace = node_modules_roots[path]


### PR DESCRIPTION
`ExternalNpmPackageInfo` had a `path` attribute introduced and used in
2c2cc6eec42b0f4f805fb3063920107b78f821fd, but the provider was publicly exported beforehand. Even
though all internal usages were updated to include a path, this change was shipped in `3.2.0` and
introduced an unintentional breaking change for consumers. Most notably, `rules_postcss` manually
implements this provider and does not give a `path` failing in versions `3.2.0` and up.

https://github.com/bazelbuild/rules_postcss/blob/2bd16fda40cd4bf4fbf0b477b968366ec1602103/internal/plugin.bzl#L30-L41

Solution here is to safely retrieve the `path` attribute and default to empty string at all places
it is used. A test is also introduced to ensure that a `nodejs_binary()` can depend on a custom
`ExternalNpmPackageInfo` provider without a `path` attribute, which should hopefully prevent against
regressions.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix

## What is the current behavior?

Usage of custom rules which provide `ExternalNpmPackageInfo` without a `path` attribute, break in versions `3.2.0` and up.

```
ERROR: /home/dparker/Source/rules_prerender/examples/styles/BUILD.bazel:5:16: in nodejs_binary rule //examples/styles:page_styles.postcss_runner: 
Traceback (most recent call last):
        File "/home/dparker/.cache/bazel/_bazel_dparker/3b4ba8c4eec5951318c36cb07368e75b/external/build_bazel_rules_nodejs/internal/node/node.bzl", line 155, column 56, in _nodejs_binary_impl
                node_modules_manifest = write_node_modules_manifest(ctx, link_workspace_root = ctx.attr.link_workspace_root)
        File "/home/dparker/.cache/bazel/_bazel_dparker/3b4ba8c4eec5951318c36cb07368e75b/external/build_bazel_rules_nodejs/internal/linker/link_node_modules.bzl", line 72, column 47, in write_node_modules_manifest
                path = dep[ExternalNpmPackageInfo].path
Error: 'ExternalNpmPackageInfo' value has no field or method 'path'
Available attributes: direct_sources, sources, workspace
```

## What is the new behavior?

All usages of an `ExternalNpmPackageInfo` provider with no `path` attribute, default to the empty string, meaning they will be linked at the root.

## Does this PR introduce a breaking change?

- [X] No

## Other information

This bug appears to have been a regression in `3.2.0` which broke `rules_postcss`, as its plugins return a custom `ExternalNpmPackageInfo` provider that does not contain a `path`, leading to the above error when using `postcss_binary()` with `rules_nodejs@>=3.2.0`.

Considering that this [shipped without note in `3.2.0`](https://github.com/bazelbuild/rules_nodejs/releases/tag/3.2.0) and in a minor version, I'm assuming this was a regression rather than a deliberate breaking change, so this PR simply provides a default value for a missing `path` field. Since then, `4.0.0` was released, so we *technically* could argue this is just an undocumented breaking change in `4.0.0`. I'm not sure if `3.x.x` is still supported, but if not we could just call this a breaking change and the `path` field is now required. I'm inclined not to do that if possible and actually fix the bug in `rules_nodejs`, which is the strategy this PR attempts to do.

I'm not very familiar with the test infrastructure of `rules_nodejs`. I think I put this test in the right package, but most of the other packages use a `linker()` rule that I don't fully understand. I found that `nodejs_binary()` was sufficient to reproduce the bug, so I just tested with that. Let me know if using `linker()` would be more appropriate here.

More context about how I came across this regression: https://github.com/dgp1130/rules_prerender/issues/39.