### PR TITLE
fix: add arm64 as a platform to //packages/concatjs:docs_scrub_platform

### DIFF
--- a/packages/concatjs/BUILD.bazel
+++ b/packages/concatjs/BUILD.bazel
@@ -73,8 +73,7 @@ genrule(
     name = "docs_scrub_platform",
     srcs = ["README.md_"],
     outs = ["README.md"],
-    cmd = "sed -e 's#devserver:devserver_.*_amd64#devserver:devserver_[platform]#' <$< >$@ ; " +
-          "sed -e 's#devserver:devserver_.*_arm64#devserver:devserver_[platform]#' <$< >$@",
+    cmd = "sed -e 's#devserver:devserver_.*_a[mr][dm]64#devserver:devserver_[platform]#' <$< >$@",
     visibility = ["//docs:__pkg__"],
 )
 

--- a/packages/concatjs/BUILD.bazel
+++ b/packages/concatjs/BUILD.bazel
@@ -73,7 +73,8 @@ genrule(
     name = "docs_scrub_platform",
     srcs = ["README.md_"],
     outs = ["README.md"],
-    cmd = "sed -e 's#devserver:devserver_.*_amd64#devserver:devserver_[platform]#' <$< >$@",
+    cmd = "sed -e 's#devserver:devserver_.*_amd64#devserver:devserver_[platform]#' <$< >$@ ; " +
+          "sed -e 's#devserver:devserver_.*_arm64#devserver:devserver_[platform]#' <$< >$@",
     visibility = ["//docs:__pkg__"],
 )
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`bazel test //docs:check_concatjs` fails on an M1 mac (Darwin arm64) host, as only the `amd64` platform is scrubbed from the docs.

Issue Number: https://github.com/bazelbuild/rules_nodejs/issues/3085


## What is the new behavior?
Both `amd64` and `arm64` will be scrubbed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

