### PR TITLE
chore: update default nodejs version to 16

### DIFF
--- a/docs/Built-ins.md
+++ b/docs/Built-ins.md
@@ -166,7 +166,7 @@ Defaults to `["https://nodejs.org/dist/v{version}/{filename}"]`
 
 (*String*): the specific version of NodeJS to install or, if vendored_node is specified, the vendored version of node
 
-Defaults to `"14.17.5"`
+Defaults to `"16.12.0"`
 
 <h4 id="node_repositories-package_json">package_json</h4>
 

--- a/examples/parcel/WORKSPACE
+++ b/examples/parcel/WORKSPACE
@@ -29,7 +29,29 @@ load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_depende
 
 rules_nodejs_dependencies()
 
-load("@build_bazel_rules_nodejs//:index.bzl", "npm_install")
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "npm_install")
+
+node_repositories(
+    # with node 16, this example fails on circleCI, because
+    # parcel has a gyp build on install that fails due to wrong
+    # version of the python interpreter:
+    # npm ERR! code 1
+    # npm ERR! path /tmp/tmp-22804uFaivyUQN3f5/node_modules/deasync
+    # npm ERR! command failed
+    # npm ERR! command sh -c node ./build.js
+    # npm ERR! gyp info it worked if it ends with ok
+    # npm ERR! gyp info using node-gyp@8.2.0
+    # npm ERR! gyp info using node@16.12.0 | linux | x64
+    # npm ERR! gyp ERR! find Python
+    # npm ERR! gyp ERR! find Python Python is not set from command line or npm configuration
+    # npm ERR! gyp ERR! find Python Python is not set from environment variable PYTHON
+    # npm ERR! gyp ERR! find Python checking if "python3" can be used
+    # npm ERR! gyp ERR! find Python - executable path is "/usr/bin/python3"
+    # npm ERR! gyp ERR! find Python - version is "3.5.3"
+    # npm ERR! gyp ERR! find Python - version is 3.5.3 - should be >=3.6.0
+    # npm ERR! gyp ERR! find Python - THIS VERSION OF PYTHON IS NOT SUPPORTED
+    node_version = "14.17.5",
+)
 
 npm_install(
     name = "npm",

--- a/nodejs/repositories.bzl
+++ b/nodejs/repositories.bzl
@@ -8,7 +8,7 @@ load("//nodejs/private:yarn_versions.bzl", "YARN_VERSIONS")
 load("//third_party/github.com/bazelbuild/bazel-skylib:lib/paths.bzl", "paths")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-DEFAULT_NODE_VERSION = "14.17.5"
+DEFAULT_NODE_VERSION = "16.12.0"
 
 BUILT_IN_NODE_PLATFORMS = PLATFORMS.keys()
 


### PR DESCRIPTION
As of 2021-10-26, v16 has entered LTS, so it's the most appropriate default.
Also, it provides darwin_arm releases (apple silicon) which many developers now expect.

BREAKING CHANGE:
The default nodejs version is now 16.12.0. To go back to the previous default, put this in your WORKSPACE:

```starlark
load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")

node_repositories(
    node_version = "14.17.5",
)
```

Fixes #3101
