### PR TITLE
fix: update `tsutils` to version `3.21.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "tmp": "0.1.0",
         "ts-lit-plugin": "1.1.9",
         "tsickle": "0.38.0",
-        "tsutils": "2.27.2",
+        "tsutils": "3.21.0",
         "typeorm": "0.2.18",
         "typescript": "~4.3.2",
         "unidiff": "1.0.1",

--- a/packages/concatjs/package.json
+++ b/packages/concatjs/package.json
@@ -19,7 +19,7 @@
     "dependencies": {
         "protobufjs": "6.8.8",
         "source-map-support": "0.5.9",
-        "tsutils": "2.27.2"
+        "tsutils": "3.21.0"
     },
     "peerDependencies": {
         "karma": ">=4.0.0",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -29,7 +29,7 @@
         "protobufjs": "6.8.8",
         "semver": "5.6.0",
         "source-map-support": "0.5.9",
-        "tsutils": "2.27.2"
+        "tsutils": "3.21.0"
     },
     "scripts": {
       "postinstall": "node npm_version_check.js"

--- a/third_party/github.com/bazelbuild/rules_typescript/internal/tsc_wrapped/package.json
+++ b/third_party/github.com/bazelbuild/rules_typescript/internal/tsc_wrapped/package.json
@@ -7,7 +7,7 @@
     "protobufjs": "5.0.3",
     "tmp": "0.0.33",
     "tsickle": "0.28.0",
-    "tsutils": "2.27.2",
+    "tsutils": "3.21.0",
     "typescript": "2.7.2"
   }
 }

--- a/third_party/github.com/bazelbuild/rules_typescript/package.json
+++ b/third_party/github.com/bazelbuild/rules_typescript/package.json
@@ -33,7 +33,7 @@
         "source-map-support": "0.5.9",
         "tmp": "0.0.33",
         "tsickle": "0.38.0",
-        "tsutils": "2.27.2",
+        "tsutils": "3.21.0",
         "typescript": "^4.3.2",
         "which": "~1.0.5"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10582,10 +10582,10 @@ tslib@^2.0.0, tslib@^2.2.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
-tsutils@2.27.2:
-  version "2.27.2"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.27.2.tgz#60ba88a23d6f785ec4b89c6e8179cac9b431f1c7"
-  integrity sha512-qf6rmT84TFMuxAKez2pIfR8UCai49iQsfB7YWVjV1bKpy/d0PWT5rEOSM6La9PiHZ0k1RRZQiwVdVJfQ3BPHgg==
+tsutils@3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
`tsetse` - `check-return-value` rule is returning false positives due because the short-circuit code in https://github.com/bazelbuild/rules_nodejs/blob/9b454e38f7e2bbc64f75ee9a7dcb6ff45f1c7a12/third_party/github.com/bazelbuild/rules_typescript/internal/tsetse/rules/check_return_value_rule.ts#L60-L62 is not working as expected for certain usecases.

Example:

```ts
    get content() {
      try {
        return expect(harness.readFile(path)).withContext(`With file content for '${path}'`);
      } catch (e) {
        if (e.code !== 'ENOENT') {
          throw e;
        }

        // File does not exist so always fail the expectation
        return createFailureExpectation(
          expect(''),
          `Expected file content but file does not exist: '${path}'`,
        );
      }
    },
```

WIll cause tsetse to fail with the bellow;
```
              ~~~~~~~~~~
packages/angular_devkit/build_angular/src/testing/jasmine-helpers.ts:112:16 - error TS21222: [tsetse] return value is unused.
        See http://tsetse.info/check-return-value

112         return expect(Buffer.byteLength(harness.readFile(path))).withContext(
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
113           `With file size for '${path}'`,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
114         );
```
