### PR TITLE
chore: bump versioned browsers for rules_webtesting to 0.3.3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -123,7 +123,7 @@ load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories"
 
 web_test_repositories()
 
-load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.2.bzl", "browser_repositories")
+load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
 
 browser_repositories(
     chromium = True,

--- a/docs/Concatjs.md
+++ b/docs/Concatjs.md
@@ -142,7 +142,7 @@ load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories"
 
 web_test_repositories()
 
-load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.2.bzl", "browser_repositories")
+load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
 
 browser_repositories(
     chromium = True,

--- a/docs/Karma.md
+++ b/docs/Karma.md
@@ -31,7 +31,7 @@ load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories"
 
 web_test_repositories()
 
-load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.2.bzl", "browser_repositories")
+load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
 
 browser_repositories(
     chromium = True,

--- a/e2e/concatjs_devserver/WORKSPACE
+++ b/e2e/concatjs_devserver/WORKSPACE
@@ -42,7 +42,7 @@ load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories"
 
 web_test_repositories()
 
-load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.2.bzl", "browser_repositories")
+load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
 
 browser_repositories(
     chromium = True,

--- a/e2e/concatjs_devserver_directory_artifacts/WORKSPACE
+++ b/e2e/concatjs_devserver_directory_artifacts/WORKSPACE
@@ -43,7 +43,7 @@ load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories"
 
 web_test_repositories()
 
-load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.2.bzl", "browser_repositories")
+load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
 
 browser_repositories(
     chromium = True,

--- a/examples/angular/WORKSPACE
+++ b/examples/angular/WORKSPACE
@@ -80,7 +80,7 @@ load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories"
 
 web_test_repositories()
 
-load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.2.bzl", "browser_repositories")
+load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
 
 browser_repositories(
     chromium = True,

--- a/examples/app/WORKSPACE
+++ b/examples/app/WORKSPACE
@@ -45,7 +45,7 @@ load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories"
 
 web_test_repositories()
 
-load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.2.bzl", "browser_repositories")
+load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
 
 browser_repositories(
     chromium = True,

--- a/examples/web_testing/WORKSPACE
+++ b/examples/web_testing/WORKSPACE
@@ -43,7 +43,7 @@ load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories"
 
 web_test_repositories()
 
-load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.2.bzl", "browser_repositories")
+load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
 
 browser_repositories(
     chromium = True,

--- a/examples/webapp/WORKSPACE
+++ b/examples/webapp/WORKSPACE
@@ -43,7 +43,7 @@ load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories"
 
 web_test_repositories()
 
-load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.2.bzl", "browser_repositories")
+load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
 
 browser_repositories(
     chromium = True,

--- a/packages/concatjs/index.docs.bzl
+++ b/packages/concatjs/index.docs.bzl
@@ -153,7 +153,7 @@ load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories"
 
 web_test_repositories()
 
-load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.2.bzl", "browser_repositories")
+load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
 
 browser_repositories(
     chromium = True,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No valid headless browsers or drivers are defined for M1 Mac hosts (Darwin arm64) in `browsers-0.3.2.bzl`, and tests fail.

Issue Number: https://github.com/bazelbuild/rules_nodejs/issues/3085


## What is the new behavior?
`browsers-0.3.3.bzl` defines browsers and drivers for M1 Mac hosts, and tests progress.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This does bump the versions of headless browsers being used, so there is possibility for regressions.
