### PR TITLE
refactor: bbrnj re-exports rules_nodejs providers

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -40,6 +40,17 @@ stardoc(
     name = "providers",
     out = "providers.md_",
     input = "//:providers.bzl",
+    symbol_names = [
+        "ExternalNpmPackageInfo",
+        "js_ecma_script_module_info",
+        "js_named_module_info",
+        "JSEcmaScriptModuleInfo",
+        "JSNamedModuleInfo",
+        "node_modules_aspect",
+        "NodeRuntimeDepsInfo",
+        "run_node",
+        "NpmPackageInfo",
+    ],
     tags = ["fix-windows"],
     deps = [
         "//:bzl",

--- a/providers.bzl
+++ b/providers.bzl
@@ -38,6 +38,25 @@ load(
     _run_node = "run_node",
 )
 
+# TODO(6.0): remove these re-exports, they are just for easier migration to 5.0.0
+# This includes everything from
+# https://github.com/bazelbuild/rules_nodejs/blob/4.x/providers.bzl
+# which wasn't removed in 5.0 (NodeContextInfo, NODE_CONTEXT_ATTRS)
+load(
+    "@rules_nodejs//nodejs:providers.bzl",
+    _DeclarationInfo = "DeclarationInfo",
+    _DirectoryFilePathInfo = "DirectoryFilePathInfo",
+    _JSModuleInfo = "JSModuleInfo",
+    _LinkablePackageInfo = "LinkablePackageInfo",
+    _declaration_info = "declaration_info",
+)
+
+DeclarationInfo = _DeclarationInfo
+declaration_info = _declaration_info
+JSModuleInfo = _JSModuleInfo
+LinkablePackageInfo = _LinkablePackageInfo
+DirectoryFilePathInfo = _DirectoryFilePathInfo
+
 ExternalNpmPackageInfo = _ExternalNpmPackageInfo
 js_ecma_script_module_info = _js_ecma_script_module_info
 js_named_module_info = _js_named_module_info


### PR DESCRIPTION
This makes the 5.0 release less breaking by restoring back-compat with
rulesets that loaded these from the old location.

I manually verified that the same symbol comes through, so even though
a provider creation and usage site load from different places, the
provided symbol still matches and works.
