### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,8 +7,14 @@ on:
   # run at 01:30 UTC daily
   - cron: "30 1 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update-esbuild-versions.yml
+++ b/.github/workflows/update-esbuild-versions.yml
@@ -5,6 +5,9 @@ on:
     # run at 01:30 UTC daily
     - cron: '30 1 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   updateNodejsVersions:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-nodejs-versions.yml
+++ b/.github/workflows/update-nodejs-versions.yml
@@ -5,6 +5,9 @@ on:
     # run at 01:30 UTC daily
     - cron: '30 1 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   updateNodejsVersions:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-yarn-versions.yml
+++ b/.github/workflows/update-yarn-versions.yml
@@ -5,6 +5,9 @@ on:
     # run at 01:30 UTC daily
     - cron: '30 1 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   updateNodejsVersions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
