### PR TITLE
fix: symlink to runfiles only when running under ibazel

### DIFF
--- a/internal/linker/index.js
+++ b/internal/linker/index.js
@@ -291,6 +291,8 @@ function main(args, runfiles) {
         log_verbose('isExecroot:', isExecroot.toString());
         const isBazelRun = !!process.env['BUILD_WORKSPACE_DIRECTORY'];
         log_verbose('isBazelRun:', isBazelRun.toString());
+        const isiBazel = !!process.env['IBAZEL'];
+        log_verbose('isiBazel:', isiBazel.toString());
         if (!isExecroot && execroot) {
             process.chdir(execroot);
             log_verbose('changed directory to execroot', execroot);
@@ -358,17 +360,19 @@ function main(args, runfiles) {
                     primaryNodeModules = execrootNodeModules;
                 }
             }
-            if (!isExecroot) {
-                const runfilesNodeModules = path.posix.join(startCwd, packagePath, 'node_modules');
-                yield mkdirp(path.dirname(runfilesNodeModules));
-                yield symlinkWithUnlink(primaryNodeModules, runfilesNodeModules);
-            }
-            if (process.env['RUNFILES']) {
-                const stat = yield gracefulLstat(process.env['RUNFILES']);
-                if (stat && stat.isDirectory()) {
-                    const runfilesNodeModules = path.posix.join(process.env['RUNFILES'], workspace, 'node_modules');
+            if (isiBazel) {
+                if (!isExecroot) {
+                    const runfilesNodeModules = path.posix.join(startCwd, packagePath, 'node_modules');
                     yield mkdirp(path.dirname(runfilesNodeModules));
                     yield symlinkWithUnlink(primaryNodeModules, runfilesNodeModules);
+                }
+                if (process.env['RUNFILES']) {
+                    const stat = yield gracefulLstat(process.env['RUNFILES']);
+                    if (stat && stat.isDirectory()) {
+                        const runfilesNodeModules = path.posix.join(process.env['RUNFILES'], workspace, 'node_modules');
+                        yield mkdirp(path.dirname(runfilesNodeModules));
+                        yield symlinkWithUnlink(primaryNodeModules, runfilesNodeModules);
+                    }
                 }
             }
         }

--- a/internal/linker/link_node_modules.ts
+++ b/internal/linker/link_node_modules.ts
@@ -427,6 +427,10 @@ export async function main(args: string[], runfiles: Runfiles) {
   const isBazelRun = !!process.env['BUILD_WORKSPACE_DIRECTORY']
   log_verbose('isBazelRun:', isBazelRun.toString());
 
+  // See: https://github.com/bazelbuild/bazel-watcher/commit/c089d96c95c2aa7a0acff02f5a7a458abefed8ec
+  const isiBazel = !!process.env['IBAZEL'];
+  log_verbose('isiBazel:', isiBazel.toString());
+
   if (!isExecroot && execroot) {
     // If we're not in the execroot and we've found one then change to the execroot
     // directory to create the node_modules symlinks
@@ -525,25 +529,29 @@ export async function main(args: string[], runfiles: Runfiles) {
       // https://github.com/bazelbuild/rules_nodejs/issues/3054
     }
 
-    // If start cwd was in runfiles then create
-    // start/cwd
-    if (!isExecroot) {
-      const runfilesNodeModules = path.posix.join(startCwd, packagePath, 'node_modules');
-      await mkdirp(path.dirname(runfilesNodeModules));
-      // Don't link to the root execroot node_modules if there is a workspace node_modules.
-      // Bazel will delete that symlink on rebuild in the ibazel run context.
-      await symlinkWithUnlink(primaryNodeModules, runfilesNodeModules);
-    }
-
-    // RUNFILES symlink -> execroot node_modules
-    if (process.env['RUNFILES']) {
-      const stat = await gracefulLstat(process.env['RUNFILES']);
-      if (stat && stat.isDirectory()) {
-        const runfilesNodeModules = path.posix.join(process.env['RUNFILES'], workspace, 'node_modules');
+    // Turn on <target>.runfiles/<wksp>/node_modules only when running under ibazel run
+    // where linker has no chance to rerun
+    if (isiBazel) {
+      // If start cwd was in runfiles then create
+      // start/cwd
+      if (!isExecroot) {
+        const runfilesNodeModules = path.posix.join(startCwd, packagePath, 'node_modules');
         await mkdirp(path.dirname(runfilesNodeModules));
         // Don't link to the root execroot node_modules if there is a workspace node_modules.
         // Bazel will delete that symlink on rebuild in the ibazel run context.
         await symlinkWithUnlink(primaryNodeModules, runfilesNodeModules);
+      }
+
+      // RUNFILES symlink -> execroot node_modules
+      if (process.env['RUNFILES']) {
+        const stat = await gracefulLstat(process.env['RUNFILES']);
+        if (stat && stat.isDirectory()) {
+          const runfilesNodeModules = path.posix.join(process.env['RUNFILES'], workspace, 'node_modules');
+          await mkdirp(path.dirname(runfilesNodeModules));
+          // Don't link to the root execroot node_modules if there is a workspace node_modules.
+          // Bazel will delete that symlink on rebuild in the ibazel run context.
+          await symlinkWithUnlink(primaryNodeModules, runfilesNodeModules);
+        }
       }
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Linker links into runfiles which causes nodejs to load from multiple node_modules.

Issue Number: #3067 


## What is the new behavior?
Linker does not link into runfiles tree unless it runs under `ibazel run` which was the original intention of us to link into runfiles. (i need to confirm this with @gregmagolan)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

