### PR TITLE
New vscode-js-debug plugin

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -49,6 +49,7 @@ You will first need to configure your `.vscode/launch.json`:
       "request": "attach",
       "name": "Attach nodejs_binary",
       "internalConsoleOptions": "neverOpen",
+      "resolveSourceMapLocations": null,
       "sourceMapPathOverrides": {
         "../*": "${workspaceRoot}/*",
         "../../*": "${workspaceRoot}/*",


### PR DESCRIPTION
# VS Code debug instructions update for Typescript

In the August 2021 update, legacy debuggers have been dropped from vscode, leaving us with the new `vscode-js-debug` plugin that introduces a number of breaking changes.

In order to properly hit breakpoints with the new `vscode-js-debug` plugin, the option `resolveSourceMapLocations` needs to be set to `null` so it can resolve sourcemaps outside of the workspace location. Otherwise the transpiled js files will be used. 

See question in: https://github.com/microsoft/vscode-js-debug/issues/1105

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

