### PR TITLE
fix: update tsconfigs to include darwin_arm64-fastbuild in rootDirs

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -526,6 +526,7 @@ Any code that works with `tsc` should work with `ts_project` with a few caveats:
 >         ".",
 >         "../../bazel-out/host/bin/path/to",
 >         "../../bazel-out/darwin-fastbuild/bin/path/to",
+>         "../../bazel-out/darwin_arm64-fastbuild/bin/path/to",
 >         "../../bazel-out/k8-fastbuild/bin/path/to",
 >         "../../bazel-out/x64_windows-fastbuild/bin/path/to",
 >         "../../bazel-out/darwin-dbg/bin/path/to",

--- a/examples/nestjs/tsconfig.json
+++ b/examples/nestjs/tsconfig.json
@@ -3,7 +3,12 @@
         "experimentalDecorators": true,
         "target": "ES2015",
         "module": "commonjs",
-        "rootDirs": [".", "bazel-out/k8-fastbuild/bin", "bazel-out/darwin-fastbuild/bin"],
+        "rootDirs": [
+            ".",
+            "bazel-out/k8-fastbuild/bin",
+            "bazel-out/darwin-fastbuild/bin",
+            "bazel-out/darwin_arm64-fastbuild/bin"
+        ],
         "declaration": true
     },
     "exclude": ["external"]

--- a/examples/protobufjs/tsconfig.json
+++ b/examples/protobufjs/tsconfig.json
@@ -8,6 +8,7 @@
       "rootDirs": [
           ".", 
           "bazel-out/darwin-fastbuild/bin",
+          "bazel-out/darwin_arm64-fastbuild/bin",
           "bazel-out/k8-fastbuild/bin",
           "bazel-out/x64_windows-fastbuild/bin",
           "bazel-out/darwin-dbg/bin",

--- a/examples/protocol_buffers/tsconfig.json
+++ b/examples/protocol_buffers/tsconfig.json
@@ -12,6 +12,7 @@
     "rootDirs": [
       ".",
       "bazel-out/darwin-fastbuild/bin",
+      "bazel-out/darwin_arm64-fastbuild/bin",
       "bazel-out/k8-fastbuild/bin",
       "bazel-out/x64_windows-fastbuild/bin",
       "bazel-out/darwin-dbg/bin",

--- a/packages/esbuild/test/ts_project/tsconfig.json
+++ b/packages/esbuild/test/ts_project/tsconfig.json
@@ -13,6 +13,7 @@
     "rootDirs": [
         ".",
         "../../../../bazel-out/darwin-fastbuild/bin/packages/esbuild/test/ts_project",
+        "../../../../bazel-out/darwin_arm64-fastbuild/bin/packages/esbuild/test/ts_project",
         "../../../../bazel-out/k8-fastbuild/bin/packages/esbuild/test/ts_project",
         "../../../../bazel-out/x64_windows-fastbuild/bin/packages/esbuild/test/ts_project",
         "../../../../bazel-out/darwin-dbg/bin/packages/esbuild/test/ts_project",

--- a/packages/rollup/test/ts_project/tsconfig.json
+++ b/packages/rollup/test/ts_project/tsconfig.json
@@ -11,6 +11,7 @@
     "rootDirs": [
         ".",
         "../../../../bazel-out/darwin-fastbuild/bin/packages/rollup/test/ts_project",
+        "../../../../bazel-out/darwin_arm64-fastbuild/bin/packages/rollup/test/ts_project",
         "../../../../bazel-out/k8-fastbuild/bin/packages/rollup/test/ts_project",
         "../../../../bazel-out/x64_windows-fastbuild/bin/packages/rollup/test/ts_project",
         "../../../../bazel-out/darwin-dbg/bin/packages/rollup/test/ts_project",

--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -425,6 +425,7 @@ def ts_project_macro(
     >         ".",
     >         "../../bazel-out/host/bin/path/to",
     >         "../../bazel-out/darwin-fastbuild/bin/path/to",
+    >         "../../bazel-out/darwin_arm64-fastbuild/bin/path/to",
     >         "../../bazel-out/k8-fastbuild/bin/path/to",
     >         "../../bazel-out/x64_windows-fastbuild/bin/path/to",
     >         "../../bazel-out/darwin-dbg/bin/path/to",

--- a/packages/typescript/test/ts_project/empty_intermediate/tsconfig-c.json
+++ b/packages/typescript/test/ts_project/empty_intermediate/tsconfig-c.json
@@ -5,6 +5,7 @@
         "rootDirs": [
             ".",
             "../../../../../bazel-out/darwin-fastbuild/bin/packages/typescript/test/ts_project/empty_intermediate",
+            "../../../../../bazel-out/darwin_arm64-fastbuild/bin/packages/typescript/test/ts_project/empty_intermediate",
             "../../../../../bazel-out/k8-fastbuild/bin/packages/typescript/test/ts_project/empty_intermediate",
             "../../../../../bazel-out/x64_windows-fastbuild/bin/packages/typescript/test/ts_project/empty_intermediate",
             "../../../../../bazel-out/darwin-dbg/bin/packages/typescript/test/ts_project/empty_intermediate",

--- a/packages/typescript/test/ts_project/js_library/tsconfig.json
+++ b/packages/typescript/test/ts_project/js_library/tsconfig.json
@@ -7,6 +7,7 @@
         "rootDirs": [
             ".",
             "../../../../../bazel-out/darwin-fastbuild/bin/packages/typescript/test/ts_project/js_library",
+            "../../../../../bazel-out/darwin_arm64-fastbuild/bin/packages/typescript/test/ts_project/js_library",
             "../../../../../bazel-out/k8-fastbuild/bin/packages/typescript/test/ts_project/js_library",
             "../../../../../bazel-out/x64_windows-fastbuild/bin/packages/typescript/test/ts_project/js_library",
             "../../../../../bazel-out/darwin-dbg/bin/packages/typescript/test/ts_project/js_library",

--- a/packages/typescript/test/ts_project/tsconfig-base.json
+++ b/packages/typescript/test/ts_project/tsconfig-base.json
@@ -12,6 +12,7 @@
         "rootDirs": [
             ".",
             "../../../../bazel-out/darwin-fastbuild/bin/packages/typescript/test/ts_project",
+            "../../../../bazel-out/darwin_arm64-fastbuild/bin/packages/typescript/test/ts_project",
             "../../../../bazel-out/k8-fastbuild/bin/packages/typescript/test/ts_project",
             "../../../../bazel-out/x64_windows-fastbuild/bin/packages/typescript/test/ts_project",
             "../../../../bazel-out/darwin-dbg/bin/packages/typescript/test/ts_project",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
ts output files cannot be found when building test and example code on an M1 Mac (Darwin arm64) host. This is because the `tsconfig.json` files look in specific `bazel-out` directories, and `darwin_arm64-fastbuild` is not on that list.

Issue Number: https://github.com/bazelbuild/rules_nodejs/issues/3085


## What is the new behavior?
`darwin_arm64-fastbuild` will be included in typescript's search for output files.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

