### PR TITLE
chore: set symlink_node_modules to False in examples/from_source

### DIFF
--- a/examples/from_source/WORKSPACE
+++ b/examples/from_source/WORKSPACE
@@ -1,7 +1,4 @@
-workspace(
-    name = "from_source",
-    managed_directories = {"@npm": ["node_modules"]},
-)
+workspace(name = "from_source")
 
 # In your code, you'd fetch this repository with a `git_repository` call.
 # We do this local repository only because this example lives in the same
@@ -38,7 +35,6 @@ load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install
 
 node_repositories(
     node_version = "12.13.0",
-    package_json = ["//:package.json"],
     yarn_version = "1.19.1",
 )
 
@@ -47,5 +43,6 @@ yarn_install(
     exports_directories_only = True,
     package_json = "//:package.json",
     strict_visibility = True,
+    symlink_node_modules = False,
     yarn_lock = "//:yarn.lock",
 )

--- a/examples/from_source/index.bzl
+++ b/examples/from_source/index.bzl
@@ -2,23 +2,22 @@
 
 load("@build_bazel_rules_nodejs//packages/typescript:index.bzl", "ts_project")
 
-def custom_ts_project(name, deps = [], **kwargs):
+def custom_ts_project(name, **kwargs):
     """
     Helper wrapper around ts_project adding default attributes and dependencies
 
     Args:
         name: The name that should be given the this rule
-        deps: A list of dependencies for this rule
-        kwargs: All other attrs are passed to ts_project
+        **kwargs: All other attrs are passed to ts_project
     """
 
     ts_project(
         name = name,
         tsconfig = "tsconfig.json",
-        deps = [
+        deps = kwargs.pop("deps", []) + [
             "@npm//tsutils",
             "@npm//@types/node",
-        ] + deps,
+        ],
         validate = False,
         **kwargs
     )


### PR DESCRIPTION
Likely to become the default in 5.0 in https://github.com/bazelbuild/rules_nodejs/pull/3214.

This PR is a subset of https://github.com/bazelbuild/rules_nodejs/pull/3214 and can be abandoned if that one goes green