### PR TITLE
*_install: only create nodejs or yarn repositories if we need them

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -63,6 +63,13 @@ nodejs_register_toolchains(
     node_version = "15.14.0",
 )
 
+load("@rules_nodejs//nodejs:yarn_repositories.bzl", "yarn_repositories")
+
+yarn_repositories(
+    name = "yarn",
+    node_repository = "node16",
+)
+
 load("@build_bazel_rules_nodejs//:npm_deps.bzl", "npm_deps")
 
 npm_deps()
@@ -131,7 +138,9 @@ browser_repositories(
 # Setup esbuild dependencies
 load("//toolchains/esbuild:esbuild_repositories.bzl", "esbuild_repositories")
 
-esbuild_repositories()
+esbuild_repositories(
+    node_repository = "node16",
+)
 
 #
 # Dependencies to run stardoc & generating documentation

--- a/docs/Toolchains.md
+++ b/docs/Toolchains.md
@@ -186,7 +186,7 @@ Defaults to `""`
 **USAGE**
 
 <pre>
-esbuild_repositories(<a href="#esbuild_repositories-name">name</a>, <a href="#esbuild_repositories-npm_repository">npm_repository</a>, <a href="#esbuild_repositories-npm_args">npm_args</a>)
+esbuild_repositories(<a href="#esbuild_repositories-name">name</a>, <a href="#esbuild_repositories-npm_repository">npm_repository</a>, <a href="#esbuild_repositories-npm_args">npm_args</a>, <a href="#esbuild_repositories-kwargs">kwargs</a>)
 </pre>
 
 Helper for fetching and setting up the esbuild versions and toolchains
@@ -227,5 +227,11 @@ Defaults to `"npm"`
 additional args to pass to the npm install rule
 
 Defaults to `[]`
+
+<h4 id="esbuild_repositories-kwargs">kwargs</h4>
+
+additional named parameters to the npm_install rule
+
+
 
 

--- a/docs/esbuild.md
+++ b/docs/esbuild.md
@@ -434,7 +434,7 @@ Any other common attributes
 **USAGE**
 
 <pre>
-esbuild_repositories(<a href="#esbuild_repositories-name">name</a>, <a href="#esbuild_repositories-npm_repository">npm_repository</a>, <a href="#esbuild_repositories-npm_args">npm_args</a>)
+esbuild_repositories(<a href="#esbuild_repositories-name">name</a>, <a href="#esbuild_repositories-npm_repository">npm_repository</a>, <a href="#esbuild_repositories-npm_args">npm_args</a>, <a href="#esbuild_repositories-kwargs">kwargs</a>)
 </pre>
 
 Helper for fetching and setting up the esbuild versions and toolchains
@@ -475,5 +475,11 @@ Defaults to `"npm"`
 additional args to pass to the npm install rule
 
 Defaults to `[]`
+
+<h4 id="esbuild_repositories-kwargs">kwargs</h4>
+
+additional named parameters to the npm_install rule
+
+
 
 

--- a/e2e/nodejs_image/BUILD.bazel
+++ b/e2e/nodejs_image/BUILD.bazel
@@ -17,7 +17,7 @@ nodejs_image(
     name = "nodejs_image",
     binary = ":main",
     include_node_repo_args = False,
-    node_repository_name = "nodejs_linux_amd64",
+    node_repository_name = "node16_linux_amd64",
 )
 
 container_test(

--- a/e2e/nodejs_image/WORKSPACE
+++ b/e2e/nodejs_image/WORKSPACE
@@ -30,6 +30,7 @@ load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(
     name = "npm",
+    node_repository = "node16",
     package_json = "//:package.json",
     yarn_lock = "//:yarn.lock",
 )

--- a/e2e/symlinked_node_modules_npm/WORKSPACE
+++ b/e2e/symlinked_node_modules_npm/WORKSPACE
@@ -15,7 +15,9 @@ local_repository(
 
 load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
 
-nodejs_register_toolchains(name = "node")
+_NODE_REPO = "node"
+
+nodejs_register_toolchains(name = _NODE_REPO)
 
 # build_bazel_rules_nodejs_dev_dependencies() required since we're using local_repository for
 # build_bazel_rules_nodejs above.
@@ -27,6 +29,7 @@ load("@build_bazel_rules_nodejs//:index.bzl", "npm_install")
 
 npm_install(
     name = "npm",
+    node_repository = _NODE_REPO,
     package_json = "//:package.json",
     package_lock_json = "//:package-lock.json",
     quiet = False,

--- a/e2e/symlinked_node_modules_yarn/WORKSPACE
+++ b/e2e/symlinked_node_modules_yarn/WORKSPACE
@@ -15,7 +15,9 @@ local_repository(
 
 load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
 
-nodejs_register_toolchains(name = "node")
+_NODE_REPO = "node"
+
+nodejs_register_toolchains(name = _NODE_REPO)
 
 # build_bazel_rules_nodejs_dev_dependencies() required since we're using local_repository for
 # build_bazel_rules_nodejs above.
@@ -27,6 +29,7 @@ load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(
     name = "npm",
+    node_repository = _NODE_REPO,
     package_json = "//:package.json",
     quiet = False,
     yarn_lock = "//:yarn.lock",

--- a/examples/vendored_node_and_yarn/WORKSPACE
+++ b/examples/vendored_node_and_yarn/WORKSPACE
@@ -28,23 +28,26 @@ build_bazel_rules_nodejs_dependencies()
 
 # See comment in README about these fetches
 http_archive(
-    name = "vendored_node_linux",
-    build_file_content = """exports_files(["node-v15.0.1-linux-x64/bin/node"])""",
+    name = "vendored_node_linux_amd64",
+    build_file_content = """exports_files(["bin/node"])""",
     sha256 = "cc9c3eed21755b490e5333ccab208ce15b539c35f64a764eeeae77c58746a7ff",
+    strip_prefix = "node-v15.0.1-linux-x64",
     urls = ["https://nodejs.org/dist/v15.0.1/node-v15.0.1-linux-x64.tar.xz"],
 )
 
 http_archive(
-    name = "vendored_node_mac",
-    build_file_content = """exports_files(["node-v15.0.1-darwin-x64/bin/node"])""",
+    name = "vendored_node_darwin_amd64",
+    build_file_content = """exports_files(["bin/node"])""",
     sha256 = "78571df5b35d3ec73d7543332776bcb8cab3bc0e3abd12b1440fbcd01c74c055",
+    strip_prefix = "node-v15.0.1-darwin-x64",
     urls = ["https://nodejs.org/dist/v15.0.1/node-v15.0.1-darwin-x64.tar.xz"],
 )
 
 http_archive(
-    name = "vendored_node_windows",
-    build_file_content = """exports_files(["node-v15.0.1-win-x64/node.exe"])""",
+    name = "vendored_node_windows_amd64",
+    build_file_content = """exports_files(["node.exe"])""",
     sha256 = "efa7a74d91789a6e9f068f375e49f108ff87578fd88ff4b4e7fefd930c04db6c",
+    strip_prefix = "node-v15.0.1-win-x64",
     urls = ["https://nodejs.org/dist/v15.0.1/node-v15.0.1-win-x64.zip"],
 )
 
@@ -62,6 +65,7 @@ load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 yarn_install(
     name = "npm",
     exports_directories_only = False,
+    node_repository = "vendored_node",
     package_json = "//:package.json",
     yarn = "@vendored_yarn_1_10_0//:yarn-v1.10.0/bin/yarn.js",
     yarn_lock = "//:yarn.lock",

--- a/examples/vendored_node_and_yarn/toolchains/BUILD.bazel
+++ b/examples/vendored_node_and_yarn/toolchains/BUILD.bazel
@@ -28,15 +28,15 @@ load("@rules_nodejs//nodejs:toolchain.bzl", "node_toolchain")
 
 node_toolchain(
     name = "node_linux",
-    target_tool = "@vendored_node_linux//:node-v15.0.1-linux-x64/bin/node",
+    target_tool = "@vendored_node_linux_amd64//:bin/node",
 )
 
 node_toolchain(
     name = "node_macos",
-    target_tool = "@vendored_node_mac//:node-v15.0.1-darwin-x64/bin/node",
+    target_tool = "@vendored_node_darwin_amd64//:bin/node",
 )
 
 node_toolchain(
     name = "node_windows",
-    target_tool = "@vendored_node_windows//:node-v15.0.1-win-x64/node.exe",
+    target_tool = "@vendored_node_windows_amd64//:node.exe",
 )

--- a/examples/vue/WORKSPACE
+++ b/examples/vue/WORKSPACE
@@ -14,8 +14,10 @@ build_bazel_rules_nodejs_dependencies()
 
 load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
 
+_NODE_REPO = "node16"
+
 nodejs_register_toolchains(
-    name = "node16",
+    name = _NODE_REPO,
     node_version = "16.0.0",
 )
 
@@ -23,6 +25,7 @@ load("@build_bazel_rules_nodejs//:index.bzl", "npm_install")
 
 npm_install(
     name = "npm",
+    node_repository = _NODE_REPO,
     package_json = "//:package.json",
     package_lock_json = "//:package-lock.json",
 )

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -19,9 +19,7 @@ See https://docs.bazel.build/versions/main/skylark/repository_rules.html
 """
 
 load("@bazel_skylib//lib:versions.bzl", "versions")
-load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@rules_nodejs//nodejs/private:os_name.bzl", "OS_ARCH_NAMES", "node_exists_for_os", "os_name")
-load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains", node_repositories_rule = "node_repositories")
+load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
 load("@rules_nodejs//nodejs:yarn_repositories.bzl", "yarn_repositories")
 
 def node_repositories(**kwargs):
@@ -41,27 +39,12 @@ def node_repositories(**kwargs):
     yarn_args = {}
     yarn_name = kwargs.pop("yarn_repository_name", "yarn")
     for k, v in kwargs.items():
-        if k.startswith("yarn_"):
+        if k.startswith("yarn"):
             yarn_args[k] = kwargs.pop(k)
     yarn_repositories(
         name = yarn_name,
         **yarn_args
     )
-
-    # This needs to be setup so toolchains can access nodejs for all different versions
-    node_version = kwargs.get("node_version", DEFAULT_NODE_VERSION)
-    for os_arch_name in OS_ARCH_NAMES:
-        os_name = "_".join(os_arch_name)
-
-        # If we couldn't download node, don't make an external repo for it either
-        if not node_exists_for_os(node_version, os_name):
-            continue
-        node_repository_name = "nodejs_%s" % os_name
-        maybe(
-            node_repositories_rule,
-            name = node_repository_name,
-            **kwargs
-        )
 
     # Install new toolchain under "nodejs" repository name prefix
     nodejs_register_toolchains(name = "nodejs")

--- a/toolchains/esbuild/esbuild_repositories.bzl
+++ b/toolchains/esbuild/esbuild_repositories.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@build_bazel_rules_nodejs//:index.bzl", "npm_install")
 load(":esbuild_packages.bzl", "ESBUILD_PACKAGES")
 
-def esbuild_repositories(name = "", npm_repository = "npm", npm_args = []):
+def esbuild_repositories(name = "", npm_repository = "npm", npm_args = [], **kwargs):
     """Helper for fetching and setting up the esbuild versions and toolchains
 
     This uses Bazel's downloader (via `http_archive`) to fetch the esbuild package
@@ -29,6 +29,7 @@ def esbuild_repositories(name = "", npm_repository = "npm", npm_args = []):
         npm_repository:  the name of the repository where the @bazel/esbuild package is installed
             by npm_install or yarn_install.
         npm_args: additional args to pass to the npm install rule
+        **kwargs: additional named parameters to the npm_install rule
     """
 
     maybe(
@@ -78,4 +79,5 @@ def esbuild_repositories(name = "", npm_repository = "npm", npm_args = []):
             "--ignore-scripts",
         ] + npm_args,
         package_path = package_path,
+        **kwargs
     )


### PR DESCRIPTION
Previously we'd create these repositories even if the user already installed node some other way.

Note, this is minor extra breaking change after rc1, but based on testing at one client I think this may be a good idea. This PR demonstrates how it caught some bugs in our e2e/examples where the wrong node (default version) was getting used.