### PR TITLE
fix: #3054 regression in linker behavior in 4.4.2

### DIFF
--- a/internal/linker/index.js
+++ b/internal/linker/index.js
@@ -337,9 +337,11 @@ function main(args, runfiles) {
             else {
                 yield mkdirp(execrootNodeModules);
             }
-            const packagePathBin = path.posix.join(bin, packagePath);
-            yield mkdirp(`${packagePathBin}`);
-            yield symlinkWithUnlink(execrootNodeModules, `${packagePathBin}/node_modules`);
+            if (packagePath) {
+                const packagePathBin = path.posix.join(bin, packagePath);
+                yield mkdirp(`${packagePathBin}`);
+                yield symlinkWithUnlink(execrootNodeModules, `${packagePathBin}/node_modules`);
+            }
             if (!isExecroot) {
                 const runfilesPackagePath = path.posix.join(startCwd, packagePath);
                 yield mkdirp(`${runfilesPackagePath}`);

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -502,10 +502,15 @@ export async function main(args: string[], runfiles: Runfiles) {
       await mkdirp(execrootNodeModules);
     }
 
-    // Bin symlink -> execroot node_modules
-    const packagePathBin = path.posix.join(bin, packagePath);
-    await mkdirp(`${packagePathBin}`);
-    await symlinkWithUnlink(execrootNodeModules, `${packagePathBin}/node_modules`);
+    if (packagePath) {
+      // Bin symlink -> execroot node_modules
+      // NB: don't do this for the root of the bin tree since standard node_modules resolution
+      // will fall back to the execroot node_modules naturally
+      // See https://github.com/bazelbuild/rules_nodejs/issues/3054
+      const packagePathBin = path.posix.join(bin, packagePath);
+      await mkdirp(`${packagePathBin}`);
+      await symlinkWithUnlink(execrootNodeModules, `${packagePathBin}/node_modules`);
+    }
     
     // Start CWD symlink -> execroot node_modules
     if (!isExecroot) {


### PR DESCRIPTION
resolves: https://github.com/bazelbuild/rules_nodejs/issues/3054

This restores the linker behaviour from 4.4.1.

The problem seems to be that after the refactor in 4.4.2, the linker is now creating a node_modules symlink at the root of the bazel-out tree where as before the refactor it wasn't.

In short, in 4.4.2 there is now node_modules symlinked at,

`execroot/<wksp>/bazel-out/darwin-fastbuild/bin/node_modules` -> `execroot/<wksp>/node_modules`

while in 4.4.1 this wasn't created.

The error for the nextjs build AFAICT is that it is resolving react to the two different node_modules trees in the build which is breaks the react build. React requires a single version at a single node_modules location. I've seen the error produced by next.js before due to this problem in another scenario:

```
Error occurred prerendering page "/500". Read more: https://nextjs.org/docs/messages/prerender-error
Error: Minified React error #321; visit https://reactjs.org/docs/error-decoder.html?invariant=321 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
```

The `execroot/<wksp>/bazel-out/darwin-fastbuild/bin/node_modules` is redundant anyway since standard node_modules resolution will go down the tree and find `execroot/<wksp>/node_modules` without any extra help.