### PR TITLE
fix(builtin): pass kwargs from node_repositories helper

### DIFF
--- a/e2e/nodejs_host/BUILD.bazel
+++ b/e2e/nodejs_host/BUILD.bazel
@@ -14,6 +14,7 @@ nodejs_test(
         "@nodejs_host//:npm_bin",
         "@nodejs_host//:npm_files",
         "@nodejs_host//:npx_bin",
+        "@npm//:node_modules",
         "@yarn",
         "@yarn//:yarn_bin",
         "@yarn//:yarn_files",

--- a/e2e/nodejs_host/WORKSPACE
+++ b/e2e/nodejs_host/WORKSPACE
@@ -12,7 +12,11 @@ load("@build_bazel_rules_nodejs//:repositories.bzl", "build_bazel_rules_nodejs_d
 
 build_bazel_rules_nodejs_dependencies()
 
-load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
+
+node_repositories(
+    node_version = "12.12.0",
+)
 
 yarn_install(
     name = "npm",

--- a/e2e/nodejs_host/package.json
+++ b/e2e/nodejs_host/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {},
   "scripts": {
+    "postinstall": "node -e \"require('assert').equal(process.version, 'v12.12.0')\"",
     "test": "bazel test ..."
   }
 }

--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -47,4 +47,4 @@ def node_repositories(**kwargs):
     )
 
     # Install new toolchain under "nodejs" repository name prefix
-    nodejs_register_toolchains(name = "nodejs")
+    nodejs_register_toolchains(name = "nodejs", **kwargs)


### PR DESCRIPTION
We were missing test coverage for attributes like node_version being passed to the new toolchain registration
