### PR TITLE
feat(esbuild): add option to disable metafile generation

### DIFF
--- a/docs/esbuild.md
+++ b/docs/esbuild.md
@@ -103,8 +103,9 @@ This will create an output directory containing all the code split chunks, along
 
 <pre>
 esbuild(<a href="#esbuild-name">name</a>, <a href="#esbuild-args">args</a>, <a href="#esbuild-args_json">args_json</a>, <a href="#esbuild-config">config</a>, <a href="#esbuild-define">define</a>, <a href="#esbuild-deps">deps</a>, <a href="#esbuild-entry_point">entry_point</a>, <a href="#esbuild-entry_points">entry_points</a>, <a href="#esbuild-external">external</a>, <a href="#esbuild-format">format</a>,
-        <a href="#esbuild-launcher">launcher</a>, <a href="#esbuild-link_workspace_root">link_workspace_root</a>, <a href="#esbuild-max_threads">max_threads</a>, <a href="#esbuild-minify">minify</a>, <a href="#esbuild-node_context_data">node_context_data</a>, <a href="#esbuild-output">output</a>, <a href="#esbuild-output_css">output_css</a>,
-        <a href="#esbuild-output_dir">output_dir</a>, <a href="#esbuild-output_map">output_map</a>, <a href="#esbuild-platform">platform</a>, <a href="#esbuild-sourcemap">sourcemap</a>, <a href="#esbuild-sources_content">sources_content</a>, <a href="#esbuild-splitting">splitting</a>, <a href="#esbuild-srcs">srcs</a>, <a href="#esbuild-target">target</a>)
+        <a href="#esbuild-launcher">launcher</a>, <a href="#esbuild-link_workspace_root">link_workspace_root</a>, <a href="#esbuild-max_threads">max_threads</a>, <a href="#esbuild-metafile">metafile</a>, <a href="#esbuild-minify">minify</a>, <a href="#esbuild-node_context_data">node_context_data</a>, <a href="#esbuild-output">output</a>,
+        <a href="#esbuild-output_css">output_css</a>, <a href="#esbuild-output_dir">output_dir</a>, <a href="#esbuild-output_map">output_map</a>, <a href="#esbuild-platform">platform</a>, <a href="#esbuild-sourcemap">sourcemap</a>, <a href="#esbuild-sources_content">sources_content</a>, <a href="#esbuild-splitting">splitting</a>, <a href="#esbuild-srcs">srcs</a>,
+        <a href="#esbuild-target">target</a>)
 </pre>
 
 Runs the esbuild bundler under Bazel
@@ -218,6 +219,12 @@ For general use, leave this attribute unset.
 
 Defaults to `0`
 
+<h4 id="esbuild-metafile">metafile</h4>
+
+(*Boolean*): if true, esbuild creates a metafile along the output
+
+Defaults to `True`
+
 <h4 id="esbuild-minify">minify</h4>
 
 (*Boolean*): Minifies the bundle with the built in minification.
@@ -306,7 +313,7 @@ Defaults to `[]`
 
 <h4 id="esbuild-target">target</h4>
 
-(*String*): Environment target (e.g. es2017, chrome58, firefox57, safari11, 
+(*String*): Environment target (e.g. es2017, chrome58, firefox57, safari11,
 edge16, node10, esnext). Default es2015.
 
 See https://esbuild.github.io/api/#target for more details

--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -70,7 +70,7 @@ def _esbuild_impl(ctx):
         # Also disable the log limit and show all logs
         "logLevel": "warning",
         "logLimit": 0,
-        "metafile": True,
+        "metafile": ctx.attr.metafile,
         "platform": ctx.attr.platform,
         "preserveSymlinks": True,
         "sourcesContent": ctx.attr.sources_content,
@@ -146,9 +146,10 @@ def _esbuild_impl(ctx):
     launcher_args.add("--esbuild_args=%s" % args_file.path)
 
     # add metafile
-    meta_file = ctx.actions.declare_file("%s_metadata.json" % ctx.attr.name)
-    outputs.append(meta_file)
-    launcher_args.add("--metafile=%s" % meta_file.path)
+    if ctx.attr.metafile:
+        meta_file = ctx.actions.declare_file("%s_metadata.json" % ctx.attr.name)
+        outputs.append(meta_file)
+        launcher_args.add("--metafile=%s" % meta_file.path)
 
     # add reference to the users args file, these are merged within the launcher
     if ctx.attr.args_json:
@@ -282,6 +283,11 @@ This can be useful if running many esbuild rule invocations in parallel, which h
 For general use, leave this attribute unset.
             """,
         ),
+        "metafile": attr.bool(
+            default = True,
+            doc = "if true, esbuild creates a metafile along the output",
+            mandatory = False,
+        ),
         "minify": attr.bool(
             default = False,
             doc = """Minifies the bundle with the built in minification.
@@ -350,7 +356,7 @@ See https://esbuild.github.io/api/#splitting and https://esbuild.github.io/api/#
         ),
         "target": attr.string(
             default = "es2015",
-            doc = """Environment target (e.g. es2017, chrome58, firefox57, safari11, 
+            doc = """Environment target (e.g. es2017, chrome58, firefox57, safari11,
 edge16, node10, esnext). Default es2015.
 
 See https://esbuild.github.io/api/#target for more details

--- a/packages/esbuild/launcher.js
+++ b/packages/esbuild/launcher.js
@@ -99,7 +99,7 @@ async function runOneBuild(args, userArgsFilePath, configFilePath) {
       ...getEsbuildArgs(userArgsFilePath)
     }
   }
-  
+
   if (configFilePath) {
     const config = await processConfigFile(configFilePath, args);
     args = {
@@ -107,12 +107,13 @@ async function runOneBuild(args, userArgsFilePath, configFilePath) {
       ...config
     };
   }
-  
-  const metafile = getFlag('--metafile');
-  
+
   try {
     const result = await esbuild.build(args);
-    writeFileSync(metafile, JSON.stringify(result.metafile));
+    if (result.metafile) {
+      const metafile = getFlag('--metafile');
+      writeFileSync(metafile, JSON.stringify(result.metafile));
+    }
   } catch (e) {
     console.error(e);
     process.exit(1);

--- a/packages/esbuild/test/metafile/BUILD.bazel
+++ b/packages/esbuild/test/metafile/BUILD.bazel
@@ -1,0 +1,24 @@
+load("//packages/esbuild:index.bzl", "esbuild")
+
+esbuild(
+    name = "lib",
+    srcs = [
+        ":main.js",
+    ],
+    entry_point = "main.js",
+    metafile = False,
+)
+
+sh_test(
+    name = "test",
+    size = "small",
+    srcs = [
+        "test.sh",
+    ],
+    args = [
+        "$(locations :lib)",
+    ],
+    data = [
+        ":lib",
+    ],
+)

--- a/packages/esbuild/test/metafile/test.sh
+++ b/packages/esbuild/test/metafile/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -uo pipefail;
+
+while [ "$#" -ne 0 ]; do
+  [[ "lib_metadata.json" == "$(basename $1)" ]] && exit 1;
+  shift;
+done


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Feature (please, look at the "Scope of the project" section in the README.md file)

## What is the current behavior?

`esbuild` always generates `*._metadata.json` file.

## What is the new behavior?

The new option `metafile` can turn of generation of the _metafile_.

This might be useful if one would like to inject the output into html as possible with `@bazel/rollup`.

## Does this PR introduce a breaking change?

- [x] No