### PR TITLE
Changed calculation of outs in ts_project to support using rule outputs as srcs

### DIFF
--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -48,6 +48,7 @@ _ATTRS = dict(_VALIDATED_ATTRS, **{
     "link_workspace_root": attr.bool(),
     "out_dir": attr.string(),
     "root_dir": attr.string(),
+    "absolute_root_dir": attr.bool(),
     # NB: no restriction on extensions here, because tsc sometimes adds type-check support
     # for more file kinds (like require('some.json')) and also
     # if you swap out the `compiler` attribute (like with ngtsc)
@@ -112,6 +113,13 @@ def _calculate_root_dir(ctx):
              "since this would prevent giving a single rootDir to the TypeScript compiler\n" +
              "    found generated file %s and source file %s" %
              (some_generated_path, some_source_path))
+
+    if ctx.attr.absolute_root_dir:
+        return _join(
+            root_path,
+            ctx.label.workspace_root,
+            ctx.attr.root_dir,
+        )
 
     return _join(
         root_path,


### PR DESCRIPTION
Hi 👋 

Fixes #2504

The goal of this PR is to make ts_project support using output files from rules in srcs without breaking the pre-calculated outputs in the macro. I understand the outputs are calculated in the macro so that they can be set as outputs on the rule which exposes the output files via a Bazel label like `//path/to/package:out-file-name`.

My changes introduce a secondary calculation of out files in the implementation of the ts_project rule so that the resolved list of files from the context `ctx.files.srcs` can be used. This makes it possible to use targets in the srcs attribute that point to other rules instead of being locked into using `glob` and source files in the same package.

Example:
```
filegroup(
  name = "ts_files",
  srcs = glob(["**/*.ts"]),
)

ts_project(
  name = "js_files",
  srcs = ["ts_files"],
  ...
)
```

Please let me know if you have any feedback or would like any changes made.