### PR TITLE
fix(yarn): when running vendored yarn, prefix command with path to node

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -216,10 +216,7 @@ example_integration_test(
     npm_packages = {
         "//packages/jasmine:npm_package": "@bazel/jasmine",
     },
-    # Needs some thought about how to invoke "node.exe path/to/yarn.js on windows to avoid
-    # Error in fail: yarn --version failed:  (java.io.IOException: ERROR: src/main/native/windows/process.cc(202):
-    # CreateProcessW("C:\users\b\_bazel_b\ag3rxjdr\external\vendored_yarn_1_10_0\yarn-v1.10.0\bin\yarn.js" --version):
-    # %1 is not a valid Win32 application.
+    # TODO: make it find node.exe rather than rely on us writing a .cmd wrapper
     tags = ["no-bazelci-windows"],
 )
 

--- a/examples/vendored_node_and_yarn/WORKSPACE
+++ b/examples/vendored_node_and_yarn/WORKSPACE
@@ -53,8 +53,9 @@ http_archive(
 
 http_archive(
     name = "vendored_yarn_1_10_0",
-    build_file_content = """exports_files(["vendored_yarn_1_10_0/yarn-v1.10.0/bin/yarn.js"])""",
+    build_file_content = """exports_files(["bin/yarn.js"])""",
     sha256 = "83277bd505c7f4009c13077266020c97298727de7edf67af5ca66eccae9d4632",
+    strip_prefix = "yarn-v1.10.0",
     urls = ["https://github.com/yarnpkg/yarn/releases/download/v1.10.0/yarn-v1.10.0.tar.gz"],
 )
 
@@ -67,6 +68,6 @@ yarn_install(
     exports_directories_only = False,
     node_repository = "vendored_node",
     package_json = "//:package.json",
-    yarn = "@vendored_yarn_1_10_0//:yarn-v1.10.0/bin/yarn.js",
+    yarn = "@vendored_yarn_1_10_0//:bin/yarn.js",
     yarn_lock = "//:yarn.lock",
 )


### PR DESCRIPTION
Otherwise we fall through to the system node on the PATH which may not be set, or may be skewed

rebased on #3250