### PR TITLE
fix(builtin): npm_package_bin include runfiles in DefaultInfo

### DIFF
--- a/internal/node/npm_package_bin.bzl
+++ b/internal/node/npm_package_bin.bzl
@@ -87,8 +87,11 @@ def _impl(ctx):
         exit_code_out = ctx.outputs.exit_code_out,
         link_workspace_root = ctx.attr.link_workspace_root,
     )
-
-    return [DefaultInfo(files = depset(outputs + tool_outputs))]
+    files = outputs + tool_outputs
+    return [DefaultInfo(
+        files = depset(files),
+        runfiles = ctx.runfiles(files = files),
+    )]
 
 _npm_package_bin = rule(
     _impl,

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -6,6 +6,7 @@ load("//packages/jasmine:index.bzl", "jasmine_node_test")
 load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "copy_file")
 load("//third_party/github.com/bazelbuild/bazel-skylib:rules/write_file.bzl", "write_file")
 load(":nodejs_toolchain_test.bzl", "nodejs_toolchain_test")
+load(":npm_package_bin_test.bzl", "npm_package_bin_test_suite")
 
 # You can have a nodejs_binary with no node_modules attribute
 # and no fine grained deps
@@ -259,6 +260,8 @@ npm_package_bin(
     package = "terser",
     stdout = "minified.stdout.js",
 )
+
+npm_package_bin_test_suite()
 
 generated_file_test(
     name = "stdout_output_test",

--- a/internal/node/test/npm_package_bin_test.bzl
+++ b/internal/node/test/npm_package_bin_test.bzl
@@ -1,0 +1,21 @@
+"Unit tests for js_library rule"
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+def _impl(ctx):
+    env = unittest.begin(ctx)
+
+    runfiles = []
+    for r in ctx.attr.lib[DefaultInfo].default_runfiles.files.to_list():
+        runfiles.append(r.basename)
+    asserts.equals(env, ctx.attr.expected_runfiles, sorted(runfiles))
+
+    return unittest.end(env)
+
+runfiles_test = unittest.make(_impl, attrs = {
+    "lib": attr.label(default = ":run_terser"),
+    "expected_runfiles": attr.string_list(default = ["minified.js"]),
+})
+
+def npm_package_bin_test_suite():
+    unittest.suite("runfiles", runfiles_test)


### PR DESCRIPTION
Otherwise you can't use a data dep on one of these to gather runtime deps

fixes #3257
