### PR TITLE
fix(builtin): take custom node_repositories value into account when checking if Node version exists for the platform

### DIFF
--- a/internal/node/node_repositories.bzl
+++ b/internal/node/node_repositories.bzl
@@ -42,13 +42,20 @@ def node_repositories(**kwargs):
         minimum_bazel_version = "4.0.0",
     )
 
+    # Cheap check to see if we have already set up the node_repositories when being called via the
+    # npm_install or yarn_install macros that call this first
+    if "nodejs" in native.existing_rules().keys():
+        return
+
     # This needs to be setup so toolchains can access nodejs for all different versions
     node_version = kwargs.get("node_version", DEFAULT_NODE_VERSION)
+    node_repositories = kwargs.get("node_repositories", None)
+
     for os_arch_name in OS_ARCH_NAMES:
         os_name = "_".join(os_arch_name)
 
         # If we couldn't download node, don't make an external repo for it either
-        if not node_exists_for_os(node_version, os_name):
+        if not node_exists_for_os(node_version, os_name, node_repositories):
             continue
         node_repository_name = "nodejs_%s" % os_name
         _maybe(

--- a/nodejs/private/os_name.bzl
+++ b/nodejs/private/os_name.bzl
@@ -72,12 +72,17 @@ def is_linux_os(rctx):
     name = os_name(rctx)
     return name == OS_NAMES[3] or name == OS_NAMES[4] or name == OS_NAMES[5] or name == OS_NAMES[6]
 
-def node_exists_for_os(node_version, os_name):
-    return "-".join([node_version, os_name]) in NODE_VERSIONS.keys()
+def node_exists_for_os(node_version, os_name, node_repositories):
+    if not node_repositories:
+        node_repositories = NODE_VERSIONS
+
+    return "-".join([node_version, os_name]) in node_repositories.keys()
 
 def assert_node_exists_for_host(rctx):
     node_version = rctx.attr.node_version
-    if not node_exists_for_os(node_version, os_name(rctx)):
+    node_repositories = rctx.attr.node_repositories
+
+    if not node_exists_for_os(node_version, os_name(rctx), node_repositories):
         fail("No nodejs is available for {} at version {}".format(os_name(rctx), node_version) +
              "\n    Consider upgrading by setting node_version in a call to node_repositories in WORKSPACE." +
              "\n    Note that Node 16.x is the minimum published for Apple Silicon (M1 Macs)")

--- a/nodejs/repositories.bzl
+++ b/nodejs/repositories.bzl
@@ -255,15 +255,17 @@ def _download_node(repository_ctx):
 
     _verify_version_is_valid(node_version)
 
-    # Skip the download if we know it will fail
-    if not node_exists_for_os(node_version, host_os):
-        return
     node_repositories = repository_ctx.attr.node_repositories
 
     # We insert our default value here, not on the attribute's default, so it isn't documented.
     # The size of NODE_VERSIONS constant is huge and not useful to document.
     if not node_repositories.items():
         node_repositories = NODE_VERSIONS
+
+    # Skip the download if we know it will fail
+    if not node_exists_for_os(node_version, host_os, node_repositories):
+        return
+
     node_urls = repository_ctx.attr.node_urls
 
     # Download node & npm


### PR DESCRIPTION
4.x version of #3339
Contains cherry-pick of 5a1cbfaf5ebedc7b9c94f80d9bdb0509508c6377

Fixes issue raised in #3319 by @mitul45 and on Slack by @mhevery 