### PR TITLE
docs: demonstrate workaround for jasmine with export_directories_only

### DIFF
--- a/examples/nestjs/WORKSPACE
+++ b/examples/nestjs/WORKSPACE
@@ -30,7 +30,6 @@ load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(
     name = "npm",
-    exports_directories_only = False,
     package_json = "//:package.json",
     yarn_lock = "//:yarn.lock",
 )

--- a/examples/nestjs/src/BUILD.bazel
+++ b/examples/nestjs/src/BUILD.bazel
@@ -68,6 +68,10 @@ nodejs_binary(
 
 jasmine_node_test(
     name = "test",
+    # Workaround for https://github.com/bazelbuild/rules_nodejs/issues/3280
+    # The @bazel/jasmine package is installed as a directory, so we need to use a dictionary
+    # to give a nested path to the entry point in that directory.
+    jasmine_entry_point = {"@npm//:node_modules/@bazel/jasmine": "jasmine_runner.js"},
     deps = [
         ":test_lib",
     ],


### PR DESCRIPTION
Workaround for https://github.com/bazelbuild/rules_nodejs/issues/3280