### PR TITLE
fix(jasmine): allow cjs specs + add cjs/mjs tests in jasmine_node_test

### DIFF
--- a/packages/jasmine/jasmine_node_test.bzl
+++ b/packages/jasmine/jasmine_node_test.bzl
@@ -21,6 +21,7 @@ than launching a test in Karma, for example.
 load("@rules_nodejs//nodejs:providers.bzl", "JSModuleInfo")
 load("//packages/jasmine/private:index.bzl", "bazel_jasmine_runner_test")
 load("@build_bazel_rules_nodejs//internal/node:node.bzl", nodejs_test = "nodejs_test_macro")
+load("@build_bazel_rules_nodejs//internal/common:is_js_file.bzl", "is_javascript_file")
 
 def _js_sources_impl(ctx):
     depsets = []
@@ -36,7 +37,7 @@ def _js_sources_impl(ctx):
     ctx.actions.write(ctx.outputs.manifest, "".join([
         f.short_path + "\n"
         for f in sources.to_list()
-        if f.path.endswith(".js") or f.path.endswith(".mjs")
+        if is_javascript_file(f)
     ]))
 
     return [DefaultInfo(files = sources)]

--- a/packages/jasmine/test/BUILD.bazel
+++ b/packages/jasmine/test/BUILD.bazel
@@ -3,33 +3,54 @@ load("//internal/common:copy_to_bin.bzl", "copy_to_bin")
 load("//packages/jasmine:index.bzl", "jasmine_node_test")
 load("//packages/typescript:index.bzl", "ts_project")
 
-jasmine_node_test(
-    name = "underscore_spec_test",
-    srcs = ["foo_spec.js"],
-)
+_JS_EXTENSIONS = [
+    "js",
+    "cjs",
+    "mjs",
+]
+
+[
+    jasmine_node_test(
+        name = "underscore_spec_%s_test" % ext,
+        srcs = ["foo_spec.%s" % ext],
+    )
+    for ext in _JS_EXTENSIONS
+]
 
 # Verify that a bootstrap script does not break the test
-jasmine_node_test(
-    name = "underscore_spec_bootstrap_test",
-    srcs = ["foo_spec.js"],
-    data = ["bootstrap.js"],
-    templated_args = ["--node_options=--require=$$(rlocation $(location :bootstrap.js))"],
-)
+[
+    jasmine_node_test(
+        name = "underscore_spec_%s_bootstrap_test" % ext,
+        srcs = ["foo_spec.%s" % ext],
+        data = ["bootstrap.js"],
+        templated_args = ["--node_options=--require=$$(rlocation $(location :bootstrap.js))"],
+    )
+    for ext in _JS_EXTENSIONS
+]
 
-jasmine_node_test(
-    name = "underscore_test_test",
-    srcs = ["foo_test.js"],
-)
+[
+    jasmine_node_test(
+        name = "underscore_test_%s_test" % ext,
+        srcs = ["foo_test.%s" % ext],
+    )
+    for ext in _JS_EXTENSIONS
+]
 
-jasmine_node_test(
-    name = "dot_spec_test",
-    srcs = ["foo.spec.js"],
-)
+[
+    jasmine_node_test(
+        name = "dot_spec_%s_test" % ext,
+        srcs = ["foo.spec.%s" % ext],
+    )
+    for ext in _JS_EXTENSIONS
+]
 
-jasmine_node_test(
-    name = "dot_test_test",
-    srcs = ["foo.test.js"],
-)
+[
+    jasmine_node_test(
+        name = "dot_test_%s_test" % ext,
+        srcs = ["foo.test.%s" % ext],
+    )
+    for ext in _JS_EXTENSIONS
+]
 
 jasmine_node_test(
     name = "sharding_test",

--- a/packages/jasmine/test/foo.spec.cjs
+++ b/packages/jasmine/test/foo.spec.cjs
@@ -1,0 +1,5 @@
+describe('spec in file ending with .spec.cjs', () => {
+  it('should run', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/jasmine/test/foo.spec.mjs
+++ b/packages/jasmine/test/foo.spec.mjs
@@ -1,0 +1,5 @@
+describe('spec in file ending with .spec.mjs', () => {
+  it('should run', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/jasmine/test/foo.test.cjs
+++ b/packages/jasmine/test/foo.test.cjs
@@ -1,0 +1,5 @@
+describe('spec in file ending with .test.cjs', () => {
+  it('should run', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/jasmine/test/foo.test.mjs
+++ b/packages/jasmine/test/foo.test.mjs
@@ -1,0 +1,5 @@
+describe('spec in file ending with .test.mjs', () => {
+  it('should run', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/jasmine/test/foo_spec.cjs
+++ b/packages/jasmine/test/foo_spec.cjs
@@ -1,0 +1,5 @@
+describe('spec in file ending with _spec.cjs', () => {
+  it('should run', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/jasmine/test/foo_spec.mjs
+++ b/packages/jasmine/test/foo_spec.mjs
@@ -1,0 +1,5 @@
+describe('spec in file ending with _spec.mjs', () => {
+  it('should run', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/jasmine/test/foo_test.cjs
+++ b/packages/jasmine/test/foo_test.cjs
@@ -1,0 +1,5 @@
+describe('spec in file ending with _test.cjs', () => {
+  it('should run', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/jasmine/test/foo_test.mjs
+++ b/packages/jasmine/test/foo_test.mjs
@@ -1,0 +1,5 @@
+describe('spec in file ending with _test.mjs', () => {
+  it('should run', () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using jasmine_node_test, currently spec/test files ending with the .cjs extension are not recognized.

Issue Number:
#3400


## What is the new behavior?
Spec/test files ending in the .cjs extension will be recognized

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This PR also adds tests for whether .mjs are recognized in jasmine_node_test
