### PR TITLE
Fix TsConfigInfo to use depset and deduplicate files (#3430)

### DIFF
--- a/nodejs/private/ts_config.bzl
+++ b/nodejs/private/ts_config.bzl
@@ -30,10 +30,11 @@ def _ts_config_impl(ctx):
     transitive_deps = []
     for dep in ctx.attr.deps:
         if TsConfigInfo in dep:
-            transitive_deps.extend(dep[TsConfigInfo].deps)
+            transitive_deps.append(dep[TsConfigInfo].deps)
+    transitive_deps.append(depset(ctx.files.deps))
     return [
         DefaultInfo(files = files),
-        TsConfigInfo(deps = [ctx.file.src] + ctx.files.deps + transitive_deps),
+        TsConfigInfo(deps = depset([ctx.file.src], transitive = transitive_deps)),
     ]
 
 ts_config = rule(

--- a/nodejs/private/ts_validate_options.bzl
+++ b/nodejs/private/ts_validate_options.bzl
@@ -7,15 +7,15 @@ def _tsconfig_inputs(ctx):
     """Returns all transitively referenced tsconfig files from "tsconfig" and "extends" attributes."""
     inputs = []
     if TsConfigInfo in ctx.attr.tsconfig:
-        inputs.extend(ctx.attr.tsconfig[TsConfigInfo].deps)
+        inputs.append(ctx.attr.tsconfig[TsConfigInfo].deps)
     else:
-        inputs.append(ctx.file.tsconfig)
+        inputs.append(depset([ctx.file.tsconfig]))
     if hasattr(ctx.attr, "extends") and ctx.attr.extends:
         if TsConfigInfo in ctx.attr.extends:
-            inputs.extend(ctx.attr.extends[TsConfigInfo].deps)
+            inputs.append(ctx.attr.extends[TsConfigInfo].deps)
         else:
-            inputs.extend(ctx.attr.extends.files.to_list())
-    return inputs
+            inputs.append(ctx.attr.extends.files)
+    return depset(transitive = inputs)
 
 def _validate_options_impl(ctx, run_action = None):
     # Bazel won't run our action unless its output is needed, so make a marker file


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
`ts_config` rules allocate way too much memory just for storing duplicate artifacts in a list:
`bazel [..] dump --rules` before this change:
```
RULE                                 COUNT     ACTIONS          BYTES         EACH
filegroup                           12,078           0     17,726,232        1,467
java_library                         4,332      13,025     35,065,464        8,09
ts_project                             136         268     14,161,720      104,130
ts_config                              131           0  1,839,281,704   14,040,318
```

Issue Number: #3430

## What is the new behavior?
with this patch `TsConfigInfo` uses depsets and therefore avoids any memory allocation (instead using objects allocated by other rules):
```
RULE                                 COUNT     ACTIONS          BYTES         EACH
filegroup                           12,078           0     19,410,448        1,607
java_library                         4,332      13,025     37,704,320        8,70
ts_project                             136         268     14,682,168      107,957
ts_config                              131           0              0            0
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
The guide here explains why flattening depsets is not a good idea and provides some motivation for the changes in this PR: https://docs.bazel.build/versions/main/skylark/depsets.html
This PR is a forward port of my patch for our project (which uses 4.6.3), I would appreciate any help with testing if it introduces any regressions
