### PR TITLE
feat(builtin): add silent_on_success option to npm_package_bin

### DIFF
--- a/docs/Built-ins.md
+++ b/docs/Built-ins.md
@@ -1859,7 +1859,7 @@ Other attributes
 
 <pre>
 npm_package_bin(<a href="#npm_package_bin-tool">tool</a>, <a href="#npm_package_bin-package">package</a>, <a href="#npm_package_bin-package_bin">package_bin</a>, <a href="#npm_package_bin-data">data</a>, <a href="#npm_package_bin-env">env</a>, <a href="#npm_package_bin-outs">outs</a>, <a href="#npm_package_bin-args">args</a>, <a href="#npm_package_bin-stderr">stderr</a>, <a href="#npm_package_bin-stdout">stdout</a>, <a href="#npm_package_bin-exit_code_out">exit_code_out</a>,
-                <a href="#npm_package_bin-output_dir">output_dir</a>, <a href="#npm_package_bin-link_workspace_root">link_workspace_root</a>, <a href="#npm_package_bin-chdir">chdir</a>, <a href="#npm_package_bin-kwargs">kwargs</a>)
+                <a href="#npm_package_bin-output_dir">output_dir</a>, <a href="#npm_package_bin-link_workspace_root">link_workspace_root</a>, <a href="#npm_package_bin-chdir">chdir</a>, <a href="#npm_package_bin-silent_on_success">silent_on_success</a>, <a href="#npm_package_bin-kwargs">kwargs</a>)
 </pre>
 
 Run an arbitrary npm package binary (e.g. a program under node_modules/.bin/*) under Bazel.
@@ -2027,6 +2027,13 @@ npm_package_bin(
 ```
 
 Defaults to `None`
+
+<h4 id="npm_package_bin-silent_on_success">silent_on_success</h4>
+
+produce no output on stdout nor stderr when program exits with status code 0.
+This makes node binaries match the expected bazel paradigm.
+
+Defaults to `False`
 
 <h4 id="npm_package_bin-kwargs">kwargs</h4>
 

--- a/docs/Rollup.md
+++ b/docs/Rollup.md
@@ -198,8 +198,8 @@ rollup_bundle(
 
 <pre>
 rollup_bundle(<a href="#rollup_bundle-name">name</a>, <a href="#rollup_bundle-args">args</a>, <a href="#rollup_bundle-config_file">config_file</a>, <a href="#rollup_bundle-deps">deps</a>, <a href="#rollup_bundle-entry_point">entry_point</a>, <a href="#rollup_bundle-entry_points">entry_points</a>, <a href="#rollup_bundle-format">format</a>, <a href="#rollup_bundle-link_workspace_root">link_workspace_root</a>,
-              <a href="#rollup_bundle-output_dir">output_dir</a>, <a href="#rollup_bundle-rollup_bin">rollup_bin</a>, <a href="#rollup_bundle-rollup_worker_bin">rollup_worker_bin</a>, <a href="#rollup_bundle-silent">silent</a>, <a href="#rollup_bundle-sourcemap">sourcemap</a>, <a href="#rollup_bundle-srcs">srcs</a>, <a href="#rollup_bundle-stamp">stamp</a>,
-              <a href="#rollup_bundle-supports_workers">supports_workers</a>)
+              <a href="#rollup_bundle-output_dir">output_dir</a>, <a href="#rollup_bundle-rollup_bin">rollup_bin</a>, <a href="#rollup_bundle-rollup_worker_bin">rollup_worker_bin</a>, <a href="#rollup_bundle-silent">silent</a>, <a href="#rollup_bundle-silent_on_success">silent_on_success</a>, <a href="#rollup_bundle-sourcemap">sourcemap</a>, <a href="#rollup_bundle-srcs">srcs</a>,
+              <a href="#rollup_bundle-stamp">stamp</a>, <a href="#rollup_bundle-supports_workers">supports_workers</a>)
 </pre>
 
 Runs the rollup.js CLI under Bazel.
@@ -350,6 +350,15 @@ Defaults to `@npm//@bazel/rollup/bin:rollup-worker`
 Using --silent can cause rollup to [ignore errors/warnings](https://github.com/rollup/rollup/blob/master/docs/999-big-list-of-options.md#onwarn) 
 which are only surfaced via logging.  Since bazel expects printing nothing on success, setting silent to True
 is a more Bazel-idiomatic experience, however could cause rollup to drop important warnings.
+
+Defaults to `False`
+
+<h4 id="rollup_bundle-silent_on_success">silent_on_success</h4>
+
+(*Boolean*): Even stronger than --silent, defaults to False.
+
+Since the build still emits some texted, even when passed --silent, this uses the same flag as npm_package_bin to
+supress all output on sucess.
 
 Defaults to `False`
 

--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -231,7 +231,7 @@ for more details about the trade-offs between the two rules.
 
 Some TypeScript options affect which files are emitted, and Bazel wants to know these ahead-of-time.
 So several options from the tsconfig file must be mirrored as attributes to ts_project.
-See https://www.typescriptlang.org/tsconfig for a listing of the TypeScript options.
+See https://www.typescriptlang.org/v2/en/tsconfig for a listing of the TypeScript options.
 
 Any code that works with `tsc` should work with `ts_project` with a few caveats:
 

--- a/internal/node/npm_package_bin.bzl
+++ b/internal/node/npm_package_bin.bzl
@@ -17,6 +17,7 @@ _ATTRS = {
     "link_workspace_root": attr.bool(),
     "output_dir": attr.bool(),
     "outs": attr.output_list(),
+    "silent_on_success": attr.bool(),
     "stderr": attr.output(),
     "stdout": attr.output(),
     "tool": attr.label(
@@ -91,6 +92,7 @@ def _impl(ctx):
         stdout = ctx.outputs.stdout,
         stderr = ctx.outputs.stderr,
         exit_code_out = ctx.outputs.exit_code_out,
+        silent_on_success = ctx.attr.silent_on_success,
         link_workspace_root = ctx.attr.link_workspace_root,
     )
     files = outputs + tool_outputs
@@ -118,6 +120,7 @@ def npm_package_bin(
         output_dir = False,
         link_workspace_root = False,
         chdir = None,
+        silent_on_success = False,
         **kwargs):
     """Run an arbitrary npm package binary (e.g. a program under node_modules/.bin/*) under Bazel.
 
@@ -146,6 +149,8 @@ def npm_package_bin(
         exit_code_out: set to capture the exit code of the binary to a file, which can later be used as an input to another target
                 subject to the same semantics as `outs`. Note that setting this will force the binary to exit 0.
                 If the binary creates outputs and these are declared, they must still be created
+        silent_on_success: produce no output on stdout nor stderr when program exits with status code 0.
+                This makes node binaries match the expected bazel paradigm.
 
         args: Command-line arguments to the tool.
 
@@ -239,5 +244,6 @@ def npm_package_bin(
         output_dir = output_dir,
         tool = tool,
         link_workspace_root = link_workspace_root,
+        silent_on_success = silent_on_success,
         **kwargs
     )

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -267,6 +267,21 @@ generated_file_test(
     generated = ":minified.stdout.js",
 )
 
+# target that shouldn't print anything on stdout nor stderr when built even through the binary does
+npm_package_bin(
+    name = "loud_binary",
+    args = [
+        "$(execpath terser_input_with_diagnostics.js)",
+        "--compress",
+        "--verbose",
+        "--warn",
+    ],
+    data = ["terser_input_with_diagnostics.js"],
+    output_dir = True,
+    package = "terser",
+    silent_on_success = True,
+)
+
 # capture stderr to diagnostics.out, then analyze it in terser_diagnostics_stats printing some stats
 # stdout is captured into greeter.min.js (again, without the --output $@ flags)
 # the exit code is also capture to a file with exit_code_out, allowing downstream actions to read it

--- a/internal/providers/node_runtime_deps_info.bzl
+++ b/internal/providers/node_runtime_deps_info.bzl
@@ -127,6 +127,10 @@ def run_node(ctx, inputs, arguments, executable, chdir = None, **kwargs):
         add_arg(arguments, "--bazel_capture_exit_code=%s" % exit_code_file.path)
         outputs = outputs + [exit_code_file]
 
+    silent_on_success = kwargs.pop("silent_on_success", False)
+    if silent_on_success:
+        add_arg(arguments, "--bazel_silent_on_success=1")
+
     if chdir:
         add_arg(arguments, "--bazel_node_working_dir=" + chdir)
 

--- a/packages/rollup/rollup_bundle.bzl
+++ b/packages/rollup/rollup_bundle.bzl
@@ -140,6 +140,13 @@ which are only surfaced via logging.  Since bazel expects printing nothing on su
 is a more Bazel-idiomatic experience, however could cause rollup to drop important warnings.
 """,
     ),
+    "silent_on_success": attr.bool(
+        doc = """Even stronger than --silent, defaults to False.
+
+Since the build still emits some texted, even when passed --silent, this uses the same flag as npm_package_bin to
+supress all output on sucess.
+""",
+    ),
     "sourcemap": attr.string(
         doc = """Whether to produce sourcemaps.
 
@@ -345,6 +352,7 @@ def _rollup_bundle(ctx):
         execution_requirements = execution_requirements,
         env = {"COMPILATION_MODE": ctx.var["COMPILATION_MODE"]},
         link_workspace_root = ctx.attr.link_workspace_root,
+        silent_on_success = ctx.attr.silent_on_success,
     )
 
     outputs_depset = depset(outputs)

--- a/packages/rollup/test/silent/BUILD.bazel
+++ b/packages/rollup/test/silent/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//packages/rollup:index.bzl", "rollup_bundle")
+
+rollup_bundle(
+    name = "silent",
+    srcs = ["input.js"],
+    entry_points = {"input.js": "silent"},
+    silent = True,
+)
+
+rollup_bundle(
+    name = "silent_on_success",
+    srcs = ["input.js"],
+    entry_points = {"input.js": "silent_on_success"},
+    silent_on_success = True,
+)

--- a/packages/rollup/test/silent/input.js
+++ b/packages/rollup/test/silent/input.js
@@ -1,0 +1,1 @@
+console.log("hello");


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

nodejs programs which output on stdout and stderr have no way to be silenced on success


## What is the new behavior?

A new flag where we can silence binaries that are loud when they are successful.

I couldn't figure out how to write a test here since `sh_test` can't invoke `bazel build` commands easily to check the stdout, and my flag doesn't change the behavior of the `stdout` nor `stderr` files incase a user wants to still use them.

Without this flag I get:
```
$ bazel build internal/node/test:loud_binary
...
INFO: From Action internal/node/test/loud_binary:
WARN: Dropping unreachable code [internal/node/test/terser_input_with_diagnostics.js:6,4]
class Greeter{greet(name){return name}}
Target //internal/node/test:loud_binary up-to-date:
  dist/bin/internal/node/test/loud_binary
```

and then with it I get:
```
$ bazel build internal/node/test:loud_binary
...
Target //internal/node/test:loud_binary up-to-date:
  dist/bin/internal/node/test/loud_binary
```

And if I introduce a syntax error into `internal/node/test/terser_input_with_diagnostics.js` I still see the errors when running:
```
$ bazel build internal/node/test:loud_binary
...
Parse error at internal/node/test/terser_input_with_diagnostics.js:9,0
ERROR: Unexpected token: eof (undefined)
...
Target //internal/node/test:loud_binary failed to build
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

