### PR TITLE
chore: build_bazel_rules_nodejs depends on rules_nodejs

### DIFF
--- a/e2e/core/WORKSPACE
+++ b/e2e/core/WORKSPACE
@@ -8,10 +8,15 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-core-4.4.0.tar.gz"],
 )
 
-load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains", "rules_nodejs_dependencies")
+# Note: skylib 1.1.1 has some bug on Windows with diff_test, which we use in this example
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "afbe4d9d033c007940acd24bb9becf1580a0280ae0b2ebbb5a7cb12912d2c115",
+    strip_prefix = "bazel-skylib-ffad33e9bfc60bdfa98292ca655a4e7035792046",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/ffad33e9bfc60bdfa98292ca655a4e7035792046.tar.gz"],
+)
 
-# This just gives us bazel-skylib
-rules_nodejs_dependencies()
+load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
 
 nodejs_register_toolchains(
     name = "node16",

--- a/nodejs/repositories.bzl
+++ b/nodejs/repositories.bzl
@@ -7,6 +7,7 @@ load("//nodejs/private:toolchains_repo.bzl", "PLATFORMS", "toolchains_repo")
 load("//nodejs/private:yarn_versions.bzl", "YARN_VERSIONS")
 load("//third_party/github.com/bazelbuild/bazel-skylib:lib/paths.bzl", "paths")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 DEFAULT_NODE_VERSION = "16.12.0"
 
@@ -746,13 +747,19 @@ def nodejs_register_toolchains(name, **kwargs):
     )
 
 def rules_nodejs_dependencies():
-    if "bazel_skylib" not in native.existing_rules():
-        http_archive(
-            name = "bazel_skylib",
-            sha256 = "afbe4d9d033c007940acd24bb9becf1580a0280ae0b2ebbb5a7cb12912d2c115",
-            strip_prefix = "bazel-skylib-ffad33e9bfc60bdfa98292ca655a4e7035792046",
-            urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/ffad33e9bfc60bdfa98292ca655a4e7035792046.tar.gz",
-                "https://github.com/bazelbuild/bazel-skylib/archive/ffad33e9bfc60bdfa98292ca655a4e7035792046.tar.gz",
-            ],
-        )
+    maybe(
+        http_archive,
+        name = "bazel_skylib",
+        sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
+        urls = [
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+        ],
+    )
+    core_sha = "8f4a19de1eb16b57ac03a8e9b78344b44473e0e06b0510cec14a81f6adfdfc25"
+    maybe(
+        http_archive,
+        name = "rules_nodejs",
+        sha256 = core_sha,
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.6/rules_nodejs-core-4.4.6.tar.gz"],
+    )

--- a/scripts/on-release.js
+++ b/scripts/on-release.js
@@ -24,6 +24,10 @@ for (const f of ['docs/install.md', 'packages/create/index.js']) {
       `download/${version}/rules_nodejs-${version}.tar.gz`, f);
   shell.sed('-i', 'sha256 = \"[0-9a-f]+\"', `sha256 = "${sha256}"`, f);
 }
+shell.sed(
+  '-i', 'download/[0-9\.]*(-(beta|rc).[0-9]+)?/rules_nodejs-core-[0-9\.]*(-(beta|rc).[0-9]+)?.tar.gz',
+  `download/${version}/rules_nodejs-core-${version}.tar.gz`, 'nodejs/repositories.bzl')
+shell.sed('-i', 'core_sha = \"[0-9a-f]+\"', `core_sha = "${coreSha256}"`, 'nodejs/repositories.bzl');
 shell.cp('-f', artifact, `rules_nodejs-${version}.tar.gz`);
 shell.cp('-f', coreArtifact, `rules_nodejs-core-${version}.tar.gz`);
 


### PR DESCRIPTION
We should fetch the latter repo when users call our dependencies helper