### PR TITLE
fix(typescript): exclude package.json and package-lock.json from default ts_project srcs

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -597,7 +597,7 @@ Defaults to `"tsconfig"`
 Label of the tsconfig.json file to use for the compilation
 
 To support "chaining" of more than one extended config, this label could be a target that
-provdes `TsConfigInfo` such as `ts_config`.
+provides `TsConfigInfo` such as `ts_config`.
 
 By default, we assume the tsconfig file is "tsconfig.json" in the same folder as the ts_project rule.
 
@@ -636,7 +636,10 @@ Defaults to `None`
 
 List of labels of TypeScript source files to be provided to the compiler.
 
-If absent, defaults to `**/*.ts[x]` (all TypeScript files in the package).
+If absent, the default is set as follows:
+- Include `**/*.ts[x]` (all TypeScript files in the package).
+- If `allow_js` is set, include `**/*.js[x]` (all JavaScript files in the package).
+- If `resolve_json_module` is set, include `**/*.json` (all JSON files in the package), but exclude `**/package.json`, `**/package-lock.json`, and `**/tsconfig*.json`.
 
 Defaults to `None`
 

--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -481,14 +481,17 @@ def ts_project_macro(
 
         srcs: List of labels of TypeScript source files to be provided to the compiler.
 
-            If absent, defaults to `**/*.ts[x]` (all TypeScript files in the package).
+            If absent, the default is set as follows:
+            - Include `**/*.ts[x]` (all TypeScript files in the package).
+            - If `allow_js` is set, include `**/*.js[x]` (all JavaScript files in the package).
+            - If `resolve_json_module` is set, include `**/*.json` (all JSON files in the package), but exclude `**/package.json`, `**/package-lock.json`, and `**/tsconfig*.json`.
 
         deps: List of labels of other rules that produce TypeScript typings (.d.ts files)
 
         tsconfig: Label of the tsconfig.json file to use for the compilation
 
             To support "chaining" of more than one extended config, this label could be a target that
-            provdes `TsConfigInfo` such as `ts_config`.
+            provides `TsConfigInfo` such as `ts_config`.
 
             By default, we assume the tsconfig file is "tsconfig.json" in the same folder as the ts_project rule.
 
@@ -618,10 +621,10 @@ def ts_project_macro(
         include = ["**/*.ts", "**/*.tsx"]
         exclude = []
         if allow_js == True:
-            include.append("**/*.js", "**/*.jsx")
+            include.extend(["**/*.js", "**/*.jsx"])
         if resolve_json_module == True:
             include.append("**/*.json")
-            exclude.append("**/tsconfig*.json")
+            exclude.extend(["**/package.json", "**/package-lock.json", "**/tsconfig*.json"])
         srcs = native.glob(include, exclude)
     extra_deps = []
 


### PR DESCRIPTION
This PR excludes `**/package.json` and `**/package-lock.json` from the default value for `srcs`. This seems like a very common case that would make the default unusable when `resolveJsonModule` is on.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
An NPM project using TypeScript with the `resolveJsonModule` set to true, not specifying `srcs` to the `ts_project` rule causes errors such as:

```
output 'package-lock.json' was not created
output 'package.json' was not created
```

Issue Number: N/A


## What is the new behavior?

Files matching the globs `**/package.json` or `**/package-lock.json` are excluded.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

This is a breaking change if anyone is relying on the existing behavior of including `package.json` or similarly-named files.

## Other information

