### PR TITLE
test: update environment spec to work with windows

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -231,7 +231,7 @@ for more details about the trade-offs between the two rules.
 
 Some TypeScript options affect which files are emitted, and Bazel wants to know these ahead-of-time.
 So several options from the tsconfig file must be mirrored as attributes to ts_project.
-See https://www.typescriptlang.org/v2/en/tsconfig for a listing of the TypeScript options.
+See https://www.typescriptlang.org/tsconfig for a listing of the TypeScript options.
 
 Any code that works with `tsc` should work with `ts_project` with a few caveats:
 

--- a/internal/node/test/env.spec.js
+++ b/internal/node/test/env.spec.js
@@ -44,7 +44,10 @@ describe('launcher.sh environment', function() {
     expectPathsToMatch(process.env['BAZEL_WORKSPACE'], 'build_bazel_rules_nodejs');
     expectPathsToMatch(process.env['BAZEL_TARGET'], '//internal/node/test:env_test');
     expectPathsToMatch(process.cwd(), `${process.env['RUNFILES_DIR']}/build_bazel_rules_nodejs`);
-    expectPathsToMatch(process.env['PWD'], `${process.env['RUNFILES_DIR']}/build_bazel_rules_nodejs`);
+    expectPathsToMatch(
+      process.env['PWD'],
+      `${process.env['RUNFILES_DIR']}/build_bazel_rules_nodejs`
+    );
     // On Windows, an empty string value for 'BAZEL_NODE_MODULES_ROOTS' does not make it into
     // dump_build_env.json
     process.env['BAZEL_NODE_MODULES_ROOTS'] = process.env['BAZEL_NODE_MODULES_ROOTS'] || '';
@@ -54,23 +57,22 @@ describe('launcher.sh environment', function() {
       `${execroot}/node_modules`,
       `${runfilesRoot}`,
       `${runfilesRoot}/build_bazel_rules_nodejs/node_modules`,
-    ]
+    ];
     if (isWindows) {
       expectedRoots.push(
         process.env['RUNFILES'],
-        `${process.env['RUNFILES']}/build_bazel_rules_nodejs/node_modules`,
-      )
+        `${process.env['RUNFILES']}/build_bazel_rules_nodejs/node_modules`
+      );
     }
     expectPathsToMatch(process.env['BAZEL_PATCH_ROOTS'].split(','), expectedRoots);
   });
-  
+
   it('should setup correct bazel environment variables when in execroot with no third party deps', function() {
     const env = require(runfiles.resolvePackageRelative('dump_build_env.json'));
     // On Windows, an empty string value for 'BAZEL_NODE_MODULES_ROOTS' does not make it into
     // dump_build_env.json
     env['BAZEL_NODE_MODULES_ROOTS'] = env['BAZEL_NODE_MODULES_ROOTS'] || '';
-    // On Windows, the RUNFILES path ends in a /MANIFEST segment in this context
-    const runfilesRoot = normPath(isWindows ? path.dirname(env['RUNFILES']) : env['RUNFILES']);
+    const runfilesRoot = normPath(env['RUNFILES']);
     const match = runfilesRoot.match(/\/bazel-out\//);
     expect(!!match).toBe(true);
     const execroot = runfilesRoot.slice(0, match.index);
@@ -87,14 +89,13 @@ describe('launcher.sh environment', function() {
     ];
     expectPathsToMatch(env['BAZEL_PATCH_ROOTS'].split(','), expectedRoots);
   });
-    
+
   it('should setup correct bazel environment variables when in execroot with third party deps', function() {
     const env = require(runfiles.resolvePackageRelative('dump_build_env_alt.json'));
     // On Windows, an empty string value for 'BAZEL_NODE_MODULES_ROOTS' does not make it into
     // dump_build_env.json
     env['BAZEL_NODE_MODULES_ROOTS'] = env['BAZEL_NODE_MODULES_ROOTS'] || '';
-    // On Windows, the RUNFILES path ends in a /MANIFEST segment in this context
-    const runfilesRoot = normPath(isWindows ? path.dirname(env['RUNFILES']) : env['RUNFILES']);
+    const runfilesRoot = normPath(env['RUNFILES']);
     const match = runfilesRoot.match(/\/bazel-out\//);
     expect(!!match).toBe(true);
     const execroot = runfilesRoot.slice(0, match.index);
@@ -111,11 +112,10 @@ describe('launcher.sh environment', function() {
     ];
     expectPathsToMatch(env['BAZEL_PATCH_ROOTS'].split(','), expectedRoots);
   });
-    
+
   it('should setup correct bazel environment variables from env attr', function() {
     const env = require(runfiles.resolvePackageRelative('dump_build_env_attr.json'));
     expect(env['FOO']).toBe('BAR');
     expect(env['LOC']).toBe('build_bazel_rules_nodejs/internal/node/test/dump_build_env.js');
   });
 });
-    


### PR DESCRIPTION
It looks like the environment spec started failing on Windows. It was
thought that this started happening with 4a025c0d197a181cfcd9556831f69467817d3a40,
but it turnes out that this failed many commits before but a Buildkite status
just did not show up in the commit history (making it look like the PnP commit
caused the failures).

Root-cause seems to be https://github.com/bazelbuild/rules_nodejs/commit/7993296829c5ddaadb04a7d76ecc6b72eacdd01c which changed the `RUNFILES` variable.