### PR TITLE
refactor: remove unneeded file from core package

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -130,7 +130,6 @@ pkg_tar(
     srcs = [
         "LICENSE",
         "README.md",
-        "providers.bzl",
         "version.bzl",
         "//nodejs:package_contents",
         # TODO(5.0) remove this and depend on real skylib


### PR DESCRIPTION
It's confusing to have the bbrnj providers file in this module, since you're meant to use /nodejs/providers.bzl instead
