### PR TITLE
fix(typescript): filter out .d.ts before passing srcs to transpiler

### DIFF
--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -826,15 +826,23 @@ def ts_project_macro(
         typecheck_target_name = "%s_typecheck" % name
         test_target_name = "%s_typecheck_test" % name
 
+        transpile_srcs = [s for s in srcs if _is_ts_src(s, allow_js)]
+        if (len(transpile_srcs) != len(js_outs)):
+            fail("ERROR: illegal state: transpile_srcs has length {} but js_outs has length {}".format(
+                len(transpile_srcs),
+                len(js_outs),
+            ))
+
         common_kwargs = {
             "tags": kwargs.get("tags", []),
             "visibility": kwargs.get("visibility", None),
             "testonly": kwargs.get("testonly", None),
         }
+
         if type(transpiler) == "function" or type(transpiler) == "rule":
             transpiler(
                 name = transpile_target_name,
-                srcs = srcs,
+                srcs = transpile_srcs,
                 js_outs = js_outs,
                 map_outs = map_outs,
                 **common_kwargs
@@ -843,7 +851,7 @@ def ts_project_macro(
             partial.call(
                 transpiler,
                 name = transpile_target_name,
-                srcs = srcs,
+                srcs = transpile_srcs,
                 js_outs = js_outs,
                 map_outs = map_outs,
                 **common_kwargs

--- a/packages/typescript/test/ts_project/swc/BUILD.bazel
+++ b/packages/typescript/test/ts_project/swc/BUILD.bazel
@@ -25,6 +25,18 @@ write_file(
     content = ["export const a: string = 1"],
 )
 
+write_file(
+    name = "gen_lib_dts",
+    out = "lib.d.ts",
+    content = ["export const a: string;"],
+)
+
+write_file(
+    name = "gen_index_ts",
+    out = "index.ts",
+    content = ["export const a: string = \"1\";"],
+)
+
 ts_project(
     name = "transpile_with_swc",
     srcs = ["big.ts"],
@@ -48,6 +60,17 @@ ts_project(
     srcs = ["typeerror.ts"],
     # The transpile_with_typeerror.check target will have a build failure
     # But the default transpile_with_typeerror target should still produce JS outs
+    tags = ["manual"],
+    transpiler = swc_macro,
+    tsconfig = _TSCONFIG,
+)
+
+ts_project(
+    name = "transpile_with_dts",
+    srcs = [
+        "index.ts",
+        "lib.d.ts",
+    ],
     tags = ["manual"],
     transpiler = swc_macro,
     tsconfig = _TSCONFIG,

--- a/packages/typescript/test/ts_project/swc/tests.bzl
+++ b/packages/typescript/test/ts_project/swc/tests.bzl
@@ -33,6 +33,22 @@ transpile_with_failing_typecheck_test = unittest.make(_impl1, attrs = {
     "expected_js": attr.string_list(default = ["typeerror.js", "typeerror.js.map"]),
 })
 
+def _impl2(ctx):
+    env = unittest.begin(ctx)
+
+    js_files = []
+    for js in ctx.attr.lib[JSModuleInfo].sources.to_list():
+        js_files.append(js.basename)
+    asserts.equals(env, ctx.attr.expected_js, sorted(js_files))
+
+    return unittest.end(env)
+
+transpile_with_dts_test = unittest.make(_impl2, attrs = {
+    "lib": attr.label(default = "transpile_with_dts"),
+    "expected_js": attr.string_list(default = ["index.js", "index.js.map"]),
+})
+
 def test_suite():
     unittest.suite("t0", transitive_declarations_test)
     unittest.suite("t1", transpile_with_failing_typecheck_test)
+    unittest.suite("t2", transpile_with_dts_test)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
At the moment non-js generating srcs are also passed to transpiler attribute causing transpiler to access out of range indices.

Issue Number: N/A

## What is the new behavior?
non-js generating sources (`d.ts`) are not passed to transpiler's srcs attribute.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

