### PR TITLE
fix(esbuild): do not ignore annotations when the `minify` shorthand attribute is `false`

### DIFF
--- a/packages/esbuild/esbuild.bzl
+++ b/packages/esbuild/esbuild.bzl
@@ -84,10 +84,6 @@ def _esbuild_impl(ctx):
 
     if ctx.attr.minify:
         args.update({"minify": True})
-    else:
-        # by default, esbuild will tree-shake 'pure' functions
-        # disable this unless also minifying
-        args.update({"ignoreAnnotations": True})
 
     if ctx.attr.splitting:
         if not ctx.attr.output_dir:


### PR DESCRIPTION
Pure annotations are currently always ignored if `esbuild(minify = False)`. There are
cases where a consumer will set fine-grained minification options through `args`, but
currently cannot do this without setting `minify = True` as otherwise pure annotations
would always be preserved.

This magical behavior should be removed and the consumer should be
responsible for enabling this if tree-shaking is undesirable.
