### PR TITLE
Turn some URLs into links

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -63,7 +63,7 @@ There is a basic example at [examples/react_webpack](https://github.com/bazelbui
 
 ### Vue
 
-We don't have a dedicated example yet, but Vue has been known to work. Follow https://github.com/bazelbuild/rules_nodejs/issues/1840 for an example.
+We don't have a dedicated example yet, but Vue has been known to work. Follow <https://github.com/bazelbuild/rules_nodejs/issues/1840> for an example.
 
 ### Svelte
 
@@ -77,7 +77,7 @@ There is a dedicated example for Jest: [examples/jest](https://github.com/bazelb
 
 ### Cypress
 
-We have done some early work to run Cypress under Bazel. Follow https://github.com/bazelbuild/rules_nodejs/issues/1904 for an example.
+We have done some early work to run Cypress under Bazel. Follow <https://github.com/bazelbuild/rules_nodejs/issues/1904> for an example.
 
 ### Mocha
 
@@ -139,7 +139,7 @@ Check for a BazelCon 2021 talk by @pcj about it.
 
 <https://github.com/Dig-Doug/rules_typescript_proto> seems promising.
 
-[protobuf.js](https://github.com/protobufjs/protobuf.js) from https://github.com/dcodeIO is a simple alternative.
+[protobuf.js](https://github.com/protobufjs/protobuf.js) from <https://github.com/dcodeIO> is a simple alternative.
 See the example in [examples/protobufjs](https://github.com/bazelbuild/rules_nodejs/tree/stable/examples/protobufjs)
 
 ## Bazel-specific


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Some URLs in https://bazelbuild.github.io/rules_nodejs/examples.html are just texts, not links.

## What is the new behavior?

Turn these URLs into links so that users can follow the links.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

