### PR TITLE
fix: use python3 instead of python in unittest.bash

### DIFF
--- a/third_party/github.com/bazelbuild/bazel-skylib/tests/unittest.bash
+++ b/third_party/github.com/bazelbuild/bazel-skylib/tests/unittest.bash
@@ -675,7 +675,7 @@ if [ "$UNAME" = "linux" ] || [[ "$UNAME" =~ msys_nt* ]]; then
 else
     function timestamp() {
       # OS X and FreeBSD do not have %N so python is the best we can do
-      python -c 'import time; print int(round(time.time() * 1000))'
+      python3 -c 'import time; print(int(round(time.time() * 1000)))'
     }
 fi
 


### PR DESCRIPTION
python 2 is dead, https://www.idownloadblog.com/2022/01/28/python-macos-monterey-no-more/