### PR TITLE
fix: don't symlink execroot node_modules with a package_path when under bazel run

### DIFF
--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -23,3 +23,6 @@ test --flaky_test_attempts=2
 # Expose the SSH_AUTH_SOCK variable to integration tests that need to run git_repository repository rules
 # This is needed by the CircleCI git-over-ssh environment
 test --test_env=SSH_AUTH_SOCK
+
+# Keep going after first failure
+build --keep_going

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -424,6 +424,9 @@ export async function main(args: string[], runfiles: Runfiles) {
   const isExecroot = startCwd == execroot;
   log_verbose('isExecroot:', isExecroot.toString());
 
+  const isBazelRun = !!process.env['BUILD_WORKSPACE_DIRECTORY']
+  log_verbose('isBazelRun:', isBazelRun.toString());
+
   if (!isExecroot && execroot) {
     // If we're not in the execroot and we've found one then change to the execroot
     // directory to create the node_modules symlinks
@@ -481,55 +484,66 @@ export async function main(args: string[], runfiles: Runfiles) {
       workspaceNodeModules = undefined;      
     }
 
+    let primaryNodeModules;
     if (packagePath) {
-      // In some cases packagePath may not exist in sandbox if there are no source deps
-      // and only generated file deps. we create it so that we that we can link to
-      // packagePath/node_modules since packagePathBin/node_modules is a symlink to
-      // packagePath/node_modules and is unguarded in launcher.sh as we allow symlinks to fall
-      // through to from output tree to source tree to prevent resolving the same npm package to
-      // multiple locations on disk
-      await mkdirp(packagePath);
-    }
+      const binNodeModules = path.posix.join(bin, packagePath, 'node_modules');
+      await mkdirp(path.dirname(binNodeModules));
+      
+      // Create bin/<package_path>/node_modules symlink
+      // (or empty directory if there are no 3rd party deps to symlink to)
+      if (workspaceNodeModules) {
+        await symlinkWithUnlink(workspaceNodeModules, binNodeModules);
+        primaryNodeModules = workspaceNodeModules;
+      } else {
+        await mkdirp(binNodeModules);
+        primaryNodeModules = binNodeModules;
+      }
 
-    // There are third party modules at this package path
-    const execrootNodeModules = path.posix.join(packagePath, `node_modules`);
-
-    if (workspaceNodeModules) {
-      // Execroot symlink -> external workspace node_modules
-      await symlinkWithUnlink(workspaceNodeModules, execrootNodeModules);
+      if (!isBazelRun) {
+        // Special case under bazel run where we don't want to create node_modules
+        // in an execroot under a package path as this will end up in the user's
+        // workspace via the package path folder symlink
+        const execrootNodeModules = path.posix.join(packagePath, 'node_modules');
+        await mkdirp(path.dirname(execrootNodeModules));
+        await symlinkWithUnlink(primaryNodeModules, execrootNodeModules);
+      }
     } else {
-      // Create an execroot node_modules directory since there are no third party node_modules to symlink to
-      await mkdirp(execrootNodeModules);
+      const execrootNodeModules = 'node_modules';
+
+      // Create execroot/node_modules symlink (or empty directory if there are
+      // no 3rd party deps to symlink to)
+      if (workspaceNodeModules) {
+        await symlinkWithUnlink(workspaceNodeModules, execrootNodeModules);
+        primaryNodeModules = workspaceNodeModules;
+      } else {
+        await mkdirp(execrootNodeModules);
+        primaryNodeModules = execrootNodeModules;
+      }
+
+      // NB: Don't create a bin/node_modules since standard node_modules
+      // resolution will fall back to the execroot node_modules naturally. See
+      // https://github.com/bazelbuild/rules_nodejs/issues/3054
     }
 
-    if (packagePath) {
-      // Bin symlink -> execroot node_modules
-      // NB: don't do this for the root of the bin tree since standard node_modules resolution
-      // will fall back to the execroot node_modules naturally
-      // See https://github.com/bazelbuild/rules_nodejs/issues/3054
-      const packagePathBin = path.posix.join(bin, packagePath);
-      await mkdirp(`${packagePathBin}`);
-      await symlinkWithUnlink(execrootNodeModules, `${packagePathBin}/node_modules`);
-    }
-
-    // Start CWD symlink -> execroot node_modules
+    // If start cwd was in runfiles then create
+    // start/cwd
     if (!isExecroot) {
-      const runfilesPackagePath = path.posix.join(startCwd, packagePath);
-      await mkdirp(`${runfilesPackagePath}`);
+      const runfilesNodeModules = path.posix.join(startCwd, packagePath, 'node_modules');
+      await mkdirp(path.dirname(runfilesNodeModules));
       // Don't link to the root execroot node_modules if there is a workspace node_modules.
       // Bazel will delete that symlink on rebuild in the ibazel run context.
-      await symlinkWithUnlink(!packagePath && workspaceNodeModules ? workspaceNodeModules : execrootNodeModules, `${runfilesPackagePath}/node_modules`);
+      await symlinkWithUnlink(primaryNodeModules, runfilesNodeModules);
     }
 
     // RUNFILES symlink -> execroot node_modules
     if (process.env['RUNFILES']) {
       const stat = await gracefulLstat(process.env['RUNFILES']);
       if (stat && stat.isDirectory()) {
-        const runfilesPackagePath = path.posix.join(process.env['RUNFILES'], workspace, packagePath);
-        await mkdirp(`${runfilesPackagePath}`);
+        const runfilesNodeModules = path.posix.join(process.env['RUNFILES'], workspace, 'node_modules');
+        await mkdirp(path.dirname(runfilesNodeModules));
         // Don't link to the root execroot node_modules if there is a workspace node_modules.
         // Bazel will delete that symlink on rebuild in the ibazel run context.
-        await symlinkWithUnlink(!packagePath && workspaceNodeModules ? workspaceNodeModules : execrootNodeModules, `${runfilesPackagePath}/node_modules`);
+        await symlinkWithUnlink(primaryNodeModules, runfilesNodeModules);
       }
     }
   }
@@ -593,7 +607,9 @@ export async function main(args: string[], runfiles: Runfiles) {
   }
 
   async function linkModules(package_path: string, m: LinkerTreeElement) {
-    const symlinkIn = package_path ? `${package_path}/node_modules` : 'node_modules';
+    const symlinkIn = package_path ?
+      path.posix.join(bin, package_path, 'node_modules') :
+      'node_modules';
 
     // ensure the parent directory exist
     if (path.dirname(m.name)) {

--- a/internal/node/node_patches.js
+++ b/internal/node/node_patches.js
@@ -486,7 +486,18 @@ const patcher = (fs = fs__default['default'], roots) => {
 };
 exports.patcher = patcher;
 function isOutPath(root, str) {
-    return !root || (!str.startsWith(root + path__default['default'].sep) && str !== root);
+    if (!root)
+        return true;
+    let strParts = str.split(path__default['default'].sep);
+    let rootParts = root.split(path__default['default'].sep);
+    let i = 0;
+    for (; i < rootParts.length && i < strParts.length; i++) {
+        if (rootParts[i] === strParts[i] || rootParts[i] === '*') {
+            continue;
+        }
+        break;
+    }
+    return i < rootParts.length;
 }
 exports.isOutPath = isOutPath;
 const escapeFunction = (roots) => {

--- a/packages/node-patches/src/fs.ts
+++ b/packages/node-patches/src/fs.ts
@@ -471,7 +471,18 @@ export const patcher = (fs: any = _fs, roots: string[]) => {
 };
 
 export function isOutPath(root: string, str: string) {
-  return !root || (!str.startsWith(root + path.sep) && str !== root);
+  if (!root)
+    return true;
+  let strParts = str.split(path.sep);
+  let rootParts = root.split(path.sep);
+  let i=0;
+  for (; i<rootParts.length && i<strParts.length; i++) {
+    if (rootParts[i] === strParts[i] || rootParts[i] === '*') {
+      continue;
+    }
+    break;
+  }
+  return i<rootParts.length;
 }
 
 export const escapeFunction = (roots: string[]) => {

--- a/packages/node-patches/test/fs/escape.ts
+++ b/packages/node-patches/test/fs/escape.ts
@@ -27,6 +27,21 @@ describe('escape function', () => {
     assert.ok(!isOutPath('/a/b', '/a/b/c/d'));
   });
 
+  it('isOutPath with wildcard is correct', () => {
+    assert.ok(isOutPath('/a/*', '/a'));
+    assert.ok(!isOutPath('/a/*', '/a/c/b'));
+    assert.ok(!isOutPath('/a/*', '/a/b'));
+    assert.ok(!isOutPath('/a/*', '/a/b/c/d'));
+    assert.ok(isOutPath('/a/*', '/b/b'));
+    assert.ok(isOutPath('/a/*', '/b/b/c/d'));
+    assert.ok(isOutPath('/*/b', '/a'));
+    assert.ok(isOutPath('/*/b', '/a/c/b'));
+    assert.ok(!isOutPath('/*/b', '/a/b'));
+    assert.ok(!isOutPath('/*/b', '/a/b/c/d'));
+    assert.ok(!isOutPath('/*/b', '/b/b'));
+    assert.ok(!isOutPath('/*/b', '/b/b/c/d'));
+  });
+
   it('isEscape is correct', () => {
     const roots = [
       '/a/b',


### PR DESCRIPTION
In the bazel run context there is no sandbox so node_modules not at the root (with a package_path in their `yarn_install` or `npm_install` rules) that as symlinked to a folder such as `execroot/<workspace>/<package_path>/node_modules` will end up in the user's workspace since `execroot/<workspace>/<package_path>` is a symlink into the user's workspace. This can lead to non-determinstic behavior and a corruption of the bazel managed node_modules if a user then runs `yarn install` or `npm install` outside of bazel. Those tools will follow the symlink that bazel left behind and operate in the bazel managed `node_modules` in the external repository created by `yarn_install` or `npm_install`.

With this change, the "primary" `node_modules` (where the linker symlinks 1p deps into and where other `node_modules` locations symlink to) for a node_modules within a package (ie, `.../<package_path>/node_modules`) is now the bin location since the execroot location may not exist in the `bazel run` context.

The node patches are upgraded to supported * segments in guarded roots so launcher can guard `bazel-out/*/bin/<package_path>/node_modules` directories.