### PR TITLE
Allow soft fail for "rbe_ubuntu1604"

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -359,6 +359,8 @@ tasks:
   rbe_ubuntu1604:
     name: rbe_ubuntu1604
     platform: rbe_ubuntu1604
+    soft_fail:
+      - exit_status: 1
     build_targets:
     - "//..."
     build_flags:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -359,6 +359,7 @@ tasks:
   rbe_ubuntu1604:
     name: rbe_ubuntu1604
     platform: rbe_ubuntu1604
+    # Remove soft_fail once https://github.com/bazelbuild/rules_nodejs/issues/3121 is fixed
     soft_fail:
       - exit_status: 1
     build_targets:


### PR DESCRIPTION
The "rbe_ubuntu1604" is failing with Bazel@HEAD for a long time, mark it as soft fail to not block the downstream pipeline turning green.
See https://github.com/bazelbuild/rules_nodejs/issues/3121

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

