### PR TITLE
Add mnemonic to action run by npm_package_bin

### DIFF
--- a/internal/node/npm_package_bin.bzl
+++ b/internal/node/npm_package_bin.bzl
@@ -94,7 +94,7 @@ def _impl(ctx):
         exit_code_out = ctx.outputs.exit_code_out,
         silent_on_success = ctx.attr.silent_on_success,
         link_workspace_root = ctx.attr.link_workspace_root,
-        mnemonic = 'NpmPackageBin',
+        mnemonic = "NpmPackageBin",
     )
     files = outputs + tool_outputs
     return [DefaultInfo(

--- a/internal/node/npm_package_bin.bzl
+++ b/internal/node/npm_package_bin.bzl
@@ -94,6 +94,7 @@ def _impl(ctx):
         exit_code_out = ctx.outputs.exit_code_out,
         silent_on_success = ctx.attr.silent_on_success,
         link_workspace_root = ctx.attr.link_workspace_root,
+        mnemonic = 'NpmPackageBin',
     )
     files = outputs + tool_outputs
     return [DefaultInfo(


### PR DESCRIPTION
This will allow easier tracking of this particular action being run.
In particular, we found that some npm package binaries take a lot of memory (like 8G), adding mnemonic would allow to find those actions more easily e.g. in execution logs, and perform different actions that bazel allows to do per mnemonic, in particular, enabling or disabling remote execution.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Simple addition of mnemonic to run action


## What is the current behavior?
```
$ ~/.cache/vanilla_bazel/bazel-5.0.0-linux-x86_64 test internal/node/test/... --execution_log_json_file=/tmp/exec_log.json
$ grep mnemonic /tmp/exec_log.json | sort | uniq -c
     23   "mnemonic": "Action",
      2   "mnemonic": "AssembleNpmPackage",
      2   "mnemonic": "CopyDirectory",
     11   "mnemonic": "CopyFile",
      1   "mnemonic": "GenerateNpmScripts",
      1   "mnemonic": "Genrule",
      1   "mnemonic": "Rollup",
     77   "mnemonic": "TestRunner",
      3   "mnemonic": "TsProject",

```


## What is the new behavior?

```
$ ~/.cache/vanilla_bazel/bazel-5.0.0-linux-x86_64 test internal/node/test/... --execution_log_json_file=/tmp/exec_log.json
$ grep mnemonic /tmp/exec_log.json | sort | uniq -c
      3   "mnemonic": "Action",
      2   "mnemonic": "AssembleNpmPackage",
      2   "mnemonic": "CopyDirectory",
     11   "mnemonic": "CopyFile",
      1   "mnemonic": "GenerateNpmScripts",
      1   "mnemonic": "Genrule",
     20   "mnemonic": "NpmPackageBin",
      1   "mnemonic": "Rollup",
     77   "mnemonic": "TestRunner",
      3   "mnemonic": "TsProject",
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
