### PR TITLE
Remove uses of `incompatible_use_toolchain_transition` now that it is…

### DIFF
--- a/nodejs/private/toolchains_repo.bzl
+++ b/nodejs/private/toolchains_repo.bzl
@@ -83,7 +83,7 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@rules_nodejs//nodejs:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
+
 )
 """
     repository_ctx.file("defs.bzl", starlark_content)


### PR DESCRIPTION
… enabled by

default in Bazel 5.0.

This is a step towards removing it entirely.

Part of https://github.com/bazelbuild/bazel/issues/14127.
