### PR TITLE
test(builtin): test showing duplicate module load when using workspace root

### DIFF
--- a/internal/linker/test/double_workspace_link/BUILD.bazel
+++ b/internal/linker/test/double_workspace_link/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//packages/jasmine:index.bzl", "jasmine_node_test")
+
+jasmine_node_test(
+    name = "test-",
+    srcs = ["test.js"],
+    link_workspace_root = True,
+    deps = [
+        "//internal/linker/test/double_workspace_link/bar",
+        "//internal/linker/test/double_workspace_link/foo",
+        "@npm//npm",
+    ],
+)

--- a/internal/linker/test/double_workspace_link/bar/BUILD.bazel
+++ b/internal/linker/test/double_workspace_link/bar/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+
+js_library(
+    name = "bar",
+    srcs = ["index.js"],
+    visibility = ["//internal/linker/test/double_workspace_link:__pkg__"],
+    deps = ["@npm//npm"],
+)

--- a/internal/linker/test/double_workspace_link/bar/index.js
+++ b/internal/linker/test/double_workspace_link/bar/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  bar_npm: require("npm"),
+};

--- a/internal/linker/test/double_workspace_link/foo/BUILD.bazel
+++ b/internal/linker/test/double_workspace_link/foo/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+
+js_library(
+    name = "foo",
+    srcs = ["index.js"],
+    visibility = ["//internal/linker/test/double_workspace_link:__pkg__"],
+    deps = ["@npm//npm"],
+)

--- a/internal/linker/test/double_workspace_link/foo/index.js
+++ b/internal/linker/test/double_workspace_link/foo/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  foo_npm: require("npm"),
+};

--- a/internal/linker/test/double_workspace_link/test.js
+++ b/internal/linker/test/double_workspace_link/test.js
@@ -1,0 +1,13 @@
+const npm = require("npm");
+
+describe("linker", () => {
+  it("should load the same copy of a npm dep when link_workspace_root is True and loading from workspace root path", () => {
+    const foo = require("build_bazel_rules_nodejs/internal/linker/test/double_workspace_link/foo");
+    expect(foo.foo_npm === npm).toBe(true, "Expected foo_npm to be npm");
+  });
+
+  it("should load the same copy of a npm dep when link_workspace_root is True and loading from relative path", () => {
+    const bar = require("./bar");
+    expect(bar.bar_npm === npm).toBe(true, "Expected bar_npm to be npm");
+  });
+});


### PR DESCRIPTION

This PR is a test case showing  a bug in the linker when using link_workspace_root.  


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using `link_workspace_root = True`, any file that is loaded using the root import link will see a difference node_modules. This means that the same node_modules are available but at a different path, thus asking node to load the library twice. This is a bug not just for performance, but that many libraries require the same module being used and not multiple copies due to state management, etc... 


## What is the new behavior?

This bug should be fixed. I am not sure of the best strategy as I am not very familiar with the linker internals 


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No



<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

