### PR TITLE
docs: add data attribute to ts_project macro

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -210,7 +210,7 @@ Defaults to `[]`
 **USAGE**
 
 <pre>
-ts_project(<a href="#ts_project-name">name</a>, <a href="#ts_project-tsconfig">tsconfig</a>, <a href="#ts_project-srcs">srcs</a>, <a href="#ts_project-args">args</a>, <a href="#ts_project-deps">deps</a>, <a href="#ts_project-extends">extends</a>, <a href="#ts_project-allow_js">allow_js</a>, <a href="#ts_project-declaration">declaration</a>, <a href="#ts_project-source_map">source_map</a>,
+ts_project(<a href="#ts_project-name">name</a>, <a href="#ts_project-tsconfig">tsconfig</a>, <a href="#ts_project-srcs">srcs</a>, <a href="#ts_project-args">args</a>, <a href="#ts_project-data">data</a>, <a href="#ts_project-deps">deps</a>, <a href="#ts_project-extends">extends</a>, <a href="#ts_project-allow_js">allow_js</a>, <a href="#ts_project-declaration">declaration</a>, <a href="#ts_project-source_map">source_map</a>,
            <a href="#ts_project-declaration_map">declaration_map</a>, <a href="#ts_project-resolve_json_module">resolve_json_module</a>, <a href="#ts_project-preserve_jsx">preserve_jsx</a>, <a href="#ts_project-composite">composite</a>, <a href="#ts_project-incremental">incremental</a>,
            <a href="#ts_project-emit_declaration_only">emit_declaration_only</a>, <a href="#ts_project-transpiler">transpiler</a>, <a href="#ts_project-ts_build_info_file">ts_build_info_file</a>, <a href="#ts_project-tsc">tsc</a>, <a href="#ts_project-typescript_package">typescript_package</a>,
            <a href="#ts_project-typescript_require_path">typescript_require_path</a>, <a href="#ts_project-validate">validate</a>, <a href="#ts_project-supports_workers">supports_workers</a>, <a href="#ts_project-declaration_dir">declaration_dir</a>, <a href="#ts_project-out_dir">out_dir</a>, <a href="#ts_project-root_dir">root_dir</a>,
@@ -388,6 +388,14 @@ Defaults to `None`
 <h4 id="ts_project-args">args</h4>
 
 List of strings of additional command-line arguments to pass to tsc.
+
+Defaults to `[]`
+
+<h4 id="ts_project-data">data</h4>
+
+files needed at runtime by binaries or tests that transitively depend on this target.
+
+See https://bazel.build/reference/be/common-definitions#typical-attributes
 
 Defaults to `[]`
 

--- a/packages/typescript/index.bzl
+++ b/packages/typescript/index.bzl
@@ -41,6 +41,7 @@ def ts_project(
         tsconfig = None,
         srcs = None,
         args = [],
+        data = [],
         deps = [],
         extends = None,
         allow_js = False,
@@ -180,6 +181,10 @@ def ts_project(
             - Include `**/*.ts[x]` (all TypeScript files in the package).
             - If `allow_js` is set, include `**/*.js[x]` (all JavaScript files in the package).
             - If `resolve_json_module` is set, include `**/*.json` (all JSON files in the package), but exclude `**/package.json`, `**/package-lock.json`, and `**/tsconfig*.json`.
+
+        data: files needed at runtime by binaries or tests that transitively depend on this target.
+
+            See https://bazel.build/reference/be/common-definitions#typical-attributes
 
         deps: List of labels of other rules that produce TypeScript typings (.d.ts files)
 
@@ -576,6 +581,7 @@ This is an error because Bazel does not run actions unless their outputs are nee
         name = tsc_target_name,
         srcs = srcs,
         args = args,
+        data = data,
         deps = tsc_deps,
         tsconfig = tsconfig,
         extends = extends,


### PR DESCRIPTION
This doesn't change behavior; previously it was included in the **kwargs passed to the underlying ts_project rule.
However it makes the documentation less confusing
