### PR TITLE
fix(builtin): fix a bug where mjs entry points were not added to runfiles

### DIFF
--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -23,6 +23,7 @@ a `module_name` attribute can be `require`d by that name.
 load("@rules_nodejs//nodejs:providers.bzl", "DirectoryFilePathInfo", "JSModuleInfo", "UserBuildSettingInfo")
 load("//:providers.bzl", "ExternalNpmPackageInfo", "JSNamedModuleInfo", "NodeRuntimeDepsInfo", "node_modules_aspect")
 load("//internal/common:expand_into_runfiles.bzl", "expand_location_into_runfiles")
+load("//internal/common:is_js_file.bzl", "is_javascript_file")
 load("//internal/common:maybe_directory_file_path.bzl", "maybe_directory_file_path")
 load("//internal/common:module_mappings.bzl", "module_mappings_runtime_aspect")
 load("//internal/common:path_utils.bzl", "strip_external")
@@ -361,8 +362,8 @@ if (process.cwd() !== __dirname) {
         executable = ctx.outputs.launcher_sh
 
     # syntax sugar: allows you to avoid repeating the entry point in data
-    # entry point is only needed in runfiles if it is a .js file
-    if len(ctx.files.entry_point) == 1 and ctx.files.entry_point[0].extension == "js":
+    # entry point is only needed in runfiles if it is a javascript file
+    if len(ctx.files.entry_point) == 1 and is_javascript_file(ctx.files.entry_point[0]):
         runfiles.extend(ctx.files.entry_point)
 
     return [

--- a/internal/node/test/esm/BUILD.bazel
+++ b/internal/node/test/esm/BUILD.bazel
@@ -3,7 +3,6 @@ load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 nodejs_binary(
     name = "has_deps",
     data = [
-        "has-deps.mjs",
         "@fine_grained_deps_yarn//typescript",
     ],
     entry_point = ":has-deps.mjs",
@@ -11,6 +10,5 @@ nodejs_binary(
 
 nodejs_binary(
     name = "no_deps",
-    data = ["no-deps.mjs"],
     entry_point = ":no-deps.mjs",
 )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Generally related to https://github.com/bazelbuild/rules_nodejs/issues/3277

Calling `bazel run` on a `nodejs_binary` target that doesn't add its entry_point to `data` will cause node to run with no script.

## What is the new behavior?

The script is run properly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
