### PR TITLE
fix: allow cypress to run on m1 macs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -112,6 +112,7 @@ load("//packages/cypress:index.bzl", "cypress_repositories")
 
 cypress_repositories(
     name = "cypress",
+    darwin_arm64_sha256 = "101a0ced77fb74b356800cb3a3919f5288d23cc63fdd39a0c500673159e954fc",
     darwin_sha256 = "101a0ced77fb74b356800cb3a3919f5288d23cc63fdd39a0c500673159e954fc",
     linux_sha256 = "d8ea8d16fed33fdae8f17178bcae076aaf532fa7ccb48f377df1f143e60abd59",
     version = "7.3.0",

--- a/docs/Cypress.md
+++ b/docs/Cypress.md
@@ -350,7 +350,7 @@ Defaults to `[]`
 
 <pre>
 cypress_repositories(<a href="#cypress_repositories-name">name</a>, <a href="#cypress_repositories-version">version</a>, <a href="#cypress_repositories-linux_urls">linux_urls</a>, <a href="#cypress_repositories-linux_sha256">linux_sha256</a>, <a href="#cypress_repositories-darwin_urls">darwin_urls</a>, <a href="#cypress_repositories-darwin_sha256">darwin_sha256</a>,
-                     <a href="#cypress_repositories-windows_urls">windows_urls</a>, <a href="#cypress_repositories-windows_sha256">windows_sha256</a>)
+                     <a href="#cypress_repositories-darwin_arm64_urls">darwin_arm64_urls</a>, <a href="#cypress_repositories-darwin_arm64_sha256">darwin_arm64_sha256</a>, <a href="#cypress_repositories-windows_urls">windows_urls</a>, <a href="#cypress_repositories-windows_sha256">windows_sha256</a>)
 </pre>
 
     Repository rule used to install cypress binary.
@@ -391,6 +391,16 @@ Defaults to `[]`
 <h4 id="cypress_repositories-darwin_sha256">darwin_sha256</h4>
 
 (Optional) SHA-256 of the darwin cypress binary
+
+Defaults to `""`
+
+<h4 id="cypress_repositories-darwin_arm64_urls">darwin_arm64_urls</h4>
+
+
+Defaults to `[]`
+
+<h4 id="cypress_repositories-darwin_arm64_sha256">darwin_arm64_sha256</h4>
+
 
 Defaults to `""`
 

--- a/docs/Cypress.md
+++ b/docs/Cypress.md
@@ -384,7 +384,7 @@ Defaults to `""`
 
 <h4 id="cypress_repositories-darwin_urls">darwin_urls</h4>
 
-(Optional) URLs at which the cypress binary for darwin distros of linux can be downloaded. If omitted, https://cdn.cypress.io/desktop will be used.
+(Optional) URLs at which the cypress binary for darwin can be downloaded. If omitted, https://cdn.cypress.io/desktop will be used.
 
 Defaults to `[]`
 
@@ -396,11 +396,13 @@ Defaults to `""`
 
 <h4 id="cypress_repositories-darwin_arm64_urls">darwin_arm64_urls</h4>
 
+(Optional) URLs at which the cypress binary for darwin arm64 can be downloaded. If omitted, https://cdn.cypress.io/desktop will be used (note: as of this writing (11/2021), Cypress does not have native arm64 builds, and this URL will link to the x86_64 build to run under Rosetta).
 
 Defaults to `[]`
 
 <h4 id="cypress_repositories-darwin_arm64_sha256">darwin_arm64_sha256</h4>
 
+(Optional) SHA-256 of the darwin arm64 cypress binary
 
 Defaults to `""`
 

--- a/docs/Toolchains.md
+++ b/docs/Toolchains.md
@@ -154,7 +154,7 @@ Defaults to `{}`
 
 <pre>
 cypress_repositories(<a href="#cypress_repositories-name">name</a>, <a href="#cypress_repositories-version">version</a>, <a href="#cypress_repositories-linux_urls">linux_urls</a>, <a href="#cypress_repositories-linux_sha256">linux_sha256</a>, <a href="#cypress_repositories-darwin_urls">darwin_urls</a>, <a href="#cypress_repositories-darwin_sha256">darwin_sha256</a>,
-                     <a href="#cypress_repositories-windows_urls">windows_urls</a>, <a href="#cypress_repositories-windows_sha256">windows_sha256</a>)
+                     <a href="#cypress_repositories-darwin_arm64_urls">darwin_arm64_urls</a>, <a href="#cypress_repositories-darwin_arm64_sha256">darwin_arm64_sha256</a>, <a href="#cypress_repositories-windows_urls">windows_urls</a>, <a href="#cypress_repositories-windows_sha256">windows_sha256</a>)
 </pre>
 
     Repository rule used to install cypress binary.
@@ -195,6 +195,16 @@ Defaults to `[]`
 <h4 id="cypress_repositories-darwin_sha256">darwin_sha256</h4>
 
 (Optional) SHA-256 of the darwin cypress binary
+
+Defaults to `""`
+
+<h4 id="cypress_repositories-darwin_arm64_urls">darwin_arm64_urls</h4>
+
+
+Defaults to `[]`
+
+<h4 id="cypress_repositories-darwin_arm64_sha256">darwin_arm64_sha256</h4>
+
 
 Defaults to `""`
 

--- a/docs/Toolchains.md
+++ b/docs/Toolchains.md
@@ -188,7 +188,7 @@ Defaults to `""`
 
 <h4 id="cypress_repositories-darwin_urls">darwin_urls</h4>
 
-(Optional) URLs at which the cypress binary for darwin distros of linux can be downloaded. If omitted, https://cdn.cypress.io/desktop will be used.
+(Optional) URLs at which the cypress binary for darwin can be downloaded. If omitted, https://cdn.cypress.io/desktop will be used.
 
 Defaults to `[]`
 
@@ -200,11 +200,13 @@ Defaults to `""`
 
 <h4 id="cypress_repositories-darwin_arm64_urls">darwin_arm64_urls</h4>
 
+(Optional) URLs at which the cypress binary for darwin arm64 can be downloaded. If omitted, https://cdn.cypress.io/desktop will be used (note: as of this writing (11/2021), Cypress does not have native arm64 builds, and this URL will link to the x86_64 build to run under Rosetta).
 
 Defaults to `[]`
 
 <h4 id="cypress_repositories-darwin_arm64_sha256">darwin_arm64_sha256</h4>
 
+(Optional) SHA-256 of the darwin arm64 cypress binary
 
 Defaults to `""`
 

--- a/examples/cypress/WORKSPACE
+++ b/examples/cypress/WORKSPACE
@@ -45,6 +45,7 @@ load("@build_bazel_rules_nodejs//toolchains/cypress:cypress_repositories.bzl", "
 
 cypress_repositories(
     name = "cypress",
+    darwin_arm64_sha256 = "101a0ced77fb74b356800cb3a3919f5288d23cc63fdd39a0c500673159e954fc",
     darwin_sha256 = "101a0ced77fb74b356800cb3a3919f5288d23cc63fdd39a0c500673159e954fc",
     linux_sha256 = "d8ea8d16fed33fdae8f17178bcae076aaf532fa7ccb48f377df1f143e60abd59",
     version = "7.3.0",

--- a/toolchains/cypress/BUILD.bazel
+++ b/toolchains/cypress/BUILD.bazel
@@ -28,6 +28,7 @@ toolchain_type(name = "toolchain_type")
     cypress_files = "@cypress_%s//:files" % os_name,
 ) for os_name in [
     "darwin",
+    "darwin_arm64",
     "linux",
     "windows",
 ]]
@@ -37,7 +38,8 @@ toolchain_type(name = "toolchain_type")
 alias(
     name = "toolchain",
     actual = select({
-        "@bazel_tools//src/conditions:darwin": ":cypress_darwin_toolchain_config",
+        "@bazel_tools//src/conditions:darwin_x86_64": ":cypress_darwin_toolchain_config",
+        "@bazel_tools//src/conditions:darwin_arm64": ":cypress_darwin_arm64_toolchain_config",
         "@bazel_tools//src/conditions:linux_x86_64": ":cypress_linux_toolchain_config",
         "@bazel_tools//src/conditions:windows": ":cypress_windows_toolchain_config",
         "//conditions:default": ":cypress_linux_toolchain_config",
@@ -49,7 +51,8 @@ alias(
 alias(
     name = "cypress_bin",
     actual = select({
-        "@bazel_tools//src/conditions:darwin": "@cypress_darwin//:bin",
+        "@bazel_tools//src/conditions:darwin_x86_64": "@cypress_darwin//:bin",
+        "@bazel_tools//src/conditions:darwin_arm64": "@cypress_darwin_arm64//:bin",
         "@bazel_tools//src/conditions:linux_x86_64": "@cypress_linux//:bin",
         "@bazel_tools//src/conditions:windows": "@cypress_windows//:bin",
         "//conditions:default": "@cypress_linux//:bin",
@@ -71,10 +74,19 @@ toolchain(
     name = "cypress_darwin_toolchain",
     target_compatible_with = [
         "@platforms//os:osx",
-        # Cypress does not currently have any arm builds, but arm64 macs can run
-        # Cypress x86_64 via rosetta, so we won't restrict CPU for the macos platform.
+        "@platforms//cpu:x86_64",
     ],
     toolchain = ":cypress_darwin_toolchain_config",
+    toolchain_type = ":toolchain_type",
+)
+
+toolchain(
+    name = "cypress_darwin_arm64_toolchain",
+    target_compatible_with = [
+        "@platforms//os:osx",
+        "@platforms//cpu:arm64",
+    ],
+    toolchain = ":cypress_darwin_arm64_toolchain_config",
     toolchain_type = ":toolchain_type",
 )
 

--- a/toolchains/cypress/BUILD.bazel
+++ b/toolchains/cypress/BUILD.bazel
@@ -71,7 +71,8 @@ toolchain(
     name = "cypress_darwin_toolchain",
     target_compatible_with = [
         "@platforms//os:osx",
-        "@platforms//cpu:x86_64",
+        # Cypress does not currently have any arm builds, but arm64 macs can run
+        # Cypress x86_64 via rosetta, so we won't restrict CPU for the macos platform.
     ],
     toolchain = ":cypress_darwin_toolchain_config",
     toolchain_type = ":toolchain_type",

--- a/toolchains/cypress/cypress_repositories.bzl
+++ b/toolchains/cypress/cypress_repositories.bzl
@@ -36,8 +36,10 @@ def cypress_repositories(
         version: Version of cypress binary to use. Should match package.json
         linux_urls: (Optional) URLs at which the cypress binary for linux distros of linux can be downloaded. If omitted, https://cdn.cypress.io/desktop will be used.
         linux_sha256: (Optional) SHA-256 of the linux cypress binary
-        darwin_urls: (Optional) URLs at which the cypress binary for darwin distros of linux can be downloaded. If omitted, https://cdn.cypress.io/desktop will be used.
+        darwin_urls: (Optional) URLs at which the cypress binary for darwin can be downloaded. If omitted, https://cdn.cypress.io/desktop will be used.
         darwin_sha256: (Optional) SHA-256 of the darwin cypress binary
+        darwin_arm64_urls: (Optional) URLs at which the cypress binary for darwin arm64 can be downloaded. If omitted, https://cdn.cypress.io/desktop will be used (note: as of this writing (11/2021), Cypress does not have native arm64 builds, and this URL will link to the x86_64 build to run under Rosetta).
+        darwin_arm64_sha256: (Optional) SHA-256 of the darwin arm64 cypress binary
         windows_urls: (Optional) URLs at which the cypress binary for windows distros of linux can be downloaded. If omitted, https://cdn.cypress.io/desktop will be used.
         windows_sha256: (Optional) SHA-256 of the windows cypress binary
     """

--- a/toolchains/cypress/cypress_repositories.bzl
+++ b/toolchains/cypress/cypress_repositories.bzl
@@ -24,6 +24,8 @@ def cypress_repositories(
         linux_sha256 = "",
         darwin_urls = [],
         darwin_sha256 = "",
+        darwin_arm64_urls = [],
+        darwin_arm64_sha256 = "",
         windows_urls = [],
         windows_sha256 = ""):
     """
@@ -84,6 +86,32 @@ filegroup(
     )
 
     http_archive(
+        name = "cypress_darwin_arm64".format(name),
+        sha256 = darwin_arm64_sha256,
+        # Cypress checks that the binary path matches **/Contents/MacOS/Cypress so we do not strip that particular prefix.
+        urls = darwin_arm64_urls + [
+            # Note: there is currently no arm64 builds of cypress, so here we'll default to
+            # the x64 version so apple silicon macs can run the binary using Rosetta.
+            # Once a native arm64 build is available, this should be updated
+            "https://cdn.cypress.io/desktop/{}/darwin-x64/cypress.zip".format(version),
+        ],
+        build_file_content = """
+filegroup(
+    name = "files",
+    srcs = ["Cypress.app"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "bin",
+    # Cypress checks that the binary path matches **/Contents/MacOS/Cypress
+    srcs = ["Cypress.app/Contents/MacOS/Cypress"],
+    visibility = ["//visibility:public"],
+)
+""",
+    )
+
+    http_archive(
         name = "cypress_linux".format(name),
         sha256 = linux_sha256,
         urls = linux_urls + [
@@ -105,6 +133,6 @@ filegroup(
     )
 
     # This needs to be setup so toolchains can access nodejs for all different versions
-    for os_name in ["windows", "darwin", "linux"]:
+    for os_name in ["windows", "darwin", "darwin_arm64", "linux"]:
         toolchain_label = Label("@build_bazel_rules_nodejs//toolchains/cypress:cypress_{}_toolchain".format(os_name))
         native.register_toolchains("@{}//{}:{}".format(toolchain_label.workspace_name, toolchain_label.package, toolchain_label.name))


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Bazel fails to run Cypress tests with an M1 Mac (Darwin arm64) host, as it is unable to find a toolchain that doesn't limit the host to an x86 CPU.

Issue Number: https://github.com/bazelbuild/rules_nodejs/issues/3085


## What is the new behavior?
The CPU architecture compatibility restriction is removed in this PR, so Cypress will run using the x86 build under rosetta (note: Cypress' [official take](https://www.cypress.io/blog/2021/01/20/running-cypress-on-the-apple-m1-silicon-arm-architecture-using-rosetta-2/) is: "the way to run Cypress on Apple M1 ARM chip is by using Intel emulation with Rosetta 2, Apple's translation layer."). As of opening this PR, Cypress still does not have a native arm64 build.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Discussion/Questions:
* Is this fine, or should we be defining a separate toolchain_config for `darwin_arm64` with another appropriately named toolchain and `@cypress_*`external which really just pulls the x86 build again under the hood?
* Should we add any documentation stating that rosetta is required on the host? (it's very likely that any mac developer will already have it installed)