### PR TITLE
fix(docs): stray text in npm_install docs

### DIFF
--- a/docs/Built-ins.md
+++ b/docs/Built-ins.md
@@ -549,8 +549,7 @@ Defaults to `[]`
 If symlink_node_modules is True, this attribute is optional since the package manager
 will run in your workspace folder. It is recommended, however, that all files that the
 package manager depends on, such as `.rc` files or files used in `postinstall`, are added
-symlink_node_modules is True so that the repository rule is rerun when any of these files
-change.
+so that the repository rule is rerun when any of these files change.
 
 If symlink_node_modules is False, the package manager is run in the bazel external
 repository so all files that the package manager depends on must be listed.
@@ -1214,8 +1213,7 @@ Defaults to `[]`
 If symlink_node_modules is True, this attribute is optional since the package manager
 will run in your workspace folder. It is recommended, however, that all files that the
 package manager depends on, such as `.rc` files or files used in `postinstall`, are added
-symlink_node_modules is True so that the repository rule is rerun when any of these files
-change.
+so that the repository rule is rerun when any of these files change.
 
 If symlink_node_modules is False, the package manager is run in the bazel external
 repository so all files that the package manager depends on must be listed.

--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -34,8 +34,7 @@ COMMON_ATTRIBUTES = dict(dict(), **{
 If symlink_node_modules is True, this attribute is optional since the package manager
 will run in your workspace folder. It is recommended, however, that all files that the
 package manager depends on, such as `.rc` files or files used in `postinstall`, are added
-symlink_node_modules is True so that the repository rule is rerun when any of these files
-change.
+so that the repository rule is rerun when any of these files change.
 
 If symlink_node_modules is False, the package manager is run in the bazel external
 repository so all files that the package manager depends on must be listed.


### PR DESCRIPTION
"symlink_node_modules is True" doesn't make any sense in this position. I think it was a stray copy and paste from the beginning of the paragraph.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

