### PR TITLE
chore: remove unnecessary --bazel_patch_module_resolver

### DIFF
--- a/internal/npm_install/BUILD.bazel
+++ b/internal/npm_install/BUILD.bazel
@@ -57,7 +57,5 @@ nodejs_binary(
         "//third_party/npm/node_modules/named-amd",
     ],
     entry_point = ":browserify-wrapped.js",
-    # TODO: figure out why browserify isn't resolved properly
-    templated_args = ["--bazel_patch_module_resolver"],
     visibility = ["//visibility:public"],
 )

--- a/internal/pkg_npm/BUILD.bazel
+++ b/internal/pkg_npm/BUILD.bazel
@@ -16,8 +16,6 @@ nodejs_binary(
     name = "packager",
     data = ["//third_party/github.com/gjtorikian/isBinaryFile"],
     entry_point = ":packager.js",
-    # TODO: figure out why isbinaryfile is not linked in a way this can resolve
-    templated_args = ["--bazel_patch_module_resolver"],
 )
 
 nodejs_binary(

--- a/internal/pkg_web/BUILD.bazel
+++ b/internal/pkg_web/BUILD.bazel
@@ -22,16 +22,12 @@ nodejs_binary(
         "//third_party/github.com/gjtorikian/isBinaryFile",
     ],
     entry_point = ":assembler.js",
-    # TODO: figure out why isbinaryfile isn't resolved properly
-    templated_args = ["--bazel_patch_module_resolver"],
 )
 
 # BEGIN-INTERNAL
 jasmine_node_test(
     name = "assembler_test",
     srcs = ["assembler_spec.js"],
-    # TODO: figure out why isbinaryfile isn't resolved properly
-    templated_args = ["--bazel_patch_module_resolver"],
     deps = [
         "assembler.js",
         "//third_party/github.com/gjtorikian/isBinaryFile",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

In the course of investigating #3448, I ended up looking at where `--bazel_patch_module_resolver` is used. These TODOs in the code seem to have been addressed at some point. I ran the tests locally and they all passed even after removing these uses of `--bazel_patch_module_resolver`.

## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

