### PR TITLE
fix: set correct linking location for yarn_install using package.json from external repository

### DIFF
--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -449,11 +449,14 @@ def _create_build_files(repository_ctx, rule_type, node, lock_file, generate_loc
             fail("link target must be label of form '@wksp//path/to:target', '@//path/to:target' or '//path/to:target'")
         validated_links[k] = v
 
-    package_json_dir = paths.dirname(paths.normalize(paths.join(repository_ctx.attr.package_json.package, repository_ctx.attr.package_json.name)))
+    package_json_dir = paths.dirname(paths.normalize(paths.join(
+        repository_ctx.attr.package_json.package,
+        repository_ctx.attr.package_json.name,
+    )))
     package_path = repository_ctx.attr.package_path
     if not package_path:
         # By default the package_path is the directory of the package.json file
-        package_path = package_json_dir
+        package_path = paths.join(repository_ctx.attr.package_json.workspace_root, package_json_dir)
     elif package_path == "/":
         # User specified root path
         package_path = ""


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_nodejs/issues/3323

Verified on repro repository, https://github.com/mhevery/repro-bazel-nested-project

```
gregs-mbp:repro-bazel-nested-project greg$ bazel build @child//packages/core
INFO: Analyzed target @child//packages/core:core (12 packages loaded, 99 targets configured).
INFO: Found 1 target...
Target @child//packages/core:core up-to-date:
  bazel-bin/external/child/packages/core/main.js
INFO: Elapsed time: 0.447s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
```

```
gregs-mbp:repro-bazel-nested-project greg$ cd child
gregs-mbp:child greg$ bazel build //packages/core
INFO: Analyzed target //packages/core:core (10 packages loaded, 94 targets configured).
INFO: Found 1 target...
Target //packages/core:core up-to-date:
  bazel-bin/packages/core/main.js
INFO: Elapsed time: 2.755s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
```