### PR TITLE
Add type definitions to react example

### DIFF
--- a/examples/create-react-app/BUILD.bazel
+++ b/examples/create-react-app/BUILD.bazel
@@ -105,7 +105,10 @@ react_scripts(
         "--node_options=--require=$(rootpath chdir.js)",
         "start",
     ],
-    data = _RUNTIME_DEPS,
+    data = _RUNTIME_DEPS + [
+        "@npm//@types/react",
+        "@npm//@types/react-dom",
+    ],
     tags = [
         # This tag instructs ibazel to pipe into stdin a event describing actions.
         # ibazel send EOF to stdin by default and `react-scripts start` will stop when getting EOF in stdin.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Create react app //:start target appears to be missing the following 2 type definitions:
- @npm//@types/react
- @npm//@types/react-dom

running the following on the current stable branch yields the following behaviour:
```
$ cd examples/create-react-app
$ bazel run //:start

# Snip
  > 1 | import React from 'react';
      |                   ^
    2 | import logo from './logo.svg';
    3 | import './App.css';
    4 |
```

## What is the new behavior?
```
$ cd examples/create-react-app
$ bazel run //:start

Compiled successfully!

You can now view create-react-app in the browser.

  Local:            http://localhost:3000
# Snip
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
