### PR TITLE
Allow including rules_nodejs without npm

### DIFF
--- a/packages/typescript/bin/BUILD.bazel
+++ b/packages/typescript/bin/BUILD.bazel
@@ -10,5 +10,5 @@ nodejs_binary(
     name = "ts_project_options_validator",
     data = ["@npm//typescript"],
     entry_point = "//packages/typescript/internal:ts_project_options_validator.js",
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, there is no way to include `rules_nodejs` as a regular GitHub dependency; it has to be downloaded with `npm` and imported with something like:

```starlark
load("@npm//@bazel/typescript:index.bzl", "ts_project")
```

This means that any `BUILD.bazel` files that use any of these rules have to download and install all of `@npm`, even if the typescript target isn't being built.

This makes queries and builds of non-typescript code significantly slower, since a project may have a large number of `@npm` dependencies.

With this fix, you have the option of importing the rules without `npm`, e.g.

```starlark
load("@build_bazel_rules_nodejs//packages/typescript:index.bzl", "ts_project")
```

Using the GitHub Archive at the tag rather. than the release artifact:

```starlark
http_archive(
    name = "build_bazel_rules_nodejs",
    patch_args = ["-p1"],
    sha256 = "580779e8f9ea752210b10bf1fd717103d6600640fcdf7fe977dfec0549181bd8",
    strip_prefix = "rules_nodejs-5.3.0",
    urls = ["https://github.com/bazelbuild/rules_nodejs/archive/refs/tags/5.3.0.tar.gz"],
)
```

The only issue is, if you do this, you get the error:

> ERROR: /foo/BUILD.bazel:29:11: in validate_options rule //foo:foo:_validate_google_ts_options: target '@build_bazel_rules_nodejs//packages/typescript/bin:ts_project_options_validator' is not visible from target '//common/proto/google:_validate_google_ts_options'. Check the visibility declaration of the former target if you think the dependency is legitimate

With this patch, the error is gone. After that, everything works as expected.

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

