### PR TITLE
Remove --incompatible_restrict_string_escapes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,7 +50,6 @@ build:docker-sandbox --experimental_docker_image=gcr.io/cloud-marketplace/google
 
 # Incompatible flags to run with
 build --incompatible_no_implicit_file_export
-build --incompatible_restrict_string_escapes
 # TODO(mattem): flip this when dependencies allow
 # build --incompatible_struct_has_no_methods
 # TODO(alexeagle): turn on this flag when dependencies allow


### PR DESCRIPTION
The flag was removed from Bazel HEAD in https://github.com/bazelbuild/bazel/commit/21b4b1a489c991682b9fcc9a10b468b9ea18e931 . Its default value was already true before that.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

