### PR TITLE
Revert "fix(builtin): add transitive typings to runfiles provider pro…

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -51,6 +51,15 @@ type-checking and not for producing any build outputs.
 To use it, add the load statement `load("@npm//typescript:index.bzl", "tsc_test")` to your BUILD file.
 (Possibly replacing `@npm` with the name of the repository where you installed dependencies)
 
+To get the typings available in the test (as "runfiles"), you may need to gather them from dependencies if they
+are not included as default outputs of those dependencies, like so:
+
+```starlark
+filegroup(name = "types", srcs = ["//some:js_library"], output_group = "types")
+```
+
+And then include the `:types` target in the `data` of the `tsc_test`.
+
 See example in https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/tsc_test
 
 ### Option 3: ts_project

--- a/internal/js_library/js_library.bzl
+++ b/internal/js_library/js_library.bzl
@@ -225,8 +225,10 @@ def _impl(ctx):
 
     runfiles = ctx.runfiles(
         files = all_files,
+        # We do not include typings_depsets in the runfiles because that would cause type-check actions to occur
+        # in every development workflow.
         transitive_files = depset(
-            transitive = files_depsets + typings_depsets,
+            transitive = files_depsets,
         ),
     )
     deps_runfiles = [d[DefaultInfo].default_runfiles for d in ctx.attr.deps]

--- a/packages/typescript/index.docs.bzl
+++ b/packages/typescript/index.docs.bzl
@@ -63,6 +63,15 @@ type-checking and not for producing any build outputs.
 To use it, add the load statement `load("@npm//typescript:index.bzl", "tsc_test")` to your BUILD file.
 (Possibly replacing `@npm` with the name of the repository where you installed dependencies)
 
+To get the typings available in the test (as "runfiles"), you may need to gather them from dependencies if they
+are not included as default outputs of those dependencies, like so:
+
+```starlark
+filegroup(name = "types", srcs = ["//some:js_library"], output_group = "types")
+```
+
+And then include the `:types` target in the `data` of the `tsc_test`.
+
 See example in https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/tsc_test
 
 ### Option 3: ts_project


### PR DESCRIPTION
…duced by js_library (#2547)"

This wasn't actually a fix - it causes type-checking to happen eagerly
when a js_library target is built, even if the typings aren't needed.

This prevents a transpile-only dev workflow.

As noted in the PR https://github.com/bazelbuild/rules_nodejs/pull/2547
this is easily accomplished in tsc_test by explicitly gathering typings
inputs with output_group = types

This reverts commit 41117fa93fecde3563482a9fac54073a7b529911.
