### PR TITLE
fix: use -R in copy_file(is_dir=True) so macos & linux behavior are the same

### DIFF
--- a/third_party/github.com/bazelbuild/bazel-skylib/rules/private/copy_file_private.bzl
+++ b/third_party/github.com/bazelbuild/bazel-skylib/rules/private/copy_file_private.bzl
@@ -85,7 +85,7 @@ def copy_cmd(ctx, src, dst):
 # buildifier: disable=function-docstring
 def copy_bash(ctx, src, dst):
     if dst.is_directory:
-        cmd_tmpl = "rm -rf \"$2\" && cp -rf \"$1/\" \"$2\""
+        cmd_tmpl = "rm -rf \"$2\" && cp -fR \"$1/\" \"$2\""
         mnemonic = "CopyDirectory"
         progress_message = "Copying directory %s" % src.path
     else:


### PR DESCRIPTION
Fixes #3381

For reference, the cp -r option is historic and discouraged on macos. It differs from cp -r on linux.
https://man7.org/linux/man-pages/man1/cp.1.html
https://ss64.com/osx/cp.html