### PR TITLE
fix: condition on target instead of exec

### DIFF
--- a/nodejs/private/toolchains_repo.bzl
+++ b/nodejs/private/toolchains_repo.bzl
@@ -18,18 +18,6 @@ with only the toolchain attribute pointing into the platform-specific repositori
 """
 
 PLATFORMS = {
-    "darwin_amd64": struct(
-        compatible_with = [
-            "@platforms//os:macos",
-            "@platforms//cpu:x86_64",
-        ],
-    ),
-    "darwin_arm64": struct(
-        compatible_with = [
-            "@platforms//os:macos",
-            "@platforms//cpu:aarch64",
-        ],
-    ),
     "linux_amd64": struct(
         compatible_with = [
             "@platforms//os:linux",
@@ -42,12 +30,6 @@ PLATFORMS = {
             "@platforms//cpu:aarch64",
         ],
     ),
-    "windows_amd64": struct(
-        compatible_with = [
-            "@platforms//os:windows",
-            "@platforms//cpu:x86_64",
-        ],
-    ),
     "linux_s390x": struct(
         compatible_with = [
             "@platforms//os:linux",
@@ -58,6 +40,24 @@ PLATFORMS = {
         compatible_with = [
             "@platforms//os:linux",
             "@platforms//cpu:ppc",
+        ],
+    ),
+    "darwin_amd64": struct(
+        compatible_with = [
+            "@platforms//os:macos",
+            "@platforms//cpu:x86_64",
+        ],
+    ),
+    "darwin_arm64": struct(
+        compatible_with = [
+            "@platforms//os:macos",
+            "@platforms//cpu:aarch64",
+        ],
+    ),
+    "windows_amd64": struct(
+        compatible_with = [
+            "@platforms//os:windows",
+            "@platforms//cpu:x86_64",
         ],
     ),
 }
@@ -104,6 +104,12 @@ resolved_toolchain(name = "resolved_toolchain", visibility = ["//visibility:publ
         build_content += """
 toolchain(
     name = "{platform}_toolchain",
+    exec_compatible_with = {compatible_with},
+    toolchain = "@{user_node_repository_name}_{platform}//:node_toolchain",
+    toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
+)
+toolchain(
+    name = "{platform}_toolchain_target",
     target_compatible_with = {compatible_with},
     toolchain = "@{user_node_repository_name}_{platform}//:node_toolchain",
     toolchain_type = "@rules_nodejs//nodejs:toolchain_type",

--- a/nodejs/private/toolchains_repo.bzl
+++ b/nodejs/private/toolchains_repo.bzl
@@ -104,7 +104,7 @@ resolved_toolchain(name = "resolved_toolchain", visibility = ["//visibility:publ
         build_content += """
 toolchain(
     name = "{platform}_toolchain",
-    exec_compatible_with = {compatible_with},
+    target_compatible_with = {compatible_with},
     toolchain = "@{user_node_repository_name}_{platform}//:node_toolchain",
     toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
 )

--- a/nodejs/repositories.bzl
+++ b/nodejs/repositories.bzl
@@ -388,7 +388,10 @@ def nodejs_register_toolchains(name, register = True, **kwargs):
             **kwargs
         )
         if register:
-            native.register_toolchains("@%s_toolchains//:%s_toolchain" % (name, platform))
+            native.register_toolchains(
+                "@%s_toolchains//:%s_toolchain_target" % (name, platform),
+                "@%s_toolchains//:%s_toolchain" % (name, platform),
+            )
 
     nodejs_repo_host_os_alias(
         name = name + "_host",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3357


## What is the new behavior?
nodejs toolchain was conditioned on the exec which led to nodejs_images using toolchain for the host instead of image target. hence images built from macOS were broken due to the wrong toolchain being used in runfiles. 


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Related issues;

https://github.com/bazelbuild/rules_docker/issues/2009

https://github.com/bazelbuild/rules_docker/pull/1963