### PR TITLE
fix: use execSync to call npm

### DIFF
--- a/scripts/update-esbuild-versions.js
+++ b/scripts/update-esbuild-versions.js
@@ -83,7 +83,7 @@ async function main() {
 
   // update package.json used for API wrapper
   replaceFileContent('toolchains/esbuild/package.json', [[/"esbuild": "(.+?)"/, version]]);
-  exec(`npm i --package-lock-only`, {silent: true, cwd: 'toolchains/esbuild'});
+  execSync(`npm i --package-lock-only`, {silent: true, cwd: 'toolchains/esbuild'});
 }
 
 main();


### PR DESCRIPTION
...I didn't do a good job of this change the first time around, so it's always failing currently. Update to use `execSync` which is actually imported, rather than the undefined `exec` symbol. 