### PR TITLE
fix(concatjs): adding devmode to BazelOpts

### DIFF
--- a/packages/concatjs/internal/tsc_wrapped/tsconfig.ts
+++ b/packages/concatjs/internal/tsc_wrapped/tsconfig.ts
@@ -38,10 +38,17 @@ export interface BazelOptions {
   googmodule: boolean;
 
   /**
+   * DEPRECATED. being replaced by devmode.
    * If true, emit devmode output into filename.js.
    * If false, emit prodmode output into filename.mjs.
    */
   es5Mode: boolean;
+
+  /**
+   * If true, emit devmode output into filename.js.
+   * If false, emit prodmode output into filename.mjs.
+   */
+  devmode: boolean;
 
   /** If true, convert TypeScript code into a Closure-compatible variant. */
   tsickle: boolean;


### PR DESCRIPTION
adds devmode to bazelOpts type definition imported by angular ngc-wrapped for <internal> options migration.

In the future, a better plan should be made to move away from lightly supported legacy corners of this repo.
related to https://github.com/angular/angular/pull/45804