### PR TITLE
fix(typescript): typescript downleveling breaking ESM variant of Angular v13 compiler

### DIFF
--- a/third_party/github.com/bazelbuild/rules_typescript/internal/tsc_wrapped/angular_plugin.ts
+++ b/third_party/github.com/bazelbuild/rules_typescript/internal/tsc_wrapped/angular_plugin.ts
@@ -3,21 +3,38 @@
 import type {NgTscPlugin} from '@angular/compiler-cli';
 
 type CompilerCliModule = typeof import('@angular/compiler-cli');
+type CompilerInteropExports = Partial<CompilerCliModule> & {default?: CompilerCliModule};
+
 
 /**
  * Gets the constructor for instantiating the Angular `ngtsc`
  * emit plugin supported by `tsc_wrapped`.
+ * @throws An error when the Angular emit plugin could not be retrieved.
  */
-export async function getAngularEmitPlugin(): Promise<typeof NgTscPlugin|null> {
+export async function getAngularEmitPluginOrThrow(): Promise<typeof NgTscPlugin> {
+  // Note: This is an interop allowing for the `@angular/compiler-cli` package
+  // to be shipped as strict ESM, or as CommonJS. If the CLI is a CommonJS
+  // package (pre v13 of Angular), then the exports are in the `default` property.
+  // See: https://nodejs.org/api/esm.html#esm_import_statements.
+  // Note: TypeScript downlevels the dynamic `import` to a `require` that is
+  // not compatible with ESM. We create a function to workaround this issue.
+  const exports = await loadEsmOrFallbackToRequire<CompilerInteropExports>(
+      '@angular/compiler-cli');
+  const plugin = exports.NgTscPlugin ?? exports.default?.NgTscPlugin;
+
+  if (plugin === undefined) {
+    throw new Error('Could not find `NgTscPlugin` export in `@angular/compiler-cli`.');
+  }
+
+  return plugin;
+}
+
+async function loadEsmOrFallbackToRequire<T>(moduleName: string): Promise<T> {
   try {
-    // Note: This is an interop allowing for the `@angular/compiler-cli` package
-    // to be shipped as strict ESM, or as CommonJS. If the CLI is a CommonJS
-    // package (pre v13 of Angular), then the exports are in the `default` property.
-    // See: https://nodejs.org/api/esm.html#esm_import_statements.
-    const exports = await import('@angular/compiler-cli') as
-        Partial<CompilerCliModule> & {default?: CompilerCliModule}
-    return exports.NgTscPlugin ?? exports.default?.NgTscPlugin ?? null;
+    return await new Function('m', `return import(m);`)(moduleName);
   } catch {
-    return null;
+    // If the dynamic import failed, we still re-try with `require` because
+    // some NodeJS versions do not even support the dynamic import expression.
+    return require(moduleName);
   }
 }


### PR DESCRIPTION
Unfortunately my initial refactor to allow for the ESM variant of the
compiler-cli did not contain a workaround for an issue that is caused
by TypeScript. Currently the import is rewritten to a dynamic require,
preventing the ESM variant of the compiler-cli to work. This commit
fixes this in a similar way we have made `@angular/cli` compatible with
the ESM-variant of Angular v13 packages.