### PR TITLE
fix(typescript): ts_project transpiler produces js_library

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -744,19 +744,9 @@ Defaults to `False`
 
 <h4 id="ts_project-transpiler">transpiler</h4>
 
-What tool to run that produces the JavaScript outputs.
-By default, this is the string `tsc`. With that value, `ts_project` expects `.js` outputs
-to be written in the same action that does the type-checking to produce `.d.ts` outputs.
-This is the simplest configuration, however `tsc` is slower than alternatives.
-It also means developers must wait for the type-checking in the developer loop.
+A custom transpiler tool to run that produces the JavaScript outputs instead of `tsc`.
 
-In theory, Persistent Workers (via the `supports_workers` attribute) remedies the
-slow compilation time, however it adds additional complexity because the worker process
-can only see one set of dependencies, and so it cannot be shared between different
-`ts_project` rules. That attribute is documented as experimental, and may never graduate
-to a better support contract.
-
-Instead of the string `tsc`, this attribute also accepts a rule or macro with this signature:
+This attribute accepts a rule or macro with this signature:
 `name, srcs, js_outs, map_outs, **kwargs`
 where the `**kwargs` attribute propagates the tags, visibility, and testonly attributes from `ts_project`.
 
@@ -766,7 +756,30 @@ to bind those arguments at the "make site", then pass that partial to this attri
 will be called with the remaining arguments.
 See the packages/typescript/test/ts_project/swc directory for an example.
 
-Defaults to `"tsc"`
+When a custom transpiler is used, then the `ts_project` macro expands to these targets:
+
+    - `[name]` - the default target is a `js_library` which can be included in the `deps` of downstream rules.
+        Note that it will successfully build *even if there are typecheck failures* because the `tsc` binary
+        is not needed to produce the default outputs.
+        This is considered a feature, as it allows you to have a faster development mode where type-checking
+        is not on the critical path.
+    - `[name]_typecheck` - this target will fail to build if the type-checking fails, useful for CI.
+    - `[name]_typings` - internal target which runs the binary from the `tsc` attribute
+    -  Any additional target(s) the custom transpiler rule/macro produces.
+        Some rules produce one target per TypeScript input file.
+
+By default, `ts_project` expects `.js` outputs to be written in the same action
+that does the type-checking to produce `.d.ts` outputs.
+This is the simplest configuration, however `tsc` is slower than alternatives.
+It also means developers must wait for the type-checking in the developer loop.
+
+In theory, Persistent Workers (via the `supports_workers` attribute) remedies the
+slow compilation time, however it adds additional complexity because the worker process
+can only see one set of dependencies, and so it cannot be shared between different
+`ts_project` rules. That attribute is documented as experimental, and may never graduate
+to a better support contract.
+
+Defaults to `None`
 
 <h4 id="ts_project-ts_build_info_file">ts_build_info_file</h4>
 

--- a/packages/typescript/test/ts_project/swc/BUILD.bazel
+++ b/packages/typescript/test/ts_project/swc/BUILD.bazel
@@ -1,6 +1,14 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//packages/typescript:index.bzl", "ts_project")
 load(":swc.bzl", "swc", "swc_macro")
+load(":tests.bzl", "test_suite")
+
+_TSCONFIG = {
+    "compilerOptions": {
+        "declaration": True,
+        "sourceMap": True,
+    },
+}
 
 write_file(
     name = "gen_ts",
@@ -11,16 +19,17 @@ write_file(
     ],
 )
 
+write_file(
+    name = "gen_typeerror",
+    out = "typeerror.ts",
+    content = ["export const a: string = 1"],
+)
+
 ts_project(
     name = "transpile_with_swc",
     srcs = ["big.ts"],
     transpiler = swc_macro,
-    tsconfig = {
-        "compilerOptions": {
-            "declaration": True,
-            "sourceMap": True,
-        },
-    },
+    tsconfig = _TSCONFIG,
 )
 
 ts_project(
@@ -31,10 +40,17 @@ ts_project(
         args = ["--env-name=test"],
         swcrc = "//:.swcrc",
     ),
-    tsconfig = {
-        "compilerOptions": {
-            "declaration": True,
-            "sourceMap": True,
-        },
-    },
+    tsconfig = _TSCONFIG,
 )
+
+ts_project(
+    name = "transpile_with_typeerror",
+    srcs = ["typeerror.ts"],
+    # The transpile_with_typeerror.check target will have a build failure
+    # But the default transpile_with_typeerror target should still produce JS outs
+    tags = ["manual"],
+    transpiler = swc_macro,
+    tsconfig = _TSCONFIG,
+)
+
+test_suite()

--- a/packages/typescript/test/ts_project/swc/tests.bzl
+++ b/packages/typescript/test/ts_project/swc/tests.bzl
@@ -1,0 +1,38 @@
+"Unit tests for starlark API of ts_project with custom transpiler"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//:providers.bzl", "DeclarationInfo", "JSModuleInfo")
+
+def _impl0(ctx):
+    env = unittest.begin(ctx)
+
+    decls = []
+    for decl in ctx.attr.lib[DeclarationInfo].declarations.to_list():
+        decls.append(decl.basename)
+    asserts.equals(env, ctx.attr.expected_declarations, sorted(decls))
+
+    return unittest.end(env)
+
+transitive_declarations_test = unittest.make(_impl0, attrs = {
+    "lib": attr.label(default = "transpile_with_swc"),
+    "expected_declarations": attr.string_list(default = ["big.d.ts"]),
+})
+
+def _impl1(ctx):
+    env = unittest.begin(ctx)
+
+    js_files = []
+    for js in ctx.attr.lib[JSModuleInfo].sources.to_list():
+        js_files.append(js.basename)
+    asserts.equals(env, ctx.attr.expected_js, sorted(js_files))
+
+    return unittest.end(env)
+
+transpile_with_failing_typecheck_test = unittest.make(_impl1, attrs = {
+    "lib": attr.label(default = "transpile_with_typeerror"),
+    "expected_js": attr.string_list(default = ["typeerror.js", "typeerror.js.map"]),
+})
+
+def test_suite():
+    unittest.suite("t0", transitive_declarations_test)
+    unittest.suite("t1", transpile_with_failing_typecheck_test)


### PR DESCRIPTION
This is needed so the .js files produced by the alternate transpiler
are passed down the dependency graph.
