### PR TITLE
fix(docs): expose correct bzl_library targets

### DIFF
--- a/nodejs/BUILD.bazel
+++ b/nodejs/BUILD.bazel
@@ -14,6 +14,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//nodejs/private:bzl",
+        "//nodejs/private/providers:bzl",
         "//third_party/github.com/bazelbuild/bazel-skylib:bzl",
     ],
 )

--- a/third_party/github.com/bazelbuild/bazel-skylib/BUILD
+++ b/third_party/github.com/bazelbuild/bazel-skylib/BUILD
@@ -20,7 +20,4 @@ bzl_library(
         "rules/**/*.bzl",
     ]),
     visibility = ["//visibility:public"],
-    deps = [
-        "//internal/npm_install:bzl",
-    ],
 )


### PR DESCRIPTION
allows downstream rules to run stardoc
