### PR TITLE
fix(builtin): avoid unnecessary chdir to prevent worker threads from failing

### DIFF
--- a/internal/node/test/chdir/BUILD.bazel
+++ b/internal/node/test/chdir/BUILD.bazel
@@ -52,3 +52,10 @@ nodejs_test(
     data = ["build/app.js"],
     entry_point = "test.js",
 )
+
+nodejs_test(
+    name = "test_multithread",
+    chdir = package_name(),
+    data = ["worker.js"],
+    entry_point = "multithread.js",
+)

--- a/internal/node/test/chdir/multithread.js
+++ b/internal/node/test/chdir/multithread.js
@@ -1,0 +1,18 @@
+const { Worker } = require("worker_threads")
+
+function runWorker(message) {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker("./worker.js", {workerData: {message}});
+    worker.on("message", resolve);
+    worker.on("error", reject);
+    worker.on("exit", code => {
+      if (0 !== code) {
+        reject(new Error(`Worker exited with code ${code}`));
+      }
+    });
+  })
+}
+
+(async () => {
+    await runWorker("foobar");
+})();

--- a/internal/node/test/chdir/worker.js
+++ b/internal/node/test/chdir/worker.js
@@ -1,0 +1,4 @@
+const {parentPort, workerData} = require("worker_threads");
+
+console.log(workerData.message);
+parentPort.postMessage(true);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When the `chdir` attribute is used in `nodejs_test`, the script that changes the directory will run in each worker thread. Node fails when `process.chdir` is called in a worker thread. This is because node is invoked using `--require` on the chdir script: https://github.com/bazelbuild/rules_nodejs/blob/stable/internal/node/node.bzl#L286

## What is the new behavior?

Only change directories once in the main node process. Spawned workers won't try to change the directory again.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This is needed for an architect_test rule in angular/aio to work. That project is currently on rules_nodejs 4.6.0, so I suppose we'll want to backport this and cherry-pick it into stable?
