### PR TITLE
Enable use_default_shell_env for run_node

### DIFF
--- a/internal/providers/node_runtime_deps_info.bzl
+++ b/internal/providers/node_runtime_deps_info.bzl
@@ -155,5 +155,6 @@ def run_node(ctx, inputs, arguments, executable, chdir = None, **kwargs):
         arguments = arguments,
         executable = exec_exec,
         env = env,
+        use_default_shell_env = True,
         **kwargs
     )

--- a/internal/providers/node_runtime_deps_info.bzl
+++ b/internal/providers/node_runtime_deps_info.bzl
@@ -155,6 +155,6 @@ def run_node(ctx, inputs, arguments, executable, chdir = None, **kwargs):
         arguments = arguments,
         executable = exec_exec,
         env = env,
-        use_default_shell_env = True,
+        use_default_shell_env = kwargs.pop("use_default_shell_env", True),
         **kwargs
     )

--- a/packages/typescript/internal/build_defs.bzl
+++ b/packages/typescript/internal/build_defs.bzl
@@ -179,10 +179,6 @@ def _compile_action(ctx, inputs, outputs, tsconfig_file, node_opts, description 
             mnemonic = "TypeScriptCompile",
             inputs = action_inputs,
             outputs = action_outputs,
-            # Use the built-in shell environment
-            # Allow for users who set a custom shell that can locate standard binaries like tr and uname
-            # See https://github.com/NixOS/nixpkgs/issues/43955#issuecomment-407546331
-            use_default_shell_env = True,
             arguments = arguments,
             executable = ctx.executable.compiler,
             execution_requirements = {
@@ -202,10 +198,6 @@ def _compile_action(ctx, inputs, outputs, tsconfig_file, node_opts, description 
             mnemonic = "tsc",
             inputs = action_inputs,
             outputs = action_outputs,
-            # Use the built-in shell environment
-            # Allow for users who set a custom shell that can locate standard binaries like tr and uname
-            # See https://github.com/NixOS/nixpkgs/issues/43955#issuecomment-407546331
-            use_default_shell_env = True,
             arguments = arguments,
             executable = "compiler",
             env = {"COMPILATION_MODE": ctx.var["COMPILATION_MODE"]},


### PR DESCRIPTION
Not setting this flag breaks `--action_env`, so it's basically always incorrect not to set it. The flag is also misnamed - it basically determines whether to merge the settings from `--action_env` or not.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [x] Maybe
- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

