### PR TITLE
fix patch callback

### DIFF
--- a/internal/node/node_patches.js
+++ b/internal/node/node_patches.js
@@ -102,7 +102,7 @@ const patcher = (fs = fs__default['default'], roots) => {
                 return origReadlink(args[0], (err, str) => {
                     if (err) {
                         if (err.code === 'ENOENT') {
-                            return cb(false, stats);
+                            return cb(null, stats);
                         }
                         else if (err.code === 'EINVAL') {
                             // readlink only returns einval when the target is not a link.
@@ -128,7 +128,7 @@ const patcher = (fs = fs__default['default'], roots) => {
                         });
                     }
                     // its a symlink and its inside of the root.
-                    cb(false, stats);
+                    cb(null, stats);
                 });
             };
         }
@@ -143,10 +143,10 @@ const patcher = (fs = fs__default['default'], roots) => {
                 if (err)
                     return cb(err);
                 if (isEscape(str, args[0])) {
-                    cb(false, path__default['default'].resolve(args[0]));
+                    cb(null, path__default['default'].resolve(args[0]));
                 }
                 else {
-                    cb(false, str);
+                    cb(null, str);
                 }
             };
         }
@@ -161,10 +161,10 @@ const patcher = (fs = fs__default['default'], roots) => {
                     if (err)
                         return cb(err);
                     if (isEscape(str, args[0])) {
-                        cb(false, path__default['default'].resolve(args[0]));
+                        cb(null, path__default['default'].resolve(args[0]));
                     }
                     else {
-                        cb(false, str);
+                        cb(null, str);
                     }
                 };
             }
@@ -188,7 +188,7 @@ const patcher = (fs = fs__default['default'], roots) => {
                     // if its not supposed to be a link we have to trigger an EINVAL error.
                     return cb(e);
                 }
-                cb(false, str);
+                cb(null, str);
             };
         }
         origReadlink(...args);

--- a/packages/node-patches/src/fs.ts
+++ b/packages/node-patches/src/fs.ts
@@ -79,7 +79,7 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
         return origReadlink(args[0], (err: Error&{code: string}, str: string) => {
           if (err) {
             if (err.code === 'ENOENT') {
-              return cb(false, stats);
+              return cb(null, stats);
             } else if (err.code === 'EINVAL') {
               // readlink only returns einval when the target is not a link.
               // so if we found a link and it's no longer a link someone raced file system
@@ -105,7 +105,7 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
             });
           }
           // its a symlink and its inside of the root.
-          cb(false, stats);
+          cb(null, stats);
         });
       };
     }
@@ -120,9 +120,9 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
       args[args.length - 1] = (err: Error, str: string) => {
         if (err) return cb(err);
         if (isEscape(str, args[0])) {
-          cb(false, path.resolve(args[0]));
+          cb(null, path.resolve(args[0]));
         } else {
-          cb(false, str);
+          cb(null, str);
         }
       };
     }
@@ -137,9 +137,9 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
           args[args.length - 1] = (err: Error, str: string) => {
             if (err) return cb(err);
             if (isEscape(str, args[0])) {
-              cb(false, path.resolve(args[0]));
+              cb(null, path.resolve(args[0]));
             } else {
-              cb(false, str);
+              cb(null, str);
             }
           };
         }
@@ -164,7 +164,7 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
               // if its not supposed to be a link we have to trigger an EINVAL error.
               return cb(e);
             }
-            cb(false, str);
+            cb(null, str);
           };
         }
         origReadlink(...args);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
callback methods in the `node_patches.js` use false instead of null for the error parameter. This seems to trip some 3rd party packages that are comparing the first value with null and thus report `false` error ...

e.g https://github.com/RyanZim/universalify/blob/master/index.js#L11

## What is the new behavior?
callback methods in the `node_patches.js` should use a null value  for the error parameter

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


