### PR TITLE
feat(concatjs): publish concatjs binaries on releases and fetch as a …

### DIFF
--- a/scripts/on-release.js
+++ b/scripts/on-release.js
@@ -53,3 +53,6 @@ for (const f of workspaceFiles) {
   workspaceContents = workspaceContents.replace(regex, replacement);
   fs.writeFileSync(f, workspaceContents);
 }
+
+// TODO: loop over concatjs binaries, calculate sha256 for each and replace
+// the constants in /toolchains/concatjs/repositories.bzl

--- a/third_party/github.com/bazelbuild/rules_typescript/BUILD.bazel
+++ b/third_party/github.com/bazelbuild/rules_typescript/BUILD.bazel
@@ -41,9 +41,6 @@ pkg_npm(
     vendor_external = ["build_bazel_rules_typescript"],
     visibility = ["//visibility:public"],
     deps = [
-        "//devserver:devserver-darwin",
-        "//devserver:devserver-linux",
-        "//devserver:devserver-windows",
         "//internal:generated_BUILD",
         "//internal:tsc_wrapped",
     ],

--- a/third_party/github.com/bazelbuild/rules_typescript/devserver/BUILD.bazel
+++ b/third_party/github.com/bazelbuild/rules_typescript/devserver/BUILD.bazel
@@ -64,3 +64,43 @@ go_binary(
     pure = "on",
     visibility = ["//visibility:public"],
 )
+
+go_binary(
+    name = "devserver-darwin-arm64",
+    out = "devserver-darwin_arm64",
+    embed = [":go_default_library"],
+    goarch = "arm64",
+    goos = "darwin",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "devserver-linux-arm64",
+    out = "devserver-linux_arm64",
+    embed = [":go_default_library"],
+    goarch = "arm64",
+    goos = "linux",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "devserver-linux-ppc64le",
+    out = "devserver-linux_ppc64le",
+    embed = [":go_default_library"],
+    goarch = "arm64",
+    goos = "linux",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "devserver-linux-s390x",
+    out = "devserver-linux_s390x",
+    embed = [":go_default_library"],
+    goarch = "s390x",
+    goos = "linux",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)

--- a/toolchains/concatjs/BUILD.bazel
+++ b/toolchains/concatjs/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load(":toolchain.bzl", "configure_concatjs_toolchains")
+
+filegroup(
+    name = "package_contents",
+    srcs = glob(["*"]),
+    visibility = ["//:__pkg__"],
+)
+
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+configure_concatjs_toolchains(
+    platforms = {
+        "darwin_amd64": struct(
+            exec_compatible_with = [
+                "@platforms//os:macos",
+                "@platforms//cpu:x86_64",
+            ],
+            sha = "1234",
+            urls = [
+                "https://github.com/alexeagle/rules_nodejs/releases/download/devserver-4/devserver-darwin_x64",
+            ],
+        ),
+    },
+)
+
+bzl_library(
+    name = "bzl",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:bzl",
+    ],
+)

--- a/toolchains/concatjs/repositories.bzl
+++ b/toolchains/concatjs/repositories.bzl
@@ -1,0 +1,91 @@
+"""Info for fetching published concatjs binaries"""
+
+load("//:version.bzl", "VERSION")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+# TODO: replace these with latest as we publish the release
+_DARWIN_AMD64_SHA = "9739ca4efee1f005f41a5f8ab49c0cec6938cc0072f47288baa47837e84702d3"
+_DARWIN_ARM64_SHA = "6c696a1d5cadd0c0b07d354aafed4954b49e854682c935748caf18dd9305a902"
+_LINUX_AMD64_SHA = "5e91e48b8fe63b64d3cfd4803022055ddec67a5de682d0247d8ed224e3ad7646"
+_LINUX_ARM64_SHA = "89de72dcd695fe3676aba8563d91b20d156f019dbb187bd74334efba411a449d"
+_WINDOWS_AMD64_SHA = "3d8c246649ee798d4588c547f5685d06b041769d4c5f0a2cc9645098d60e0695"
+
+CONCATJS_PACKAGES = struct(
+    platforms = dict({
+        "darwin_amd64": struct(
+            sha = _DARWIN_AMD64_SHA,
+            urls = [
+                "https://github.com/bazelbuild/rules_nodejs/releases/download/%s/concatjs-darwin_x64" % VERSION,
+            ],
+            exec_compatible_with = [
+                "@platforms//os:macos",
+                "@platforms//cpu:x86_64",
+            ],
+        ),
+        "darwin_arm64": struct(
+            sha = _DARWIN_ARM64_SHA,
+            urls = [
+                "https://github.com/bazelbuild/rules_nodejs/releases/download/%s/concatjs-darwin_arm64" % VERSION,
+            ],
+            exec_compatible_with = [
+                "@platforms//os:macos",
+                "@platforms//cpu:aarch64",
+            ],
+        ),
+        "linux_amd64": struct(
+            sha = _LINUX_AMD64_SHA,
+            urls = [
+                "https://github.com/bazelbuild/rules_nodejs/releases/download/%s/concatjs-linux_x64" % VERSION,
+            ],
+            exec_compatible_with = [
+                "@platforms//os:linux",
+                "@platforms//cpu:x86_64",
+            ],
+        ),
+        "linux_arm64": struct(
+            sha = _LINUX_ARM64_SHA,
+            urls = [
+                "https://github.com/bazelbuild/rules_nodejs/releases/download/%s/concatjs-linux_arm64" % VERSION,
+            ],
+            exec_compatible_with = [
+                "@platforms//os:linux",
+                "@platforms//cpu:aarch64",
+            ],
+        ),
+        # TODO: add linux for ppc64le and s390x
+        "windows_amd64": struct(
+            sha = _WINDOWS_AMD64_SHA,
+            urls = [
+                "https://github.com/bazelbuild/rules_nodejs/releases/download/%s/concatjs-windows_x64.exe" % VERSION,
+            ],
+            exec_compatible_with = [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64",
+            ],
+        ),
+    }),
+)
+
+def _maybe(repo_rule, name, **kwargs):
+    if name not in native.existing_rules():
+        repo_rule(name = name, **kwargs)
+
+def concatjs_repositories(name = ""):
+    """Helper for fetching and setting up the concatjs toolchain
+
+    Args:
+        name: currently unused
+    """
+
+    for name, meta in CONCATJS_PACKAGES.platforms.items():
+        _maybe(
+            http_file,
+            name = "concatjs_%s" % name,
+            urls = meta.urls,
+            strip_prefix = "package",
+            build_file_content = """exports_files(["%s"])""" % meta.binary_path,
+            sha256 = meta.sha,
+        )
+
+        toolchain_label = Label("@build_bazel_rules_nodejs//toolchains/concatjs:concatjs_%s_toolchain" % name)
+        native.register_toolchains("@%s//%s:%s" % (toolchain_label.workspace_name, toolchain_label.package, toolchain_label.name))

--- a/toolchains/concatjs/toolchain.bzl
+++ b/toolchains/concatjs/toolchain.bzl
@@ -1,0 +1,61 @@
+"""Toolchain and helper definitions for concatjs"""
+
+def _concatjs_toolchain_impl(ctx):
+    return [
+        platform_common.ToolchainInfo(
+            binary = ctx.executable.binary,
+        ),
+        platform_common.TemplateVariableInfo({
+            "DEVSERVER_PATH": ctx.executable.binary.path,
+        }),
+    ]
+
+_concatjs_toolchain = rule(
+    implementation = _concatjs_toolchain_impl,
+    attrs = {
+        "binary": attr.label(
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+
+TOOLCHAIN = Label("@build_bazel_rules_nodejs//toolchains/concatjs:toolchain_type")
+
+def configure_concatjs_toolchain(name, binary, exec_compatible_with):
+    """Defines a toolchain for concatjs given the binary path and platform constraints
+
+    Args:
+        name: unique name for this toolchain, generally in the form "concatjs_platform_arch"
+        binary: label for the concatjs binary
+        exec_compatible_with: list of platform constraints
+    """
+
+    _concatjs_toolchain(
+        name = name,
+        binary = binary,
+    )
+
+    native.toolchain(
+        name = "%s_toolchain" % name,
+        exec_compatible_with = exec_compatible_with,
+        toolchain = name,
+        toolchain_type = TOOLCHAIN,
+    )
+
+def configure_concatjs_toolchains(name = "", platforms = {}):
+    """Configures concatjs toolchains for a list of supported platforms
+
+    Args:
+        name: unused
+        platforms: dict of platforms to configure toolchains for
+    """
+
+    for name, meta in platforms.items():
+        repo = "concatjs_%s" % name
+        configure_concatjs_toolchain(
+            name = repo,
+            binary = "@%s//:file" % (repo, meta.binary_path),
+            exec_compatible_with = meta.exec_compatible_with,
+        )


### PR DESCRIPTION
…toolchain

This avoids shipping three (soon to be more) copies of the binary in the @bazel/typescript and @bazel/concatjs packages.
Unblocks us from publishing mac M1 binaries for example, or supporting linux on s390 or ppc
