### PR TITLE
fix: add back old case in linker to close: https://github.com/bazelbu…

### DIFF
--- a/internal/linker/index.js
+++ b/internal/linker/index.js
@@ -339,7 +339,12 @@ function main(args, runfiles) {
             }
             const packagePathBin = path.posix.join(bin, packagePath);
             yield mkdirp(`${packagePathBin}`);
-            yield symlinkWithUnlink(execrootNodeModules, `${packagePathBin}/node_modules`);
+            if (workspace && !packagePath && (yield exists(execrootNodeModules))) {
+                yield symlinkWithUnlink(execrootNodeModules, `node_modules`);
+            }
+            else {
+                yield symlinkWithUnlink(execrootNodeModules, `${packagePathBin}/node_modules`);
+            }
             if (!isExecroot) {
                 const runfilesPackagePath = path.posix.join(startCwd, packagePath);
                 yield mkdirp(`${runfilesPackagePath}`);

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -505,7 +505,11 @@ export async function main(args: string[], runfiles: Runfiles) {
     // Bin symlink -> execroot node_modules
     const packagePathBin = path.posix.join(bin, packagePath);
     await mkdirp(`${packagePathBin}`);
-    await symlinkWithUnlink(execrootNodeModules, `${packagePathBin}/node_modules`);
+    if (workspace && !packagePath && (await exists(execrootNodeModules))) {
+      await symlinkWithUnlink(execrootNodeModules, `node_modules`);
+    } else {
+      await symlinkWithUnlink(execrootNodeModules, `${packagePathBin}/node_modules`);
+    }
     
     // Start CWD symlink -> execroot node_modules
     if (!isExecroot) {


### PR DESCRIPTION
…ild/rules_nodejs/issues/3054

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

I'm not as familiar with how to write tests for the linker but given some of the cases were removed on a refactor we might want to define which cases to support somewhere and write tests for them. I would be happy to help with this when I have time. It seems that none of the rules in this repo hit that case and that's why it went unnoticed.

Also not sure if other cases that the linker used to support are missing, just happened to to upgrading some rules and noticed a break between 4.4.1 and 4.4.2 with this case. Or the only case that changed was the one I used.

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
There was a refactor to the linker between 4.4.1 and 4.4.2 and a case seems to have been dropped. 

Issue Number:
https://github.com/bazelbuild/rules_nodejs/issues/3054

## What is the new behavior?
restore behaviour to the linker that was there before the refactor. This fixes the issue 3054.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
I don't want it to seem like I'm blaming the refactor, it seems as though the rules I was working on used a case others have not touched. Hopefully writing a test case for this will stop this from happening again.
