### PR TITLE
docs: add hyperlinks and escape `<>`

### DIFF
--- a/docs/TypeScript.md
+++ b/docs/TypeScript.md
@@ -37,7 +37,7 @@ To use it, add the load statement `load("@npm//typescript:index.bzl", "tsc")` to
 Then call it, using the [`npm_package_bin`](Built-ins#npm_package_bin) documentation.
 
 Here is an example:
-https://github.com/bazelbuild/rules_nodejs/blob/3.2.2/internal/node/test/BUILD.bazel#L491-L507
+<https://github.com/bazelbuild/rules_nodejs/blob/3.2.2/internal/node/test/BUILD.bazel#L491-L507>
 
 ### Option 2: tsc_test
 
@@ -60,7 +60,7 @@ filegroup(name = "types", srcs = ["//some:js_library"], output_group = "types")
 
 And then include the `:types` target in the `data` of the `tsc_test`.
 
-See example in https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/tsc_test
+See example in <https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/tsc_test>
 
 ### Option 3: ts_project
 
@@ -74,9 +74,9 @@ Any behavior of `ts_project` should be reproducible outside of Bazel, with a cou
 `ts_project` is recommended for all new code.
 
 Exhaustive examples of calling `ts_project` are in the test suite:
-https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/ts_project
+<https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/ts_project>
 
-And there are also many uses of it in our <examples>
+And there are also many uses of it in our [examples](https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/ts_project).
 
 [DeclarationInfo]: Built-ins#declarationinfo
 
@@ -166,7 +166,7 @@ transpile only, outdir, rootdir, and so on.
 > Alternatively, see the `tsc_test` rule documented above.
 
 See many examples in our test cases:
-https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/ts_project
+<https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/ts_project>
 
 
 ## ts_config

--- a/packages/typescript/index.docs.bzl
+++ b/packages/typescript/index.docs.bzl
@@ -49,7 +49,7 @@ To use it, add the load statement `load("@npm//typescript:index.bzl", "tsc")` to
 Then call it, using the [`npm_package_bin`](Built-ins#npm_package_bin) documentation.
 
 Here is an example:
-https://github.com/bazelbuild/rules_nodejs/blob/3.2.2/internal/node/test/BUILD.bazel#L491-L507
+<https://github.com/bazelbuild/rules_nodejs/blob/3.2.2/internal/node/test/BUILD.bazel#L491-L507>
 
 ### Option 2: tsc_test
 
@@ -72,7 +72,7 @@ filegroup(name = "types", srcs = ["//some:js_library"], output_group = "types")
 
 And then include the `:types` target in the `data` of the `tsc_test`.
 
-See example in https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/tsc_test
+See example in <https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/tsc_test>
 
 ### Option 3: ts_project
 
@@ -86,9 +86,9 @@ Any behavior of `ts_project` should be reproducible outside of Bazel, with a cou
 `ts_project` is recommended for all new code.
 
 Exhaustive examples of calling `ts_project` are in the test suite:
-https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/ts_project
+<https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/ts_project>
 
-And there are also many uses of it in our <examples>
+And there are also many uses of it in our [examples](https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/ts_project).
 
 [DeclarationInfo]: Built-ins#declarationinfo
 
@@ -178,7 +178,7 @@ transpile only, outdir, rootdir, and so on.
 > Alternatively, see the `tsc_test` rule documented above.
 
 See many examples in our test cases:
-https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/ts_project
+<https://github.com/bazelbuild/rules_nodejs/tree/stable/packages/typescript/test/ts_project>
 """
 
 load("//nodejs/private:ts_config.bzl", _ts_config = "ts_config")


### PR DESCRIPTION
- Make the URLs in the TypeScript doc into actual links
- Markdown cannot contain `<example>` because it'll be rendered as HTML tag

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
- `<example>` is not rendered correctly because the tags are not escaped
- URLs do not show up as hyperlinks

Issue Number: N/A


## What is the new behavior?
Fixed the issues above


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

