### PR TITLE
fix(builtin): handle external repository file paths in js_library strip_prefix check

### DIFF
--- a/internal/js_library/test/strip_prefix/BUILD.bazel
+++ b/internal/js_library/test/strip_prefix/BUILD.bazel
@@ -15,3 +15,9 @@ nodejs_test(
     ],
     entry_point = "test.js",
 )
+
+nodejs_test(
+    name = "external_test",
+    data = ["@npm//very_testy"],
+    entry_point = "external_test.js",
+)

--- a/internal/js_library/test/strip_prefix/external_test.js
+++ b/internal/js_library/test/strip_prefix/external_test.js
@@ -1,0 +1,8 @@
+// Verify that we can load very_testy which is setup as a link
+// to a js_library with external files. See manual_build_file_contents of
+// @npm yarn_install in npm_deps.bzl
+const packageJson = require("very_testy/package.json")
+if (packageJson.name != "testy") {
+    const msg = `Expecting to require testy package via very_testy link of js_library with external files but got ${packageJson.name}`;
+    throw new Error(msg)
+}

--- a/npm_deps.bzl
+++ b/npm_deps.bzl
@@ -43,9 +43,27 @@ def npm_deps():
             "@test_multi_linker/lib-c2": "@build_bazel_rules_nodejs//internal/linker/test/multi_linker/lib_c",
             "@test_multi_linker/lib-d": "@build_bazel_rules_nodejs//internal/linker/test/multi_linker/lib_d",
             "@test_multi_linker/lib-d2": "@build_bazel_rules_nodejs//internal/linker/test/multi_linker/lib_d",
+            "very_testy": "@npm//:testy_copy_js_library",
         },
         package_json = "//:package.json",
         yarn_lock = "//:yarn.lock",
+        manual_build_file_contents = """
+# re-link node_modules/testy as node_modules/very_testy
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "copy_to_bin")
+copy_to_bin(
+    name = "testy_copy",
+    srcs = [
+        "node_modules/testy/package.json",
+        "node_modules/testy/index.js",
+    ],
+)
+js_library(
+    name = "testy_copy_js_library",
+    srcs = [":testy_copy"],
+    strip_prefix = "node_modules/testy",
+    visibility = ["//very_testy:__pkg__"],
+)
+""",
     )
 
     yarn_install(


### PR DESCRIPTION
Failure without the fix in `js_library.bzl`:

```
ERROR: /private/var/tmp/_bazel_gmagolan/e172f8159a8fef9694f6bd1b99308c59/external/npm/BUILD.bazel:57066:11: in _js_library rule @npm//:testy_copy_js_library: 
Traceback (most recent call last):
	File "/Users/gmagolan/oss/rules_nodejs/internal/js_library/js_library.bzl", line 243, column 30, in _impl
		path = _link_path(ctx, all_files),
	File "/Users/gmagolan/oss/rules_nodejs/internal/js_library/js_library.bzl", line 120, column 17, in _link_path
		fail("js_library %s strip_prefix path does not contain any of the provided sources" % ctx.label)
Error in fail: js_library @npm//:testy_copy_js_library strip_prefix path does not contain any of the provided sources
ERROR: Analysis of target '//internal/js_library/test/strip_prefix:external_test' failed; build aborted: Analysis of target '@npm//:testy_copy_js_library' failed
```