### PR TITLE
fix(cypress): use correct label to reference plugins/base.js

### DIFF
--- a/docs/Cypress.md
+++ b/docs/Cypress.md
@@ -254,7 +254,7 @@ Defaults to `False`
 
 (*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>*): Your cypress plugin file. See https://docs.cypress.io/guides/tooling/plugins-guide
 
-Defaults to `@npm//@bazel/cypress:internal/plugins/base.js`
+Defaults to `@npm//@bazel/cypress/internal:plugins/base.js`
 
 <h4 id="cypress_web_test-srcs">srcs</h4>
 

--- a/packages/cypress/internal/cypress_web_test.bzl
+++ b/packages/cypress/internal/cypress_web_test.bzl
@@ -34,7 +34,7 @@ ATTRS = dict(
         default = Label("@build_bazel_rules_nodejs//packages/cypress/internal:run-cypress.js"),
     ),
     plugin_file = attr.label(
-        default = Label("@build_bazel_rules_nodejs//packages/cypress:internal/plugins/base.js"),
+        default = Label("@build_bazel_rules_nodejs//packages/cypress/internal:plugins/base.js"),
         allow_single_file = True,
         doc = "Your cypress plugin file. See https://docs.cypress.io/guides/tooling/plugins-guide",
     ),


### PR DESCRIPTION
Fixes #2976

Could use some test coverage, any cypress_web_test with no `plugin_file` attribute in the repo would be enough