### PR TITLE
fix(esbuild): format attribute not working with multiple entry points or output_dir

### DIFF
--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -97,6 +97,9 @@ def _esbuild_impl(ctx):
             "splitting": True,
         })
 
+    if ctx.attr.format:
+        args.update({"format": ctx.attr.format})
+
     if ctx.attr.output_dir:
         js_out = ctx.actions.declare_directory("%s" % ctx.attr.name)
         outputs.append(js_out)
@@ -117,9 +120,6 @@ def _esbuild_impl(ctx):
 
         if ctx.outputs.output_css:
             outputs.append(ctx.outputs.output_css)
-
-        if ctx.attr.format:
-            args.update({"format": ctx.attr.format})
 
         args.update({"outfile": js_out.path})
 

--- a/packages/esbuild/test/multiple_entries_commonjs/BUILD.bazel
+++ b/packages/esbuild/test/multiple_entries_commonjs/BUILD.bazel
@@ -1,0 +1,42 @@
+load("//:index.bzl", "nodejs_test")
+load("//packages/esbuild:index.bzl", "esbuild")
+load("//packages/typescript:index.bzl", "ts_library")
+
+ts_library(
+    name = "index",
+    srcs = ["index.ts"],
+    module_name = "lib",
+)
+
+ts_library(
+    name = "lib",
+    package_name = "lib",
+    srcs = [
+        "a.ts",
+        "b.ts",
+    ],
+    deps = [
+        ":index",
+        "@npm//@types/node",
+    ],
+)
+
+esbuild(
+    name = "bundle",
+    entry_points = [
+        "a.ts",
+        "b.ts",
+    ],
+    format = "cjs",
+    platform = "node",
+    deps = [":lib"],
+)
+
+nodejs_test(
+    name = "bundle_test",
+    data = [
+        "bundle.spec.js",
+        ":bundle",
+    ],
+    entry_point = ":bundle.spec.js",
+)

--- a/packages/esbuild/test/multiple_entries_commonjs/a.ts
+++ b/packages/esbuild/test/multiple_entries_commonjs/a.ts
@@ -1,0 +1,4 @@
+import * as path from 'path';
+import {NAME} from 'lib';
+
+console.log(`Hello ${NAME} from a.ts - ${path.sep}`);

--- a/packages/esbuild/test/multiple_entries_commonjs/b.ts
+++ b/packages/esbuild/test/multiple_entries_commonjs/b.ts
@@ -1,0 +1,4 @@
+import * as path from 'path';
+import {NAME} from 'lib';
+
+console.log(`Hello ${NAME} from b.ts - ${path.sep}`);

--- a/packages/esbuild/test/multiple_entries_commonjs/bundle.spec.js
+++ b/packages/esbuild/test/multiple_entries_commonjs/bundle.spec.js
@@ -1,0 +1,22 @@
+const {join} = require('path');
+const {readFileSync} = require('fs');
+
+const helper = require(process.env.BAZEL_NODE_RUNFILES_HELPER);
+const location = helper.resolve(
+    'build_bazel_rules_nodejs/packages/esbuild/test/multiple_entries_commonjs/bundle/');
+
+const a = readFileSync(join(location, 'a.js'), {encoding: 'utf8'});
+const b = readFileSync(join(location, 'b.js'), {encoding: 'utf8'});
+
+const aHasPathCommonJsRequire = a.includes('require("path")');
+const bHasPathCommonJsRequire = b.includes('require("path")');
+
+if (!aHasPathCommonJsRequire) {
+  console.error('Expected `a.js` file to contain a CommonJS require expression for `path`.');
+  process.exitCode = 3;
+}
+
+if (!bHasPathCommonJsRequire) {
+  console.error('Expected `b.js` file to contain a CommonJS require expression for `path`.');
+  process.exitCode = 3;
+}

--- a/packages/esbuild/test/multiple_entries_commonjs/index.ts
+++ b/packages/esbuild/test/multiple_entries_commonjs/index.ts
@@ -1,0 +1,1 @@
+export const NAME = 'bazel';


### PR DESCRIPTION
Fixes that the `format` attribute does not work if multiple entry points
or the `output_dir` option is used.
