### PR TITLE
fix(builtin): take custom node_repositories value into account when checking if Node version exists for the platform

### DIFF
--- a/nodejs/private/os_name.bzl
+++ b/nodejs/private/os_name.bzl
@@ -72,12 +72,17 @@ def is_linux_os(rctx):
     name = os_name(rctx)
     return name == OS_NAMES[3] or name == OS_NAMES[4] or name == OS_NAMES[5] or name == OS_NAMES[6]
 
-def node_exists_for_os(node_version, os_name):
-    return "-".join([node_version, os_name]) in NODE_VERSIONS.keys()
+def node_exists_for_os(node_version, os_name, node_repositories):
+    if not node_repositories:
+        node_repositories = NODE_VERSIONS
+
+    return "-".join([node_version, os_name]) in node_repositories.keys()
 
 def assert_node_exists_for_host(rctx):
     node_version = rctx.attr.node_version
-    if not node_exists_for_os(node_version, os_name(rctx)):
+    node_repositories = rctx.attr.node_repositories
+
+    if not node_exists_for_os(node_version, os_name(rctx), node_repositories):
         fail("No nodejs is available for {} at version {}".format(os_name(rctx), node_version) +
              "\n    Consider upgrading by setting node_version in a call to node_repositories in WORKSPACE." +
              "\n    Note that Node 16.x is the minimum published for Apple Silicon (M1 Macs)")

--- a/nodejs/private/user_build_settings.bzl
+++ b/nodejs/private/user_build_settings.bzl
@@ -13,7 +13,7 @@ def _impl(ctx):
 user_args = rule(
     implementation = _impl,
     # This line separates a build setting from a regular target, by using
-    # the `build_setting` atttribute, you mark this rule as a build setting
+    # the `build_setting` attribute, you mark this rule as a build setting
     # including what raw type it is and if it can be used on the command
     # line or not (if yes, you must set `flag = True`)
     build_setting = config.string(flag = True),

--- a/nodejs/repositories.bzl
+++ b/nodejs/repositories.bzl
@@ -147,15 +147,17 @@ def _download_node(repository_ctx):
 
     _verify_version_is_valid(node_version)
 
-    # Skip the download if we know it will fail
-    if not node_exists_for_os(node_version, host_os):
-        return
     node_repositories = repository_ctx.attr.node_repositories
 
     # We insert our default value here, not on the attribute's default, so it isn't documented.
     # The size of NODE_VERSIONS constant is huge and not useful to document.
     if not node_repositories.items():
         node_repositories = NODE_VERSIONS
+
+    # Skip the download if we know it will fail
+    if not node_exists_for_os(node_version, host_os, node_repositories):
+        return
+
     node_urls = repository_ctx.attr.node_urls
 
     # Download node & npm


### PR DESCRIPTION
When setting `node_repositories` attribute on the `node_repositories` rule (well that's kinda confusing), ensure this is taken into account when checking if the requested node version exists for the platform.

This can be useful when trying to trick rnj into downloading a different version of Node for a given OS (eg, a newer version of Node on darwin arm64), or when setting this attr to a version of Node that isn't included in the default list of `NODE_VERSIONS` yet.