### PR TITLE
fix: warning logic for yarn berry attrs

### DIFF
--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -821,8 +821,8 @@ def _yarn_install_impl(repository_ctx):
         if not repository_ctx.attr.use_global_yarn_cache:
             fail("""Disabling global_yarn_cache has no effect while using Yarn Berry.
                 Please configure it through a .yarnrc file through 'data' attribute.""")
-        if repository_ctx.attr.frozen_lockfile:
-            fail("--frozen-lockfile should not be used with yarn 2+. Just pass arguments like --immutable.")
+        if not repository_ctx.attr.frozen_lockfile:
+            fail("Disabling frozen_lockfile has no effect while using Yarn Berry. Just pass arguments like --immutable.")
     elif yarn_version == "classic":
         # Set frozen lockfile as default install to install the exact version from the yarn.lock
         # file. To perform an yarn install use the vendord yarn binary with:


### PR DESCRIPTION
The default for frozen_lockfile is true so the warning should be if you try to set it false.
This API is really confusing right now though. Maybe we should have separate rules like yarn_install and yarn1_install or sth
