### PR TITLE
fix: exporting symbols from @bazel/concatjs

### DIFF
--- a/packages/concatjs/BUILD.bazel
+++ b/packages/concatjs/BUILD.bazel
@@ -23,17 +23,14 @@ load("//third_party/github.com/bazelbuild/bazel-skylib:rules/copy_file.bzl", "co
 ts_project(
     name = "bazel_concatjs_lib",
     srcs = glob(["*.ts"]),
-    tsconfig = {
-        "compilerOptions": {
-            "declaration": True,
-            "module": "umd",
-            "moduleResolution": "node",
-            "types": ["node"],
-        },
-    },
+    allow_js = True,
+    declaration = True,
+    tsconfig = ":tsconfig.json",
     deps = [
+        "//packages/concatjs/internal:tsc_wrapped_lib",
         "@npm//@types/node",
         "@npm//karma",
+        "@npm//tsickle",
     ],
 )
 
@@ -42,6 +39,12 @@ js_library(
     package_name = "@bazel/concatjs",
     srcs = ["bazel_concatjs_lib"],
     visibility = ["//packages/concatjs:__subpackages__"],
+    deps = [
+        "//packages/concatjs/internal:tsc_wrapped_lib",
+        "//packages/concatjs/third_party/github.com/bazelbuild/bazel/src/main/protobuf:npm_package_assets",
+        "@npm//protobufjs",
+        "@npm//typescript",
+    ],
 )
 
 bzl_library(

--- a/packages/concatjs/index.ts
+++ b/packages/concatjs/index.ts
@@ -128,6 +128,8 @@ function watcher(fileList: {refresh: () => void}) {
 
 (watcher as any).$inject = ['fileList'];
 
+export * from "./internal/tsc_wrapped";
+
 module.exports = {
   'framework:concat_js': ['factory', initConcatJs],
   'watcher': ['value', watcher],

--- a/packages/concatjs/internal/BUILD.bazel
+++ b/packages/concatjs/internal/BUILD.bazel
@@ -15,7 +15,7 @@
 # gazelle:exclude worker_protocol.proto
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//:index.bzl", "nodejs_binary")
+load("//:index.bzl", "js_library", "nodejs_binary")
 load("//packages/jasmine:index.bzl", "jasmine_node_test")
 load("//packages/concatjs:index.bzl", "ts_library")
 load("@npm//typescript:index.bzl", "tsc")
@@ -80,6 +80,11 @@ tsc(
         "@npm//typescript",
     ],
     visibility = ["//visibility:public"],
+)
+
+js_library(
+    name = "tsc_wrapped_lib",
+    srcs = [":tsc_wrapped"],
 )
 
 # Other ts_library rules will use this custom compiler, which calls the

--- a/packages/concatjs/tsconfig.json
+++ b/packages/concatjs/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+        "declaration": true,
+        "module": "umd",
+        "allowJs": true,
+        "moduleResolution": "node",
+        "types": ["node"],
+        "rootDirs": [
+            ".",
+            "../../bazel-out/darwin-fastbuild/bin/packages/concatjs",
+            "../../bazel-out/k8-fastbuild/bin/packages/concatjs",
+            "../../bazel-out/host/bin/packages/concatjs",
+            "../../bazel-out/darwin_arm64-fastbuild/bin/packages/concatjs",
+            "../../bazel-out/darwin_amd64-fastbuild/bin/packages/concatjs",
+            "../../bazel-out/x64_windows-fastbuild/bin/packages/concatjs",
+            "../../bazel-out/darwin-dbg/bin/packages/concatjs",
+            "../../bazel-out/k8-dbg/bin/packages/concatjs",
+            "../../bazel-out/x64_windows-dbg/bin/packages/concatjs",
+            "../../bazel-out/k8-opt-exec-2B5CBBC6/bin/packages/concatjs",
+            "../../bazel-out/darwin-opt-exec-2B5CBBC6/bin/packages/concatjs",
+            "../../bazel-out/windows-opt-exec-2B5CBBC6/bin/packages/concatjs",
+            "../../bazel-out/x64_windows-opt-exec-2B5CBBC6/bin/packages/concatjs",
+            "../../bazel-out/k8-opt-exec-60723E07/bin/packages/concatjs",
+        ]
+    }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

symbols from @bazel/typescript were not exported after they moved to @bazel/concatjs


## What is the new behavior?

export all needed symbols from @bazel/concatjs

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

