### PR TITLE
fix(typescript): propagate tags to validate_options

### DIFF
--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -754,6 +754,7 @@ def ts_project_macro(
                 allow_js = allow_js,
                 tsconfig = tsconfig,
                 extends = extends,
+                tags = kwargs.get("tags", []),
             )
             tsc_deps = tsc_deps + ["_validate_%s_options" % name]
 

--- a/packages/typescript/internal/ts_project.bzl
+++ b/packages/typescript/internal/ts_project.bzl
@@ -700,6 +700,12 @@ def ts_project_macro(
         fail("As of rules_nodejs 3.0, extends should have a single value, not a list.\n" +
              "Use a ts_config rule to group together a chain of extended tsconfigs.")
 
+    common_kwargs = {
+        "tags": kwargs.get("tags", []),
+        "visibility": kwargs.get("visibility", None),
+        "testonly": kwargs.get("testonly", None),
+    }
+
     if type(tsconfig) == type(dict()):
         # Copy attributes <-> tsconfig properties
         # TODO: fail if compilerOptions includes a conflict with an attribute?
@@ -754,7 +760,7 @@ def ts_project_macro(
                 allow_js = allow_js,
                 tsconfig = tsconfig,
                 extends = extends,
-                tags = kwargs.get("tags", []),
+                **common_kwargs
             )
             tsc_deps = tsc_deps + ["_validate_%s_options" % name]
 
@@ -833,12 +839,6 @@ def ts_project_macro(
                 len(transpile_srcs),
                 len(js_outs),
             ))
-
-        common_kwargs = {
-            "tags": kwargs.get("tags", []),
-            "visibility": kwargs.get("visibility", None),
-            "testonly": kwargs.get("testonly", None),
-        }
 
         if type(transpiler) == "function" or type(transpiler) == "rule":
             transpiler(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3259 


## What is the new behavior?
Tags are propagated to the validate_options rule

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Strictly, the answer here might be yes, particularly if someone was doing something very esoteric with custom tags and relying on the fact that propagation to this rule was not happening, but this seems extremely unlikely.

## Other information

