### PR TITLE
fix(cypress): add js files from JSModuleInfo to plugin wrapper sources if available

### DIFF
--- a/packages/cypress/internal/cypress_web_test.bzl
+++ b/packages/cypress/internal/cypress_web_test.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 "E2E testing with Cypress"
 
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSNamedModuleInfo")
+load("@build_bazel_rules_nodejs//:providers.bzl", "JSModuleInfo", "JSNamedModuleInfo")
 load("@build_bazel_rules_nodejs//internal/node:node.bzl", "nodejs_test_kwargs")
 
 ATTRS = dict(
@@ -55,9 +55,10 @@ def _filter_js(files):
 def _cypress_plugin_wrapper(ctx):
     plugin_file = None
 
-    # TODO: switch to JSModuleInfo when it is available
-    if JSNamedModuleInfo in ctx.attr.plugin_file:
+    if JSNamedModuleInfo in ctx.attr.plugin_file and len(ctx.attr.plugin_file[JSNamedModuleInfo].direct_sources.to_list()) > 0:
         plugin_file = _filter_js(ctx.attr.plugin_file[JSNamedModuleInfo].direct_sources.to_list())[0]
+    if JSModuleInfo in ctx.attr.plugin_file and len(ctx.attr.plugin_file[JSModuleInfo].direct_sources.to_list()) > 0:
+        plugin_file = _filter_js(ctx.attr.plugin_file[JSModuleInfo].direct_sources.to_list())[0]
     else:
         plugin_file = ctx.file.plugin_file
 

--- a/packages/cypress/test/BUILD.bazel
+++ b/packages/cypress/test/BUILD.bazel
@@ -1,5 +1,14 @@
 load("@build_bazel_rules_nodejs//packages/cypress:index.bzl", "cypress_web_test")
 load("@build_bazel_rules_nodejs//packages/typescript:index.bzl", "ts_library")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+
+js_library(
+    name = "lib_plugin_file",
+    srcs = ["lib_plugin.js"],
+    deps = [
+        "@cypress_deps//:node_modules",
+    ],
+)
 
 ts_library(
     name = "plugin_file",
@@ -35,5 +44,20 @@ cypress_web_test(
         "@cypress_deps//rxjs",
     ],
     plugin_file = ":plugin_file",
+    tags = ["cypress"],
+)
+
+cypress_web_test(
+    name = "lib_test",
+    srcs = [
+        "world.spec.js",
+        ":hello_spec",
+    ],
+    config_file = "cypress.json",
+    cypress_npm_package = "@cypress_deps//cypress",
+    data = [
+        "@cypress_deps//rxjs",
+    ],
+    plugin_file = ":lib_plugin_file",
     tags = ["cypress"],
 )

--- a/packages/cypress/test/lib_plugin.js
+++ b/packages/cypress/test/lib_plugin.js
@@ -1,0 +1,20 @@
+
+const http = require('http');
+
+module.exports = (_on, config) => {
+  const hostname = '127.0.0.1';
+  const port = 3000;
+  const server = http.createServer((_req, res) => {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'text/html');
+    res.end('<html><body>hello-world</body></html>');
+  });
+
+  server.listen(port, hostname, () => {
+    console.log(`Server running at http://${hostname}:${port}/`);
+  });
+
+  config.baseUrl = `http://${hostname}:${port}`;
+
+  return config;
+};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `cypress_web_test` implementation uses JSNamedModuleInfo to find the plugin source.  This is fine for typescript libraries,  but fails with the following error if a `js_library` is used to package the plugin source:

```
ERROR: /Users/mtl/Development/rules_nodejs.git/packages/cypress/test/BUILD.bazel:50:17: in cypress_web_test rule //packages/cypress/test:lib_test:
Traceback (most recent call last):
	File "/Users/mtl/Development/rules_nodejs.git/packages/cypress/internal/cypress_web_test.bzl", line 88, column 45, in _cypress_web_test_impl
		plugin_wrapper = _cypress_plugin_wrapper(ctx)
	File "/Users/mtl/Development/rules_nodejs.git/packages/cypress/internal/cypress_web_test.bzl", line 59, column 99, in _cypress_plugin_wrapper
		plugin_file = _filter_js(ctx.attr.plugin_file[JSNamedModuleInfo].direct_sources.to_list())[0]
Error: index out of range (index is 0, but sequence has 0 elements)
ERROR: Analysis of target '//packages/cypress/test:lib_test' failed; build aborted: Analysis of target '//packages/cypress/test:lib_test' failed
```

## What is the new behavior?

This PR extends the `_cypress_plugin_wrapper` to consider both `JSNamedModuleInfo` and `JSModuleInfo` sources, with priority given to the original behavior if there are both.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

