### PR TITLE
fix(typescript): write json srcs to generated tsconfig for resolveJso…

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -473,9 +473,10 @@ Defaults to `False`
 
 <pre>
 ts_project(<a href="#ts_project-name">name</a>, <a href="#ts_project-tsconfig">tsconfig</a>, <a href="#ts_project-srcs">srcs</a>, <a href="#ts_project-args">args</a>, <a href="#ts_project-deps">deps</a>, <a href="#ts_project-extends">extends</a>, <a href="#ts_project-allow_js">allow_js</a>, <a href="#ts_project-declaration">declaration</a>, <a href="#ts_project-source_map">source_map</a>,
-           <a href="#ts_project-declaration_map">declaration_map</a>, <a href="#ts_project-preserve_jsx">preserve_jsx</a>, <a href="#ts_project-composite">composite</a>, <a href="#ts_project-incremental">incremental</a>, <a href="#ts_project-emit_declaration_only">emit_declaration_only</a>,
-           <a href="#ts_project-ts_build_info_file">ts_build_info_file</a>, <a href="#ts_project-tsc">tsc</a>, <a href="#ts_project-typescript_package">typescript_package</a>, <a href="#ts_project-typescript_require_path">typescript_require_path</a>, <a href="#ts_project-validate">validate</a>,
-           <a href="#ts_project-supports_workers">supports_workers</a>, <a href="#ts_project-declaration_dir">declaration_dir</a>, <a href="#ts_project-out_dir">out_dir</a>, <a href="#ts_project-root_dir">root_dir</a>, <a href="#ts_project-link_workspace_root">link_workspace_root</a>, <a href="#ts_project-kwargs">kwargs</a>)
+           <a href="#ts_project-declaration_map">declaration_map</a>, <a href="#ts_project-resolve_json_module">resolve_json_module</a>, <a href="#ts_project-preserve_jsx">preserve_jsx</a>, <a href="#ts_project-composite">composite</a>, <a href="#ts_project-incremental">incremental</a>,
+           <a href="#ts_project-emit_declaration_only">emit_declaration_only</a>, <a href="#ts_project-ts_build_info_file">ts_build_info_file</a>, <a href="#ts_project-tsc">tsc</a>, <a href="#ts_project-typescript_package">typescript_package</a>,
+           <a href="#ts_project-typescript_require_path">typescript_require_path</a>, <a href="#ts_project-validate">validate</a>, <a href="#ts_project-supports_workers">supports_workers</a>, <a href="#ts_project-declaration_dir">declaration_dir</a>, <a href="#ts_project-out_dir">out_dir</a>, <a href="#ts_project-root_dir">root_dir</a>,
+           <a href="#ts_project-link_workspace_root">link_workspace_root</a>, <a href="#ts_project-kwargs">kwargs</a>)
 </pre>
 
 Compiles one TypeScript project using `tsc --project`
@@ -685,6 +686,12 @@ Defaults to `False`
 
 if the `declarationMap` bit is set in the tsconfig.
 Instructs Bazel to expect a `.d.ts.map` output for each `.ts` source.
+
+Defaults to `False`
+
+<h4 id="ts_project-resolve_json_module">resolve_json_module</h4>
+
+boolean; Specifies whether TypeScript will read .json files.
 
 Defaults to `False`
 

--- a/packages/typescript/internal/ts_project_options_validator.ts
+++ b/packages/typescript/internal/ts_project_options_validator.ts
@@ -88,6 +88,7 @@ function main([tsconfigPath, output, target, attrsStr]: string[]): 0|1 {
   check('allowJs', 'allow_js');
   check('declarationMap', 'declaration_map');
   check('emitDeclarationOnly', 'emit_declaration_only');
+  check('resolveJsonModule', 'resolve_json_module');
   check('sourceMap', 'source_map');
   check('composite');
   check('declaration');

--- a/packages/typescript/test/ts_project/json/BUILD.bazel
+++ b/packages/typescript/test/ts_project/json/BUILD.bazel
@@ -9,15 +9,74 @@ SRCS = [
     "baz.svg",
 ]
 
+# resolveJsonModule in checked-in tsconfig.json file
 ts_project(
     name = "transpile",
     srcs = SRCS,
     out_dir = "foobar",
+    resolve_json_module = True,
+)
+
+# resolveJsonModule in generated tsconfig.json file
+ts_project(
+    name = "transpile-generated-tsconfig",
+    srcs = SRCS,
+    out_dir = "generated-tsconfig",
+    resolve_json_module = True,
+    tsconfig = {
+        "compilerOptions": {
+            "composite": True,
+            "declaration": True,
+            "resolveJsonModule": True,
+        },
+    },
+)
+
+# resolveJsonModule in checked-in tsconfig.json file - with no srcs provided
+ts_project(
+    name = "transpile-generated-tsconfig-implicit-srcs",
+    out_dir = "generated-tsconfig-implicit-srcs",
+    resolve_json_module = True,
+    tsconfig = {
+        "compilerOptions": {
+            "composite": True,
+            "declaration": True,
+            "resolveJsonModule": True,
+        },
+    },
+)
+
+# resolveJsonModule in attribute
+ts_project(
+    name = "transpile-generated-tsconfig-inline",
+    srcs = SRCS,
+    out_dir = "generated-tsconfig-inline",
+    resolve_json_module = True,
+    tsconfig = {
+        "compilerOptions": {
+            "composite": True,
+            "declaration": True,
+        },
+    },
+)
+
+# resolveJsonModule in attribute - with no srcs provided
+ts_project(
+    name = "transpile-generated-tsconfig-inline-implicit-srcs",
+    out_dir = "generated-tsconfig-inline-implicit-srcs",
+    resolve_json_module = True,
+    tsconfig = {
+        "compilerOptions": {
+            "composite": True,
+            "declaration": True,
+        },
+    },
 )
 
 ts_project(
     name = "transpile-no-outdir",
     srcs = SRCS,
+    resolve_json_module = True,
 )
 
 # Test that we don't try to declare .json outputs when tsc isn't producing any JS
@@ -38,11 +97,19 @@ nodejs_test(
     data = [
         ":transpile",
         ":transpile-decl-only",
+        ":transpile-generated-tsconfig",
+        ":transpile-generated-tsconfig-implicit-srcs",
+        ":transpile-generated-tsconfig-inline",
+        ":transpile-generated-tsconfig-inline-implicit-srcs",
         ":transpile-no-outdir",
     ],
     entry_point = "verify.js",
     templated_args = [
         "$(locations :transpile)",
         "$(locations :transpile-no-outdir)",
+        "$(locations :transpile-generated-tsconfig)",
+        "$(locations :transpile-generated-tsconfig-implicit-srcs)",
+        "$(locations :transpile-generated-tsconfig-inline)",
+        "$(locations :transpile-generated-tsconfig-inline-implicit-srcs)",
     ],
 )

--- a/packages/typescript/test/ts_project/json/verify.js
+++ b/packages/typescript/test/ts_project/json/verify.js
@@ -6,3 +6,6 @@ assert.ok(files.some(f => f.endsWith('json/subdir/foo.json')), 'Missing subdir/f
 assert.ok(files.some(f => f.endsWith('json/foobar/bar.json')), 'Missing outdir bar.json');
 assert.ok(
     files.some(f => f.endsWith('json/foobar/subdir/foo.json')), 'Missing outdir subdir/foo.json');
+
+// verify tsconfig.json files weren't pulled in by the implicit *.json src glob if resolveJsonModule = true
+assert.ok(files.every(f => !f.substring(f.lastIndexOf('/')).includes("tsconfig")), "tsconfig.json included");


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When using a `ts_project` rule with a generated tsconfig file, tsc errors when using `resolveJsonModule`, because the generated tsconfg file does not enumerate the .json inputs in the "files" array. For reasons unclear to me, tsc only enforces this on `composite` projects.


## What is the new behavior?

.json inputs are enumerated in generated tsconfig files.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

