### PR TITLE
build: update rules_webtesting to latest version supporting m1 browsers

### DIFF
--- a/common.bazelrc
+++ b/common.bazelrc
@@ -64,6 +64,11 @@ build:debug --compilation_mode=dbg
 # This prevents accidentally depending on this feature, which Bazel will remove.
 build --nolegacy_external_runfiles
 
+# Workaround for: https://github.com/bazelbuild/bazel/issues/4327.
+# The Chromium browser archive contains files with spaces that will
+# break runfile tree creation for browser tests.
+build --experimental_inprocess_symlink_creation
+
 # Turn on --incompatible_strict_action_env which was on by default
 # in Bazel 0.21.0 but turned off again in 0.22.0. Follow
 # https://github.com/bazelbuild/bazel/issues/7026 for more details.

--- a/common.bazelrc
+++ b/common.bazelrc
@@ -65,9 +65,10 @@ build:debug --compilation_mode=dbg
 build --nolegacy_external_runfiles
 
 # Workaround for: https://github.com/bazelbuild/bazel/issues/4327.
-# The Chromium browser archive contains files with spaces that will
-# break runfile tree creation for browser tests.
-build --experimental_inprocess_symlink_creation
+# The Chromium browser archive for macOS and Windows contain files with spaces that
+# will break runfile tree creation for browser tests relying on `rules_webtesting`.
+build:macos --experimental_inprocess_symlink_creation
+build:windows --experimental_inprocess_symlink_creation
 
 # Turn on --incompatible_strict_action_env which was on by default
 # in Bazel 0.21.0 but turned off again in 0.22.0. Follow

--- a/docs/Concatjs.md
+++ b/docs/Concatjs.md
@@ -133,8 +133,8 @@ if you use the web testing rules in `@bazel/concatjs`:
 # Fetch transitive Bazel dependencies of karma_web_test
 http_archive(
     name = "io_bazel_rules_webtesting",
-    sha256 = "9bb461d5ef08e850025480bab185fd269242d4e533bca75bfb748001ceb343c3",
-    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz"],
+    sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
+    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz"],
 )
 
 # Set up web testing, choose browsers we can test on

--- a/docs/Concatjs.md
+++ b/docs/Concatjs.md
@@ -150,6 +150,14 @@ browser_repositories(
 )
 ```
 
+## Known issues with running Chromium for macOS/Windows in Bazel
+
+For macOS and Windows, Chromium comes with files that contain spaces in their file names. This breaks runfile tree
+creation within Bazel due to a bug. There are various workarounds that allow for Chromium on these platforms:
+
+* Instruct Bazel to automatically disable runfile tree creation if not needed. [More details here](https://github.com/bazelbuild/bazel/issues/4327#issuecomment-922106293)
+* Instruct Bazel to use an alternative experimental approach for creating runfile trees. [More details here](https://github.com/bazelbuild/bazel/issues/4327#issuecomment-627422865)
+
 ## Installing with user-managed dependencies
 
 If you didn't use the `yarn_install` or `npm_install` rule to create an `npm` workspace, you'll have to declare a rule in your root `BUILD.bazel` file to execute karma:

--- a/docs/Protractor.md
+++ b/docs/Protractor.md
@@ -13,6 +13,14 @@ The Protractor rules run tests under the Protractor framework with Bazel.
 
 Add the `@bazel/protractor` npm package to your `devDependencies` in `package.json`.
 
+## Known issues with running Chromium for macOS/Windows in Bazel
+
+For macOS and Windows, Chromium comes with files that contain spaces in their file names. This breaks runfile tree
+creation within Bazel due to a bug. There are various workarounds that allow for Chromium on these platforms:
+
+* Instruct Bazel to automatically disable runfile tree creation if not needed. [More details here](https://github.com/bazelbuild/bazel/issues/4327#issuecomment-922106293)
+* Instruct Bazel to use an alternative experimental approach for creating runfile trees. [More details here](https://github.com/bazelbuild/bazel/issues/4327#issuecomment-627422865)
+
 
 ## protractor_web_test
 

--- a/examples/angular/WORKSPACE
+++ b/examples/angular/WORKSPACE
@@ -71,8 +71,8 @@ npm_bazel_protractor_dependencies()
 # Load karma_web_test dependencies
 http_archive(
     name = "io_bazel_rules_webtesting",
-    sha256 = "9bb461d5ef08e850025480bab185fd269242d4e533bca75bfb748001ceb343c3",
-    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz"],
+    sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
+    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz"],
 )
 
 # Setup the rules_webtesting toolchain

--- a/examples/angular_view_engine/WORKSPACE
+++ b/examples/angular_view_engine/WORKSPACE
@@ -58,8 +58,8 @@ npm_bazel_protractor_dependencies()
 # Load karma dependencies
 http_archive(
     name = "io_bazel_rules_webtesting",
-    sha256 = "9bb461d5ef08e850025480bab185fd269242d4e533bca75bfb748001ceb343c3",
-    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz"],
+    sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
+    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz"],
 )
 
 # Setup the rules_webtesting toolchain

--- a/examples/web_testing/WORKSPACE
+++ b/examples/web_testing/WORKSPACE
@@ -35,8 +35,8 @@ yarn_install(
 
 http_archive(
     name = "io_bazel_rules_webtesting",
-    sha256 = "9bb461d5ef08e850025480bab185fd269242d4e533bca75bfb748001ceb343c3",
-    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz"],
+    sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
+    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz"],
 )
 
 load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories")

--- a/package.bzl
+++ b/package.bzl
@@ -120,8 +120,8 @@ def rules_nodejs_dev_dependencies():
     _maybe(
         http_archive,
         name = "io_bazel_rules_webtesting",
-        sha256 = "9bb461d5ef08e850025480bab185fd269242d4e533bca75bfb748001ceb343c3",
-        urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz"],
+        sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
+        urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz"],
     )
 
 def _maybe(repo_rule, name, **kwargs):

--- a/packages/concatjs/index.docs.bzl
+++ b/packages/concatjs/index.docs.bzl
@@ -161,6 +161,14 @@ browser_repositories(
 )
 ```
 
+## Known issues with running Chromium for macOS/Windows in Bazel
+
+For macOS and Windows, Chromium comes with files that contain spaces in their file names. This breaks runfile tree
+creation within Bazel due to a bug. There are various workarounds that allow for Chromium on these platforms:
+
+* Instruct Bazel to automatically disable runfile tree creation if not needed. [More details here](https://github.com/bazelbuild/bazel/issues/4327#issuecomment-922106293)
+* Instruct Bazel to use an alternative experimental approach for creating runfile trees. [More details here](https://github.com/bazelbuild/bazel/issues/4327#issuecomment-627422865)
+
 ## Installing with user-managed dependencies
 
 If you didn't use the `yarn_install` or `npm_install` rule to create an `npm` workspace, you'll have to declare a rule in your root `BUILD.bazel` file to execute karma:

--- a/packages/concatjs/index.docs.bzl
+++ b/packages/concatjs/index.docs.bzl
@@ -144,8 +144,8 @@ if you use the web testing rules in `@bazel/concatjs`:
 # Fetch transitive Bazel dependencies of karma_web_test
 http_archive(
     name = "io_bazel_rules_webtesting",
-    sha256 = "9bb461d5ef08e850025480bab185fd269242d4e533bca75bfb748001ceb343c3",
-    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz"],
+    sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
+    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz"],
 )
 
 # Set up web testing, choose browsers we can test on

--- a/packages/concatjs/web_test/karma.conf.js
+++ b/packages/concatjs/web_test/karma.conf.js
@@ -403,6 +403,13 @@ try {
                   webTestNamedFiles['FIREFOX']}' in runfiles`);
             }
           }
+
+          // For Firefox, we need to disable the content sandbox as the browser is already being
+          // launched as part of the Bazel sandbox. This is necessary because the integrated content
+          // sandbox in Firefox will conflict with the Bazel sandbox due to nested sandboxing.
+          // This is similar to why we disable sandbox for Chromium (as seen above).
+          process.env.MOZ_DISABLE_CONTENT_SANDBOX = '1';
+
           conf.browsers.push(process.env['DISPLAY'] ? 'Firefox' : 'FirefoxHeadless');
         }
       });

--- a/packages/protractor/index.bzl
+++ b/packages/protractor/index.bzl
@@ -20,6 +20,14 @@ The Protractor rules run tests under the Protractor framework with Bazel.
 ## Installation
 
 Add the `@bazel/protractor` npm package to your `devDependencies` in `package.json`.
+
+## Known issues with running Chromium for macOS/Windows in Bazel
+
+For macOS and Windows, Chromium comes with files that contain spaces in their file names. This breaks runfile tree
+creation within Bazel due to a bug. There are various workarounds that allow for Chromium on these platforms:
+
+* Instruct Bazel to automatically disable runfile tree creation if not needed. [More details here](https://github.com/bazelbuild/bazel/issues/4327#issuecomment-922106293)
+* Instruct Bazel to use an alternative experimental approach for creating runfile trees. [More details here](https://github.com/bazelbuild/bazel/issues/4327#issuecomment-627422865)
 """
 
 load(

--- a/packages/protractor/package.bzl
+++ b/packages/protractor/package.bzl
@@ -29,8 +29,8 @@ def npm_bazel_protractor_dependencies():
     _maybe(
         http_archive,
         name = "io_bazel_rules_webtesting",
-        sha256 = "9bb461d5ef08e850025480bab185fd269242d4e533bca75bfb748001ceb343c3",
-        urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.3/rules_webtesting.tar.gz"],
+        sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
+        urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz"],
     )
 
 def _maybe(repo_rule, name, **kwargs):


### PR DESCRIPTION
Updates to the latest version of `rules_webtesting` that comes with
M1 macOS browser support, RBE/exec platform selection fixes and better
caching of the browser (and tool) binaries.

https://github.com/bazelbuild/rules_webtesting/commit/6b2ef24cfe95d6e31d5e61414949ff8f0f184b13