### PR TITLE
chore(esbuild): remove default value of npm from the npm_repository attr

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -140,6 +140,7 @@ load("//toolchains/esbuild:esbuild_repositories.bzl", "esbuild_repositories")
 
 esbuild_repositories(
     node_repository = "node16",
+    npm_repository = "npm",
 )
 
 #

--- a/docs/Toolchains.md
+++ b/docs/Toolchains.md
@@ -186,7 +186,7 @@ Defaults to `""`
 **USAGE**
 
 <pre>
-esbuild_repositories(<a href="#esbuild_repositories-name">name</a>, <a href="#esbuild_repositories-npm_repository">npm_repository</a>, <a href="#esbuild_repositories-npm_args">npm_args</a>, <a href="#esbuild_repositories-kwargs">kwargs</a>)
+esbuild_repositories(<a href="#esbuild_repositories-npm_repository">npm_repository</a>, <a href="#esbuild_repositories-name">name</a>, <a href="#esbuild_repositories-npm_args">npm_args</a>, <a href="#esbuild_repositories-kwargs">kwargs</a>)
 </pre>
 
 Helper for fetching and setting up the esbuild versions and toolchains
@@ -209,18 +209,18 @@ For example if you created `.bazel_downloader_config` you might add to your `.ba
 **PARAMETERS**
 
 
-<h4 id="esbuild_repositories-name">name</h4>
-
-currently unused
-
-Defaults to `""`
-
 <h4 id="esbuild_repositories-npm_repository">npm_repository</h4>
 
 the name of the repository where the @bazel/esbuild package is installed
 by npm_install or yarn_install.
 
-Defaults to `"npm"`
+
+
+<h4 id="esbuild_repositories-name">name</h4>
+
+currently unused
+
+Defaults to `""`
 
 <h4 id="esbuild_repositories-npm_args">npm_args</h4>
 

--- a/docs/esbuild.md
+++ b/docs/esbuild.md
@@ -38,7 +38,7 @@ npm_install(
 
 load("@build_bazel_rules_nodejs//toolchains/esbuild:esbuild_repositories.bzl", "esbuild_repositories")
 
-esbuild_repositories(npm_repository = "npm")  # Note, npm is the default value for npm_repository
+esbuild_repositories(npm_repository = "npm")
 ```
 
 > To avoid eagerly fetching all the npm dependencies, this load statement comes from the "Built-in"
@@ -434,7 +434,7 @@ Any other common attributes
 **USAGE**
 
 <pre>
-esbuild_repositories(<a href="#esbuild_repositories-name">name</a>, <a href="#esbuild_repositories-npm_repository">npm_repository</a>, <a href="#esbuild_repositories-npm_args">npm_args</a>, <a href="#esbuild_repositories-kwargs">kwargs</a>)
+esbuild_repositories(<a href="#esbuild_repositories-npm_repository">npm_repository</a>, <a href="#esbuild_repositories-name">name</a>, <a href="#esbuild_repositories-npm_args">npm_args</a>, <a href="#esbuild_repositories-kwargs">kwargs</a>)
 </pre>
 
 Helper for fetching and setting up the esbuild versions and toolchains
@@ -457,18 +457,18 @@ For example if you created `.bazel_downloader_config` you might add to your `.ba
 **PARAMETERS**
 
 
-<h4 id="esbuild_repositories-name">name</h4>
-
-currently unused
-
-Defaults to `""`
-
 <h4 id="esbuild_repositories-npm_repository">npm_repository</h4>
 
 the name of the repository where the @bazel/esbuild package is installed
 by npm_install or yarn_install.
 
-Defaults to `"npm"`
+
+
+<h4 id="esbuild_repositories-name">name</h4>
+
+currently unused
+
+Defaults to `""`
 
 <h4 id="esbuild_repositories-npm_args">npm_args</h4>
 

--- a/examples/angular/WORKSPACE
+++ b/examples/angular/WORKSPACE
@@ -86,7 +86,9 @@ browser_repositories(
 # Setup esbuild repositories
 load("@build_bazel_rules_nodejs//toolchains/esbuild:esbuild_repositories.bzl", "esbuild_repositories")
 
-esbuild_repositories()
+esbuild_repositories(
+    npm_repository = "npm",
+)
 
 # Setup the rules_sass toolchain
 load("@io_bazel_rules_sass//sass:sass_repositories.bzl", "sass_repositories")

--- a/examples/esbuild/WORKSPACE
+++ b/examples/esbuild/WORKSPACE
@@ -36,4 +36,6 @@ yarn_install(
 
 load("@build_bazel_rules_nodejs//toolchains/esbuild:esbuild_repositories.bzl", "esbuild_repositories")
 
-esbuild_repositories()
+esbuild_repositories(
+    npm_repository = "npm",
+)

--- a/packages/esbuild/index.docs.bzl
+++ b/packages/esbuild/index.docs.bzl
@@ -32,7 +32,7 @@ npm_install(
 
 load("@build_bazel_rules_nodejs//toolchains/esbuild:esbuild_repositories.bzl", "esbuild_repositories")
 
-esbuild_repositories(npm_repository = "npm")  # Note, npm is the default value for npm_repository
+esbuild_repositories(npm_repository = "npm")
 ```
 
 > To avoid eagerly fetching all the npm dependencies, this load statement comes from the "Built-in"

--- a/toolchains/esbuild/esbuild_repositories.bzl
+++ b/toolchains/esbuild/esbuild_repositories.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@build_bazel_rules_nodejs//:index.bzl", "npm_install")
 load(":esbuild_packages.bzl", "ESBUILD_PACKAGES")
 
-def esbuild_repositories(name = "", npm_repository = "npm", npm_args = [], **kwargs):
+def esbuild_repositories(npm_repository, name = "", npm_args = [], **kwargs):
     """Helper for fetching and setting up the esbuild versions and toolchains
 
     This uses Bazel's downloader (via `http_archive`) to fetch the esbuild package
@@ -25,9 +25,9 @@ def esbuild_repositories(name = "", npm_repository = "npm", npm_args = [], **kwa
         common --experimental_downloader_config=.bazel_downloader_config
 
     Args:
-        name: currently unused
         npm_repository:  the name of the repository where the @bazel/esbuild package is installed
             by npm_install or yarn_install.
+        name: currently unused
         npm_args: additional args to pass to the npm install rule
         **kwargs: additional named parameters to the npm_install rule
     """


### PR DESCRIPTION
**BREAKING CHANGE**

Removes the default value of `npm` for the `esbuild_repositories` rules `npm_repository` attr. When changing the default npm name, often users trip up on this default, so make it explicit.