### PR TITLE
chore(typescript): allow newer TS versions

### DIFF
--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -20,7 +20,7 @@
     },
     "//": "NOTE: Typescript does not follow SemVer. Usually the minor digit signifies a major version.",
     "peerDependencies": {
-        "typescript": ">=3.0.0 <4.4.0"
+        "typescript": ">=3.0.0"
     },
     "dependencies": {
         "protobufjs": "6.8.8",


### PR DESCRIPTION
Now that ts_library has moved to @bazel/concatjs, the @bazel/typescript package is free of code that uses TS internals.
Instead, it contains just ts_project which uses the tsc CLI and so there's little reason to be concerned that newer TypeScript causes a problem.
So just relax our peerDep constraint to have no upper bound on the TS version.
