### PR TITLE
fix(esbuild): fix depending on testonly targets 

### DIFF
--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -406,6 +406,7 @@ def esbuild_macro(name, output_dir = False, splitting = False, **kwargs):
         args_file = "%s.user.args.json" % name
         params_file(
             name = "%s_args" % name,
+            testonly = kwargs.get("testonly", False),
             out = args_file,
             args = [json.encode(args)],
             data = deps + srcs,

--- a/packages/esbuild/test/testonly/BUILD.bazel
+++ b/packages/esbuild/test/testonly/BUILD.bazel
@@ -1,0 +1,48 @@
+load("//:index.bzl", "generated_file_test", "js_library", "nodejs_binary", "npm_package_bin")
+load("//packages/esbuild:index.bzl", "esbuild")
+
+js_library(
+    name = "lib",
+    srcs = ["lib.jsx"],
+)
+
+js_library(
+    name = "main",
+    testonly = True,
+    srcs = ["main.js"],
+    deps = [":lib"],
+)
+
+esbuild(
+    name = "bundle",
+    testonly = True,
+    args = {
+        "keepNames": True,
+    },
+    entry_point = "main.js",
+    deps = [
+        ":main",
+    ],
+)
+
+nodejs_binary(
+    name = "bin",
+    testonly = True,
+    data = [
+        ":bundle",
+    ],
+    entry_point = "bundle.js",
+)
+
+npm_package_bin(
+    name = "runner",
+    testonly = True,
+    stdout = "out.txt",
+    tool = ":bin",
+)
+
+generated_file_test(
+    name = "test",
+    src = "out.golden.txt",
+    generated = "out.txt",
+)

--- a/packages/esbuild/test/testonly/lib.jsx
+++ b/packages/esbuild/test/testonly/lib.jsx
@@ -1,0 +1,1 @@
+export const NAME = 'rules_nodejs';

--- a/packages/esbuild/test/testonly/main.js
+++ b/packages/esbuild/test/testonly/main.js
@@ -1,0 +1,3 @@
+import {NAME as name} from './lib';
+
+console.log(name);

--- a/packages/esbuild/test/testonly/out.golden.txt
+++ b/packages/esbuild/test/testonly/out.golden.txt
@@ -1,0 +1,1 @@
+rules_nodejs


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- N/A: Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?
Fix esbuild error when depending on testonly targets.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When an esbuild target with non-empty `args` is marked as `testonly`, it does not mark its `params_file` as testonly. This causes the following error when it depends on another `testonly` target:
```
ERROR: /home/[username]/rules_nodejs/packages/esbuild/test/testonly/BUILD.bazel:16:8: in _params_file rule //packages/esbuild/test/testonly:bundle_args: non-test target '//packages/esbuild/test/testonly:bundle_args' depends on testonly target '//packages/esbuild/test/testonly:main' and doesn't have testonly attribute set
```
Issue Number: N/A


## What is the new behavior?
No error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

