### PR TITLE
feat: add src patch being copied to progress message of vendored copy_file

### DIFF
--- a/third_party/github.com/bazelbuild/bazel-skylib/rules/private/copy_file_private.bzl
+++ b/third_party/github.com/bazelbuild/bazel-skylib/rules/private/copy_file_private.bzl
@@ -53,11 +53,11 @@ def copy_cmd(ctx, src, dst):
     if dst.is_directory:
         cmd_tmpl = "@xcopy \"%s\" \"%s\\\" /V /E /H /Y /Q >NUL"
         mnemonic = "CopyDirectory"
-        progress_message = "Copying directory"
+        progress_message = "Copying directory %s" % src.path
     else:
         cmd_tmpl = "@copy /Y \"%s\" \"%s\" >NUL"
         mnemonic = "CopyFile"
-        progress_message = "Copying file"
+        progress_message = "Copying file %s" % src.path
 
     ctx.actions.write(
         output = bat,


### PR DESCRIPTION
With copy_file#is_directory being a very common code path with exports_directories_only,
more detail in the progress messages makes for a much better DX
