### PR TITLE
refactor: depend on bazel-skylib at runtime

### DIFF
--- a/e2e/bazel_managed_deps/WORKSPACE
+++ b/e2e/bazel_managed_deps/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/e2e/concatjs_devserver/WORKSPACE
+++ b/e2e/concatjs_devserver/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/e2e/fine_grained_symlinks/WORKSPACE
+++ b/e2e/fine_grained_symlinks/WORKSPACE
@@ -11,6 +11,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
 
 # This test needs to run with yarn 1.9.2 to test the fix for

--- a/e2e/jasmine/WORKSPACE
+++ b/e2e/jasmine/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/e2e/node_loader_no_preserve_symlinks/WORKSPACE
+++ b/e2e/node_loader_no_preserve_symlinks/WORKSPACE
@@ -13,6 +13,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
 
 node_repositories(preserve_symlinks = False)

--- a/e2e/node_loader_preserve_symlinks/WORKSPACE
+++ b/e2e/node_loader_preserve_symlinks/WORKSPACE
@@ -13,6 +13,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/e2e/nodejs_repository/WORKSPACE
+++ b/e2e/nodejs_repository/WORKSPACE
@@ -11,6 +11,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/e2e/packages/WORKSPACE
+++ b/e2e/packages/WORKSPACE
@@ -8,6 +8,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "check_rules_nodejs_version", "node_repositories", "npm_install", "yarn_install")
 
 # Test that check_rules_nodejs_version works as expected

--- a/e2e/webapp/WORKSPACE
+++ b/e2e/webapp/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/examples/angular_bazel_architect/WORKSPACE
+++ b/examples/angular_bazel_architect/WORKSPACE
@@ -16,6 +16,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 # The yarn_install rule runs yarn anytime the package.json or yarn.lock file changes.
 # It also extracts and installs any Bazel rules distributed in an npm package.
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")

--- a/examples/closure/WORKSPACE
+++ b/examples/closure/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/examples/cypress/WORKSPACE
+++ b/examples/cypress/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/examples/esbuild/WORKSPACE
+++ b/examples/esbuild/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/examples/jest/WORKSPACE
+++ b/examples/jest/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/examples/parcel/WORKSPACE
+++ b/examples/parcel/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "npm_install")
 
 npm_install(

--- a/examples/react_webpack/WORKSPACE
+++ b/examples/react_webpack/WORKSPACE
@@ -11,6 +11,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/examples/vendored_node/WORKSPACE
+++ b/examples/vendored_node/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 http_archive(
     name = "vendored_node_15_0_1",
     build_file_content = """exports_files(["node-v15.0.1-linux-x64/bin/node"])""",

--- a/examples/vendored_node_and_yarn/WORKSPACE
+++ b/examples/vendored_node_and_yarn/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 http_archive(
     name = "vendored_node_10_12_0",
     build_file_content = """exports_files(["node-v10.12.0-linux-x64/bin/node"])""",

--- a/examples/vue/WORKSPACE
+++ b/examples/vue/WORKSPACE
@@ -11,6 +11,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "npm_install")
 
 node_repositories(

--- a/examples/worker/WORKSPACE
+++ b/examples/worker/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/index.bzl
+++ b/index.bzl
@@ -53,18 +53,8 @@ js_library = _js_library
 directory_file_path = _directory_file_path
 # ANY RULES ADDED HERE SHOULD BE DOCUMENTED, see index.for_docs.bzl
 
-# Allows us to avoid a transitive dependency on bazel_skylib from leaking to users
-def dummy_bzl_library(name, srcs = [], deps = [], visibility = ["//visibility:public"], **kwargs):
-    native.filegroup(
-        name = name,
-        srcs = srcs + deps,
-        visibility = visibility,
-    )
-
 # @unsorted-dict-items
 COMMON_REPLACEMENTS = {
-    # Replace loads from @bazel_skylib with the dummy rule above
-    "(load\\(\"@bazel_skylib//:bzl_library.bzl\", \"bzl_library\"\\))": "# bazel_skylib mocked out\n# $1\nload(\"@build_bazel_rules_nodejs//:index.bzl\", bzl_library = \"dummy_bzl_library\")",
     # Make sure we don't try to load from under tools/ which isn't in the distro
     "(load\\(\"//:tools/defaults.bzl\", .*\\))": "# defaults.bzl not included in distribution\n# $1",
     # Cleanup up package.json @bazel/foobar package deps for published packages:


### PR DESCRIPTION
This allows us to always publish regular bzl_library targets. We can also stop carefully vendoring skylib and shipping our own copy.
Eventually we would run into a provider problem, where our vendored copy doesn't have the same provider symbol as the real repo.

BREAKING CHANGE:

build_bazel_rules_nodejs now depends on bazel_skylib.
You can install it in your WORKSPACE directly, or use our helper macro like so:
