### PR TITLE
fix: remove dependency on shelljs in esbuild-update script

### DIFF
--- a/scripts/update-esbuild-versions.js
+++ b/scripts/update-esbuild-versions.js
@@ -1,5 +1,5 @@
 const https = require('https');
-const { exec } = require('shelljs');
+const { execSync } = require('child_process');
 const { mkdirSync, createWriteStream, readFileSync, writeFileSync } = require('fs');
 const { join } = require('path');
 const { tmpdir } = require('os');
@@ -73,7 +73,7 @@ async function main() {
     const downloadPath = join(tmpDir, platform);
 
     await downloadFile(`https://registry.npmjs.org/${platform}/-/${platform}-${version}.tgz`, downloadPath);
-    const shasum = exec(`shasum -a 256 ${downloadPath}`, {silent: true}).stdout.split(' ')[0];
+    const shasum = execSync(`shasum -a 256 ${downloadPath}`, {silent: true, encoding: 'utf-8'}).split(' ')[0];
 
     return [new RegExp(`${_var}_SHA = "(.+?)"`, 's'), shasum];
   }));


### PR DESCRIPTION
Removes the dependency on `shelljs` when running the esbuild update script. This was causing the GH action to fail as we didn't perform an `npm install` during the action, and for once dependency that's already a built-in, that seems excessive.

Context https://github.com/bazelbuild/rules_nodejs/runs/3479696864?check_suite_focus=true