### PR TITLE
fix: angular example needs bump for 5.0

### DIFF
--- a/examples/angular/WORKSPACE
+++ b/examples/angular/WORKSPACE
@@ -24,7 +24,7 @@ load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
 
 nodejs_register_toolchains(
     name = "nodejs",
-    node_version = "12.14.1",
+    node_version = "16.13.2",
 )
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")

--- a/examples/angular/angular.json
+++ b/examples/angular/angular.json
@@ -15,14 +15,14 @@
       },
       "architect": {
         "build": {
-          "builder": "@bazel/angular:build",
+          "builder": "@angular-builders/bazel:build",
           "options": {
             "targetLabel": "//src:prodapp",
             "bazelCommand": "build"
           }
         },
         "serve": {
-          "builder": "@bazel/angular:build",
+          "builder": "@angular-builders/bazel:build",
           "options": {
             "targetLabel": "//src:devserver",
             "bazelCommand": "run",
@@ -41,7 +41,7 @@
           }
         },
         "test": {
-          "builder": "@bazel/angular:build",
+          "builder": "@angular-builders/bazel:build",
           "options": {
             "bazelCommand": "test",
             "targetLabel": "//src/app/..."
@@ -67,7 +67,7 @@
       "prefix": "",
       "architect": {
         "e2e": {
-          "builder": "@bazel/angular:build",
+          "builder": "@angular-builders/bazel:build",
           "options": {
             "bazelCommand": "test",
             "targetLabel": "//e2e:devserver_test"

--- a/examples/angular/io_bazel_rules_sass.patch
+++ b/examples/angular/io_bazel_rules_sass.patch
@@ -5,7 +5,7 @@ index 314d400b..bbdfbf87 100755
  {
    "devDependencies": {
 -    "@bazel/worker": "3.0.0",
-+    "@bazel/worker": "4.0.0-beta.0",
++    "@bazel/worker": "5.0.0-rc.0",
      "sass": "1.34.0"
    }
  }

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -4,7 +4,7 @@
     "description": "Demo of building Angular apps with Bazel",
     "license": "Apache-2.0",
     "engines": {
-        "node": ">=12.14.1 <=14.16.1",
+        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
         "yarn": ">=1.9.2 <2.0.0"
     },
     "dependencies": {
@@ -32,10 +32,10 @@
         "@angular/cli": "12.2.7",
         "@angular/compiler": "12.2.7",
         "@angular/compiler-cli": "12.2.7",
+        "@angular-builders/bazel": "^13.1.0",
         "@babel/cli": "^7.6.0",
         "@babel/core": "^7.6.0",
         "@babel/preset-env": "^7.6.0",
-        "@bazel/angular": "^4.4.0",
         "@bazel/benchmark-runner": "^0.1.0",
         "@bazel/buildifier": "^4.2.5",
         "@bazel/esbuild": "5.0.0-rc.0",

--- a/examples/angular/yarn.lock
+++ b/examples/angular/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@angular-builders/bazel@^13.1.0":
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/@angular-builders/bazel/-/bazel-13.1.0.tgz#eca2035ef8e8d33e0c2419dff531934f3dc506b5"
+  integrity sha512-IxwSD35oxKV5Ygr514hrTkkBhNU4n5yJLmxQLgpib1rP2LovsFs4oCAnVuhfw5qXAgHYEclBzlCuwk+tbKOroQ==
+  dependencies:
+    "@angular-devkit/architect" ">=0.1300.0 < 0.1400.0"
+    "@bazel/bazelisk" "^1.4.0"
+    "@bazel/ibazel" "^0.13.1"
+
 "@angular-devkit/architect@0.1202.7":
   version "0.1202.7"
   resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.1202.7.tgz#0f25851c72d45dd15e86c92cd72c6390e88be432"
@@ -10,13 +19,13 @@
     "@angular-devkit/core" "12.2.7"
     rxjs "6.6.7"
 
-"@angular-devkit/architect@^0.901.7":
-  version "0.901.15"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.901.15.tgz#692f4ca5914a024fc6c50fcd37759d3d5f52ef40"
-  integrity sha512-t4yT34jQ3wA3NFZxph/PquITv8tFrkaexUusbNp4UN10+k+04lPF3aPnJJhM1VKjjfChznMMhLnqLjA+9o0Rmw==
+"@angular-devkit/architect@>=0.1300.0 < 0.1400.0":
+  version "0.1301.3"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.1301.3.tgz#197f92c984adf22776798ce568e64396e464a03d"
+  integrity sha512-fFSevgYGZHCybYoyTkZ9b1YCSthBmoi77alwWjqMhYXUNXx7yx50zJZ6Ur2v3YpctVjU6eoGc5FDFyVHwXT0Iw==
   dependencies:
-    "@angular-devkit/core" "9.1.15"
-    rxjs "6.5.4"
+    "@angular-devkit/core" "13.1.3"
+    rxjs "6.6.7"
 
 "@angular-devkit/core@12.2.7":
   version "12.2.7"
@@ -30,15 +39,16 @@
     rxjs "6.6.7"
     source-map "0.7.3"
 
-"@angular-devkit/core@9.1.15":
-  version "9.1.15"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-9.1.15.tgz#0a4b1d4f64287a2f3f9bc0d9ea9a8e621de6a70e"
-  integrity sha512-zyUDaFQvnqsptoXhodbH4u+voXIldfDx+d0M2OMLj0tbfD4zp2fy7UOeTvu+lq2/LLNAObkG4JSK5DM9v1s08w==
+"@angular-devkit/core@13.1.3":
+  version "13.1.3"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-13.1.3.tgz#d1f8a6b4ad4326732a160a7549fccca1369fd108"
+  integrity sha512-o14jGDk4h14dVYYQafOn+2rq9CDmDMbDV6logqKYCLzTDRlK8gccDnqJM/QKAlfWCzbllZqcHDmg6FyoRLO9RQ==
   dependencies:
-    ajv "6.12.3"
+    ajv "8.8.2"
+    ajv-formats "2.1.1"
     fast-json-stable-stringify "2.1.0"
     magic-string "0.25.7"
-    rxjs "6.5.4"
+    rxjs "6.6.7"
     source-map "0.7.3"
 
 "@angular-devkit/schematics@12.2.7":
@@ -1065,15 +1075,6 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@bazel/angular@^4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@bazel/angular/-/angular-4.4.0.tgz#3579c9f396a6e8c219e9dedf2b5b8fbf825f652f"
-  integrity sha512-iDawBI218Wn8CxE/DHSlBe6o7bZaKD97rN+xqlUEXpMTeBQSuCcmlAeIGZq7Q8KPa0sDb9iTyGX52X211qF98Q==
-  dependencies:
-    "@angular-devkit/architect" "^0.901.7"
-    "@bazel/bazelisk" "^1.4.0"
-    "@bazel/ibazel" "^0.13.1"
-
 "@bazel/bazelisk@^1.4.0":
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/@bazel/bazelisk/-/bazelisk-1.10.1.tgz#46236a43ad58e310c55247f866da0dc6083c3d8b"
@@ -1464,20 +1465,27 @@ ajv-formats@2.1.0:
   dependencies:
     ajv "^8.0.0"
 
-ajv@6.12.3:
-  version "6.12.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
-  integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
+ajv-formats@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
   dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
+    ajv "^8.0.0"
 
 ajv@8.6.2:
   version "8.6.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.2.tgz#2fb45e0e5fcbc0813326c1c3da535d1881bb0571"
   integrity sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ajv@8.8.2:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.8.2.tgz#01b4fef2007a28bf75f0b7fc009f62679de4abbb"
+  integrity sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -6049,13 +6057,6 @@ rxjs@6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
   integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@6.5.4:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
-  integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
The rules_sass patch needs to bring version 5 of the @bazel/worker package.
Also account for the move of the @bazel/angular package.
