### PR TITLE
fix: remove trailing forward slash when resolving workspace root link in runfiles MANIFEST

### DIFF
--- a/internal/linker/index.js
+++ b/internal/linker/index.js
@@ -416,7 +416,7 @@ function main(args, runfiles) {
                             runfilesPath = runfilesPath.slice(externalPrefix.length);
                         }
                         else {
-                            runfilesPath = `${workspace}/${runfilesPath}`;
+                            runfilesPath = path.posix.join(workspace, runfilesPath);
                         }
                         try {
                             target = runfiles.resolve(runfilesPath);

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -623,7 +623,7 @@ export async function main(args: string[], runfiles: Runfiles) {
         if (runfilesPath.startsWith(externalPrefix)) {
           runfilesPath = runfilesPath.slice(externalPrefix.length);
         } else {
-          runfilesPath = `${workspace}/${runfilesPath}`;
+          runfilesPath = path.posix.join(workspace, runfilesPath);
         }
         try {
           target = runfiles.resolve(runfilesPath);


### PR DESCRIPTION
This regressed at some point between 3.3 and 4.4 releases.

The problem appears specific to binary targets (not build targets) that resolve from the MANIFEST.

Repro here: https://github.com/ssilve1989/bazel-playground on `bug/link_workspace_root` branch

```
❯ bazelisk run //packages/examples/node/helloworld
INFO: Invocation ID: a0fce2a3-518b-438c-a490-7614f1680c76
INFO: Analyzed target //packages/examples/node/helloworld:helloworld (1 packages loaded, 4 targets configured).
INFO: Found 1 target...
Target //packages/examples/node/helloworld:helloworld up-to-date:
  dist/bin/packages/examples/node/helloworld/helloworld.sh
  dist/bin/packages/examples/node/helloworld/helloworld_loader.js
  dist/bin/packages/examples/node/helloworld/helloworld_require_patch.js
INFO: Elapsed time: 3.259s, Critical Path: 2.96s
INFO: 5 processes: 1 internal, 4 darwin-sandbox.
INFO: Build completed successfully, 5 total actions
INFO: Build completed successfully, 5 total actions
Error: Cannot find module 'playground/packages/common/math/math'
Require stack:
- /private/var/tmp/_bazel_SSilvestri/0b924cd44f9ad5151fc11486fa79c02d/execroot/playground/bazel-out/darwin-fastbuild/bin/packages/examples/node/helloworld/helloworld.sh.runfiles/playground/packages/examples/node/helloworld/main.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (packages/examples/node/helloworld/main.js:3:16)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
```
