### PR TITLE
fix(typescript): write json srcs to generated tsconfig for resolveJsonModule+composite projects

### DIFF
--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -323,6 +323,9 @@ def _is_ts_src(src, allow_js):
         return True
     return allow_js and (src.endswith(".js") or src.endswith(".jsx"))
 
+def _is_json_src(src):
+    return src.endswith(".json")
+
 def _replace_ext(f, ext_map):
     cur_ext = f[f.rindex("."):]
     new_ext = ext_map.get(cur_ext)
@@ -640,7 +643,7 @@ def ts_project_macro(
         write_tsconfig(
             name = "_gen_tsconfig_%s" % name,
             config = tsconfig,
-            files = [s for s in srcs if _is_ts_src(s, allow_js)],
+            files = [s for s in srcs if _is_ts_src(s, allow_js) or _is_json_src(s)],
             extends = Label("%s//%s:%s" % (native.repository_name(), native.package_name(), name)).relative(extends) if extends else None,
             out = "tsconfig_%s.json" % name,
         )

--- a/packages/typescript/test/ts_project/json/BUILD.bazel
+++ b/packages/typescript/test/ts_project/json/BUILD.bazel
@@ -16,6 +16,19 @@ ts_project(
 )
 
 ts_project(
+    name = "transpile-generated-tsconfig",
+    srcs = SRCS,
+    out_dir = "generated-tsconfig",
+    tsconfig = {
+        "compilerOptions": {
+            "composite": True,
+            "declaration": True,
+            "resolveJsonModule": True,
+        },
+    },
+)
+
+ts_project(
     name = "transpile-no-outdir",
     srcs = SRCS,
 )
@@ -38,11 +51,13 @@ nodejs_test(
     data = [
         ":transpile",
         ":transpile-decl-only",
+        ":transpile-generated-tsconfig",
         ":transpile-no-outdir",
     ],
     entry_point = "verify.js",
     templated_args = [
         "$(locations :transpile)",
         "$(locations :transpile-no-outdir)",
+        "$(locations :transpile-generated-tsconfig)",
     ],
 )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When using a `ts_project` rule with a generated tsconfig file, TSC errors when using `resolveJsonModule` and `composite`, because the generated tsconfg file does not enumerate the .json inputs in the "files" array.


## What is the new behavior?

.json inputs are enumerated in generated tsconfig files.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

