### PR TITLE
feat(typescript): support for ESM variant of the Angular compiler plugin

### DIFF
--- a/third_party/github.com/bazelbuild/rules_typescript/internal/BUILD.bazel
+++ b/third_party/github.com/bazelbuild/rules_typescript/internal/BUILD.bazel
@@ -61,6 +61,7 @@ tsc(
     data = _TSC_WRAPPED_SRCS + [
         "//internal:tsconfig.json",
         "@npm//@types/node",
+        "@npm//@angular/compiler-cli",
         "@npm//protobufjs",
         "@npm//tsickle",
         "@npm//tsutils",

--- a/third_party/github.com/bazelbuild/rules_typescript/internal/tsc_wrapped/angular_plugin.ts
+++ b/third_party/github.com/bazelbuild/rules_typescript/internal/tsc_wrapped/angular_plugin.ts
@@ -1,0 +1,23 @@
+// The `@angular/compiler-cli` module is optional so we only
+// access as type-only at the file top-level.
+import type {NgTscPlugin} from '@angular/compiler-cli';
+
+type CompilerCliModule = typeof import('@angular/compiler-cli');
+
+/**
+ * Gets the constructor for instantiating the Angular `ngtsc`
+ * emit plugin supported by `tsc_wrapped`.
+ */
+export async function getAngularEmitPlugin(): Promise<typeof NgTscPlugin|null> {
+  try {
+    // Note: This is an interop allowing for the `@angular/compiler-cli` package
+    // to be shipped as strict ESM, or as CommonJS. If the CLI is a CommonJS
+    // package (pre v13 of Angular), then the exports are in the `default` property.
+    // See: https://nodejs.org/api/esm.html#esm_import_statements.
+    const exports = await import('@angular/compiler-cli') as
+        Partial<CompilerCliModule> & {default?: CompilerCliModule}
+    return exports.NgTscPlugin ?? exports.default?.NgTscPlugin ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/third_party/github.com/bazelbuild/rules_typescript/internal/tsc_wrapped/perf_trace.ts
+++ b/third_party/github.com/bazelbuild/rules_typescript/internal/tsc_wrapped/perf_trace.ts
@@ -59,6 +59,20 @@ export function wrap<T>(name: string, f: () => T): T {
 }
 
 /**
+ * Records the execution of the given async function by invoking it. Execution
+ * is recorded until the async function completes.
+ */
+export async function wrapAsync<T>(name: string, f: () => Promise<T>): Promise<T> {
+  const start = now();
+  try {
+    return await f();
+  } finally {
+    const end = now();
+    events.push({name, ph: 'X', pid: 1, ts: start, dur: (end - start)});
+  }
+}
+
+/**
  * counter records a snapshot of counts.  The counter name identifies a
  * single graph, while the counts object provides data for each count
  * of a line on the stacked bar graph.


### PR DESCRIPTION
As of v13, the `@angular/compiler-cli` package will come as strict ESM
package. This means that the import currently in `tsc_wrapped` does
not work for v13+ of Angular. This commit adds an interop allowing for
both the ESM variant, and CJS variant of the Angular compiler to work.