### PR TITLE
chore: always install rules_nodejs_dependencies

### DIFF
--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -72,10 +72,6 @@ e2e_integration_test(
         "test ...",
         "run --platforms=@rules_nodejs//nodejs:linux_amd64 //:nodejs_image",
     ],
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-        "//:release-core": "rules_nodejs",
-    },
     # Only run on buildkite linux as other CI platforms have no docker available
     tags = [
         "no-bazelci-mac",
@@ -96,18 +92,10 @@ e2e_integration_test(
 
 e2e_integration_test(
     name = "e2e_symlinked_node_modules_npm",
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-        "//:release-core": "rules_nodejs",
-    },
 )
 
 e2e_integration_test(
     name = "e2e_symlinked_node_modules_yarn",
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-        "//:release-core": "rules_nodejs",
-    },
 )
 
 # terser rules are tested in the e2e_webapp
@@ -153,16 +141,6 @@ e2e_integration_test(
     },
     workspace_root = "typescript",
 ) for tsc_version in [
-    "3.0.x",
-    "3.1.x",
-    "3.2.x",
-    "3.3.x",
-    "3.4.x",
-    "3.5.x",
-    "3.6.x",
-    "3.7.x",
-    "3.8.x",
-    "3.9.x",
     "4.0.x",
     "4.1.x",
     "4.2.x",

--- a/e2e/coverage/WORKSPACE
+++ b/e2e/coverage/WORKSPACE
@@ -25,20 +25,15 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 # Load web_test_suite
 http_archive(
     name = "io_bazel_rules_webtesting",
     sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
     urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz"],
-)
-
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
-    urls = [
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-    ],
 )
 
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")

--- a/e2e/nodejs_image/WORKSPACE
+++ b/e2e/nodejs_image/WORKSPACE
@@ -25,13 +25,9 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
-# Temporary state: this example needs to have both build_bazel_rules_nodejs and rules_nodejs.
-# Once we have cut over the toolchains to rules_nodejs only, we shouldn't need this.
-http_archive(
-    name = "rules_nodejs",
-    sha256 = "a2b1b60c51b0193ed1646accf77a28cfd4f4ce1f6c86f32ce11455101be3a9c4",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.3/rules_nodejs-core-4.4.3.tar.gz"],
-)
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
 
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 

--- a/e2e/typescript/WORKSPACE
+++ b/e2e/typescript/WORKSPACE
@@ -25,20 +25,15 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 # Load web_test_suite
 http_archive(
     name = "io_bazel_rules_webtesting",
     sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
     urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz"],
-)
-
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
-    urls = [
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-    ],
 )
 
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -176,10 +176,6 @@ example_integration_test(
         "@rayman1104",
         "@siberex",
     ],
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-        "//:release-core": "rules_nodejs",
-    },
     # Fails on transitive dep of rules_docker
     # error running 'git init C:/users/b/_bazel_b/3oe2yqkh/external/rules_cc' while working with @rules_cc:
     # java.io.IOException: ERROR: src/main/native/windows/process.cc(199): CreateProcessW("git" init C:/users/b/_bazel_b/3oe2yqkh/external/rules_cc): The system cannot find the file specified
@@ -225,10 +221,6 @@ example_integration_test(
 example_integration_test(
     name = "examples_vue",
     npm_packages = {},
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-        "//:release-core": "rules_nodejs",
-    },
 )
 
 example_integration_test(
@@ -253,10 +245,6 @@ example_integration_test(
         "@alan-agius4",
         "@jbedard",
     ],
-    repositories = {
-        "//:release": "build_bazel_rules_nodejs",
-        "//:release-core": "rules_nodejs",
-    },
     tags = [
         # TODO(alexeagle): re-enable when it stops timing out on 4.x branch
         "manual",

--- a/examples/angular/WORKSPACE
+++ b/examples/angular/WORKSPACE
@@ -14,24 +14,18 @@ workspace(
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "bazel_skylib",
-    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
-    urls = [
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-    ],
-)
-
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
-
-# Fetch rules_nodejs so we can install our npm dependencies
-http_archive(
     name = "build_bazel_rules_nodejs",
     sha256 = "c9c5d60d6234d65b06f86abd5edc60cadd1699f739ee49d33a099d2d67eb1ae8",
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
+
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 # Fetch sass rules for compiling sass files
 http_archive(

--- a/examples/angular_bazel_architect/WORKSPACE
+++ b/examples/angular_bazel_architect/WORKSPACE
@@ -16,14 +16,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
-# Temporary state: this example needs to have both build_bazel_rules_nodejs and rules_nodejs.
-# Once we have cut over the toolchains to rules_nodejs only, we shouldn't need this.
-http_archive(
-    name = "rules_nodejs",
-    sha256 = "a2b1b60c51b0193ed1646accf77a28cfd4f4ce1f6c86f32ce11455101be3a9c4",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.3/rules_nodejs-core-4.4.3.tar.gz"],
-)
-
 load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
 
 rules_nodejs_dependencies()

--- a/examples/app/WORKSPACE
+++ b/examples/app/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/examples/create-react-app/WORKSPACE
+++ b/examples/create-react-app/WORKSPACE
@@ -11,14 +11,9 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
-    ],
-)
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
 
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 

--- a/examples/kotlin/WORKSPACE
+++ b/examples/kotlin/WORKSPACE
@@ -11,6 +11,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 # Install external npm dependencies
 load("@build_bazel_rules_nodejs//:index.bzl", "npm_install")
 

--- a/examples/nestjs/WORKSPACE
+++ b/examples/nestjs/WORKSPACE
@@ -25,13 +25,9 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
-# Temporary state: this example needs to have both build_bazel_rules_nodejs and rules_nodejs.
-# Once we have cut over the toolchains to rules_nodejs only, we shouldn't need this.
-http_archive(
-    name = "rules_nodejs",
-    sha256 = "a2b1b60c51b0193ed1646accf77a28cfd4f4ce1f6c86f32ce11455101be3a9c4",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.3/rules_nodejs-core-4.4.3.tar.gz"],
-)
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
 
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 

--- a/examples/protobufjs/WORKSPACE
+++ b/examples/protobufjs/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 http_archive(
     name = "rules_proto",
     sha256 = "66bfdf8782796239d3875d37e7de19b1d94301e8972b3cbd2446b332429b4df1",

--- a/examples/vue/WORKSPACE
+++ b/examples/vue/WORKSPACE
@@ -11,14 +11,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
-# Temporary state: this example needs to have both build_bazel_rules_nodejs and rules_nodejs.
-# Once we have cut over the toolchains to rules_nodejs only, we shouldn't need this.
-http_archive(
-    name = "rules_nodejs",
-    sha256 = "a2b1b60c51b0193ed1646accf77a28cfd4f4ce1f6c86f32ce11455101be3a9c4",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.3/rules_nodejs-core-4.4.3.tar.gz"],
-)
-
 load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
 
 rules_nodejs_dependencies()

--- a/examples/web_testing/WORKSPACE
+++ b/examples/web_testing/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/examples/webapp/WORKSPACE
+++ b/examples/webapp/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.0/rules_nodejs-4.4.0.tar.gz"],
 )
 
+load("@build_bazel_rules_nodejs//nodejs:repositories.bzl", "rules_nodejs_dependencies")
+
+rules_nodejs_dependencies()
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/internal/bazel_integration_test/bazel_integration_test.bzl
+++ b/internal/bazel_integration_test/bazel_integration_test.bzl
@@ -234,6 +234,10 @@ repositories = {
 where `//:release` is the pkg_tar target that generates the `build_bazel_rules_nodejs` `.tar.gz` release artifact that
 is published on GitHub.
 """,
+        default = {
+            "//:release": "build_bazel_rules_nodejs",
+            "//:release-core": "rules_nodejs",
+        },
     ),
     "workspace_files": attr.label(
         doc = """A filegroup of all files in the workspace-under-test necessary to run the test.""",
@@ -269,9 +273,6 @@ def rules_nodejs_integration_test(name, **kwargs):
         "exclusive",
     ]
 
-    # replace the following repositories with the generated archives
-    repositories = kwargs.pop("repositories", {"//:release": "build_bazel_rules_nodejs"})
-
     # convert the npm packages into the tar output
     npm_packages = kwargs.pop("npm_packages", {})
     _tar_npm_packages = {}
@@ -288,7 +289,6 @@ def rules_nodejs_integration_test(name, **kwargs):
         bazel_integration_test(
             name = "%s_%s" % (name, "bazel" + bazel_version) if bazel_version != BAZEL_VERSION else name,
             check_npm_packages = NPM_PACKAGES,
-            repositories = repositories,
             bazel_binary = "@build_bazel_bazel_%s//:bazel_binary" % bazel_version.replace(".", "_"),
             # some bazelrc imports are outside of the nested workspace so
             # the test runner will handle these as special cases


### PR DESCRIPTION
User install instructions will change to require this, so our nested example/e2e workspaces need to as well.
