### PR TITLE
fix(builtin): provide a DeclarationInfo from js_library is any input files are directories (TreeArtifacts)

### DIFF
--- a/internal/js_library/js_library.bzl
+++ b/internal/js_library/js_library.bzl
@@ -157,7 +157,10 @@ def _impl(ctx):
             js_files.append(file)
 
         # register typings
-        if (
+        if file.is_directory:
+            # assume a directory contains typings since we can't know that it doesn't
+            typings.append(file)
+        elif (
             (
                 file.path.endswith(".d.ts") or
                 file.path.endswith(".d.ts.map") or

--- a/packages/typescript/test/ts_project/directory_declarations/BUILD.bazel
+++ b/packages/typescript/test/ts_project/directory_declarations/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "copy_file")
+load("//:index.bzl", "js_library")
+load("//packages/typescript:index.bzl", "ts_project")
+
+# Copy lib source directory to a TreeArtifact since bazel file.is_directory
+# function does detect source directories
+copy_file(
+    name = "lib_copy",
+    src = "lib",
+    # We must give this as the directory in order for it to appear on NODE_PATH
+    out = "lib_out",
+    # This attribute comes from rules_nodejs patch of
+    # https://github.com/bazelbuild/bazel-skylib/pull/323
+    is_directory = True,
+)
+
+js_library(
+    name = "lib_js_library",
+    package_name = "directory_declarations_lib",
+    srcs = [":lib_copy"],
+    package_path = package_name(),
+    strip_prefix = "lib_out",
+)
+
+ts_project(
+    name = "b",
+    srcs = ["b.ts"],
+    tsconfig = {},
+    deps = [":lib_js_library"],
+)

--- a/packages/typescript/test/ts_project/directory_declarations/b.ts
+++ b/packages/typescript/test/ts_project/directory_declarations/b.ts
@@ -1,0 +1,2 @@
+import * as lib from 'directory_declarations_lib/a'
+console.log(lib.a)

--- a/packages/typescript/test/ts_project/directory_declarations/lib/a.d.ts
+++ b/packages/typescript/test/ts_project/directory_declarations/lib/a.d.ts
@@ -1,0 +1,1 @@
+export declare const a: string;


### PR DESCRIPTION
Error in the test case without the fix:

```
ERROR: /Users/greg/oss/rules_nodejs/packages/typescript/test/ts_project/directory_declarations/BUILD.bazel:25:11: in deps attribute of ts_project rule //packages/typescript/test/ts_project/directory_declarations:b: '//packages/typescript/test/ts_project/directory_declarations:lib_js_library' does not have mandatory providers: 'DeclarationInfo' or '_ValidOptionsInfo'. Since this rule was created by the macro 'ts_project_macro', the error might have been caused by the macro implementation
ERROR: Analysis of target '//packages/typescript/test/ts_project/directory_declarations:b' failed; build aborted: Analysis of target '//packages/typescript/test/ts_project/directory_declarations:b' failed
```