### PR TITLE
fix(builtin): use srcs on genrule to not build tool for host

### DIFF
--- a/internal/pkg_npm/pkg_npm.bzl
+++ b/internal/pkg_npm/pkg_npm.bzl
@@ -395,13 +395,11 @@ def pkg_npm_macro(name, tgz = None, **kwargs):
         native.genrule(
             name = "%s.tar" % name,
             outs = [tgz],
-            # NOTE(mattem): on windows, it seems to output a buch of other stuff on stdout when piping, so pipe to tail
+            # NOTE(mattem): on windows, it seems to output a bunch of other stuff on stdout when piping, so pipe to tail
             # and grab the last line
             cmd = "$(location :%s.pack) 2>/dev/null | tail -1 | xargs -I {} cp {} $@" % name,
             srcs = [
                 name,
-            ],
-            tools = [
                 ":%s.pack" % name,
             ],
             tags = [

--- a/internal/pkg_npm/test/tgz_out/BUILD.bazel
+++ b/internal/pkg_npm/test/tgz_out/BUILD.bazel
@@ -7,6 +7,10 @@ pkg_npm(
         "main.js",
         "package.json",
     ],
+    stamp = "@rules_nodejs//nodejs/stamp:always",
+    substitutions = {
+        "0.0.0-PLACEHOLDER": "${BUILD_SCM_VERSION}",
+    },
     tgz = "my_tar.tgz",
 )
 

--- a/internal/pkg_npm/test/tgz_out/test.sh
+++ b/internal/pkg_npm/test/tgz_out/test.sh
@@ -17,6 +17,7 @@ function test_tgz_package_json() {
     tar -vxf "${TGZ}"
     
     assert_contains "awesome-package" "./package/package.json"
+    assert_contains "1.2.3" "./package/package.json"
     assert_contains "MAIN" "./package/main.js"
 }
 


### PR DESCRIPTION
As the `.pack` script was part of the `tools` attr, it was built for the host (I think?) therefore stamping etc was lost. Move it to `srcs`.

Closes #3143