### PR TITLE
chore: renovate stop sending PRs for examples

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   ],
   "ignorePaths": [
     "e2e",
+    "examples",
     "tools",
     "third_party"
   ],


### PR DESCRIPTION
We get way too many PRs for rules_sass and rules_docker version bumps that we don't really want
