### PR TITLE
fix(builtin): pkg_npm unable to copy files from transitioned actions

### DIFF
--- a/internal/pkg_npm/test/BUILD.bazel
+++ b/internal/pkg_npm/test/BUILD.bazel
@@ -60,6 +60,7 @@ pkg_npm(
         ":produces_files",
         ":rollup/bundle/subdirectory",
         ":ts_library",
+        "//internal/pkg_npm/test/transition:test_lib",
         "@internal_npm_package_test_vendored_external//:ts_library",
     ],
 )
@@ -80,28 +81,17 @@ pkg_npm(
     srcs = [":rollup/bundle/subdirectory"],
 )
 
-genrule(
-    name = "gen_test_pkg_pack",
-    outs = [
-        "test-pkg.tgz",
-    ],
-    cmd = "export HOME='.' && $(location :test_pkg.pack) && cp test-pkg-1.2.3.tgz $@",
-    tags = ["no-rbe"],
-    tools = [
-        ":test_pkg.pack",
-    ],
-)
-
 sh_test(
     name = "test_pkg_pack",
     srcs = ["diff_pack_dir.sh"],
     args = [
-        "$(location :gen_test_pkg_pack)",
-        "$(location :test_pkg)",
+        "$(rootpath :test_pkg.pack)",
+        "$(rootpath :test_pkg)",
     ],
     data = [
-        ":gen_test_pkg_pack",
         ":test_pkg",
+        ":test_pkg.pack",
+        "//third_party/github.com/bazelbuild/bazel/tools/bash/runfiles",
     ],
     tags = ["no-rbe"],
 )

--- a/internal/pkg_npm/test/diff_pack_dir.sh
+++ b/internal/pkg_npm/test/diff_pack_dir.sh
@@ -1,25 +1,34 @@
-archived=$1
-if [ -f "$archived" ]; then
-    echo "RUNFILES are supported in this OS"
-    # run files are supported (not windows os), we can read the
-    # input from arguments directly
-    rm -rf ./pack && mkdir ./pack
-    tar -xvzf $1 -C ./pack
-    diff -r ./pack/package $2
-    if [ $? -ne 0 ]; then
-        echo "The directory was modified";
-        exit 1
-    fi
-else
-    # runfiles are not supported in Windows,
-    # hard coding the test input for now
-    rm -rf ./pack && mkdir ./pack
-    tar -xvzf ../../test-pkg.tgz -C ./pack
-    diff ./pack/package ../../test_pkg
-    if [ $? -ne 0 ]; then
-        echo "The directory was modified";
-        exit 1
-    fi
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=build_bazel_rules_nodejs/third_party/github.com/bazelbuild/bazel/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=;
+# --- end runfiles.bash initialization v2 ---
+
+pack_command=$(rlocation $TEST_WORKSPACE/$1)
+pkg_dir=$(rlocation $TEST_WORKSPACE/$2)
+
+cd $TEST_TMPDIR
+
+# Create the tar for the NPM package by running its `.pack` target.
+# Note that we need to set `HOME` as otherwise NPM will fail with
+# writing files to the cache.
+HOME=. $pack_command
+archive=./test-pkg-1.2.3.tgz
+
+# Unpack the archive so that we can run the `diff` assertion, comparing
+# the packed output with the actual NPM package directory.
+tar -xvzf $archive
+
+diff -r ./package $pkg_dir
+
+if [ $? -ne 0 ]; then
+    echo "The directories do not match. See output above.";
+    exit 3
 fi
 
 exit 0

--- a/internal/pkg_npm/test/pkg_npm.spec.js
+++ b/internal/pkg_npm/test/pkg_npm.spec.js
@@ -51,6 +51,11 @@ describe('pkg_npm', () => {
   it('copies files from deps', () => {
     expect(readFromPkg('bundle.min.js')).toBe('bundle content');
   });
+
+  it('copies files from different output directories (when used with transitions)', () => {
+    expect(readFromPkg('transition/test.js')).toEqual('OK');
+  });
+
   it('copies files from external workspace if included in srcs', () => {
     expect(readFromPkg('vendored_external_file')).toEqual('vendored_external_file content');
   });

--- a/internal/pkg_npm/test/transition/BUILD.bazel
+++ b/internal/pkg_npm/test/transition/BUILD.bazel
@@ -1,0 +1,19 @@
+load(":index.bzl", "test_rule", "test_transition_flag")
+
+package(default_visibility = ["//internal/pkg_npm/test:__pkg__"])
+
+test_transition_flag(
+    name = "test_flag",
+    build_setting_default = False,
+)
+
+test_rule(
+    name = "test_lib",
+    deps = [":transitioned_genrule"],
+)
+
+genrule(
+    name = "transitioned_genrule",
+    outs = ["test.js"],
+    cmd = """echo OK > $@""",
+)

--- a/internal/pkg_npm/test/transition/index.bzl
+++ b/internal/pkg_npm/test/transition/index.bzl
@@ -1,0 +1,43 @@
+"""Test file that sets up an outgoing transition which allows for testing that ensures
+transitioned targets are properly packaged into the package output."""
+
+TestTransitionFlagInfo = provider(
+    fields = {"enabled": "Whether the transition is enabled."},
+)
+
+def _test_transition_flag_impl(ctx):
+    return TestTransitionFlagInfo(enabled = ctx.build_setting_value)
+
+test_transition_flag = rule(
+    implementation = _test_transition_flag_impl,
+    build_setting = config.bool(flag = True),
+)
+
+def _test_transition_impl(settings, attr):
+    return {"//internal/pkg_npm/test/transition:test_flag": True}
+
+test_transition = transition(
+    implementation = _test_transition_impl,
+    inputs = [],
+    outputs = ["//internal/pkg_npm/test/transition:test_flag"],
+)
+
+def _test_rule_impl(ctx):
+    file_depsets = []
+
+    for dep in ctx.attr.deps:
+        file_depsets.append(dep[DefaultInfo].files)
+
+    return [DefaultInfo(files = depset(transitive = file_depsets))]
+
+test_rule = rule(
+    implementation = _test_rule_impl,
+    attrs = {
+        "deps": attr.label_list(cfg = test_transition),
+        # Needed in order to allow for the outgoing transition on the `deps` attribute.
+        # https://docs.bazel.build/versions/main/skylark/config.html#user-defined-transitions.
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)


### PR DESCRIPTION
The `pkg_npm` rule is currently using some basic computation to
determine output paths from action inputs. This logic is prone to
mistakes and also does not work well with inputs that have been
built as part of transitioned targets. e.g. The devserver binaries
for `@bazel/concatjs` are currently built using a 1:3 transition
where each devserver binary is built in a different Bazel output
directory fragment. e.g.

bazel-out/darwin-fastbuild-ST-05b09dfdd2e5
bazel-out/darwin-fastbuild-ST-b60b0173fed1
bazel-out/darwin-fastbuild-ST-fce3d0422d3b

https://unpkg.com/browse/@bazel/concatjs@4.1.0/bazel-out/

The `pkg_npm` rule needs to be able to properly compute
output paths regardless of the output directory fragment.
The solution to the problem is that the package rule should
pass relevant `short_path` information to the packager tool.
The shot path is relative to the containing root, allowing for
straightforward and _more reliable_ computation of the output
path with respect to the owning package declaring the `pkg_npm` rule.

e.g. `bazel-out/darwin-fastbuild-ST<..>/packages/core/index.js` should
end up being resolved to `<pkg-out>/index.js` if the owning package
name is `packages/core`. Previously this was computed by only stripping
off the leading default bazel output directory fragment, like:
`bazel-out/darwin-fastbuild/packages/core`