### PR TITLE
refactor(builtin): allow static files to be specified in `pkg_npm` `create_package` helper

### DIFF
--- a/docs/Built-ins.md
+++ b/docs/Built-ins.md
@@ -1080,7 +1080,7 @@ Defaults to `@rules_nodejs//nodejs/stamp:use_stamp_flag`
 <h4 id="pkg_npm-substitutions">substitutions</h4>
 
 (*<a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a>*): Key-value pairs which are replaced in all the files while building the package.
-        
+
 You can use values from the workspace status command using curly braces, for example
 `{"0.0.0-PLACEHOLDER": "{STABLE_GIT_VERSION}"}`.
 


### PR DESCRIPTION
The `pkg_npm` builtin exposes a `create_package` helper that is leveraged
by the `ng_package` Angular Bazel rule. The `create_package` helper
currently always determines files from the `ctx`, and it's not possible
to add more files to the package, or to omit files that are already
processed by the `ng_package` wrapping rule implementation.

The static files should be configurable similar to deps and the nested
packages.