### PR TITLE
fix: enable stardoc generation for rules that depend on ts in core

### DIFF
--- a/nodejs/private/BUILD.bazel
+++ b/nodejs/private/BUILD.bazel
@@ -14,4 +14,8 @@ bzl_library(
     name = "bzl",
     srcs = glob(["*.bzl"]),
     visibility = ["//visibility:public"],
+    deps = [
+        "//nodejs/private/providers:bzl",
+        "@bazel_skylib//lib:dicts",
+    ],
 )

--- a/nodejs/private/ts_lib.bzl
+++ b/nodejs/private/ts_lib.bzl
@@ -1,6 +1,6 @@
 "Utilities functions for selecting and filtering ts and other files"
 
-load("@rules_nodejs//nodejs:providers.bzl", "DeclarationInfo")
+load("@rules_nodejs//nodejs/private/providers:declaration_info.bzl", "DeclarationInfo")
 
 ValidOptionsInfo = provider(
     doc = "Internal: whether the validator ran successfully",

--- a/nodejs/private/ts_project.bzl
+++ b/nodejs/private/ts_project.bzl
@@ -1,7 +1,8 @@
 "ts_project rule"
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load("@rules_nodejs//nodejs:providers.bzl", "DeclarationInfo", "declaration_info", "js_module_info")
+load("@rules_nodejs//nodejs/private/providers:declaration_info.bzl", "DeclarationInfo", "declaration_info")
+load("@rules_nodejs//nodejs/private/providers:js_providers.bzl", "js_module_info")
 load(":ts_lib.bzl", "COMPILER_OPTION_ATTRS", "OUTPUT_ATTRS", "STD_ATTRS", "ValidOptionsInfo", _lib = "lib")
 load(":ts_config.bzl", "TsConfigInfo")
 load(":ts_validate_options.bzl", _validate_lib = "lib")


### PR DESCRIPTION
Noticed when trying to build docs in downstream repo.

Why not fix this by adding stardoc locally so the bzl_library has some test coverage within this repo?
So far these TS APIs are all private here so I don't think we want to document them directly.