### PR TITLE
fix(builtin): reduce linker debug string allocations

### DIFF
--- a/internal/linker/link_node_modules.bzl
+++ b/internal/linker/link_node_modules.bzl
@@ -14,9 +14,9 @@ runtimes to locate all the first-party packages.
 load("//internal/providers:external_npm_package_info.bzl", "ExternalNpmPackageInfo")
 load("@rules_nodejs//nodejs:providers.bzl", "LinkablePackageInfo")
 
-def _debug(vars, *args):
+def _debug(vars, format, args_tuple):
     if "VERBOSE_LOGS" in vars.keys():
-        print("[link_node_modules.bzl]", *args)
+        print("[link_node_modules.bzl]", format % args_tuple)
 
 LinkerPackageMappingInfo = provider(
     doc = """Provider capturing package mappings for the linker to consume.""",
@@ -194,9 +194,9 @@ def _get_linker_package_mapping_info(target, ctx):
     # Look for LinkablePackageInfo mapping in this node
     # LinkablePackageInfo may be provided without a package_name so check for that case as well
     if not LinkablePackageInfo in target:
-        _debug(ctx.var, "No LinkablePackageInfo for", target.label)
+        _debug(ctx.var, "No LinkablePackageInfo for %s", (target.label))
     elif not target[LinkablePackageInfo].package_name:
-        _debug(ctx.var, "No package_name in LinkablePackageInfo for", target.label)
+        _debug(ctx.var, "No package_name in LinkablePackageInfo for %s", (target.label))
     else:
         linkable_package_info = target[LinkablePackageInfo]
         package_path = linkable_package_info.package_path if hasattr(linkable_package_info, "package_path") else ""
@@ -207,7 +207,7 @@ def _get_linker_package_mapping_info(target, ctx):
                 link_path = linkable_package_info.path,
             ),
         )
-        _debug(ctx.var, "target %s (package path: %s) adding module mapping %s: %s" % (
+        _debug(ctx.var, "target %s (package path: %s) adding module mapping %s: %s", (
             target.label,
             package_path,
             linkable_package_info.package_name,


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The Node linker performs one string formatting per transitive dependency even if `VERBOSE_LOGS` is not set.

## What is the new behavior?

Construct the formatted strings lazily to prevent allocating and formatting a string for every transitive dependency.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

@gregmagolan Very small follow-up to #3301 

