### PR TITLE
feat(builtin): expand make vars in nodejs_binary/test env attr

### DIFF
--- a/docs/Built-ins.md
+++ b/docs/Built-ins.md
@@ -144,7 +144,7 @@ nodejs_binary(
 <h4 id="nodejs_binary-env">env</h4>
 
 (*<a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a>*): Specifies additional environment variables to set when the target is executed, subject to location
-expansion.
+and make variable expansion.
 
 Defaults to `{}`
 
@@ -402,7 +402,7 @@ nodejs_binary(
 <h4 id="nodejs_test-env">env</h4>
 
 (*<a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a>*): Specifies additional environment variables to set when the target is executed, subject to location
-expansion.
+and make variable expansion.
 
 Defaults to `{}`
 

--- a/docs/Cypress.md
+++ b/docs/Cypress.md
@@ -237,7 +237,7 @@ Defaults to `@npm//@bazel/cypress/internal:run-cypress.js`
 <h4 id="cypress_web_test-env">env</h4>
 
 (*<a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a>*): Specifies additional environment variables to set when the target is executed, subject to location
-expansion.
+and make variable expansion.
 
 Defaults to `{}`
 

--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -210,7 +210,7 @@ def _nodejs_binary_impl(ctx, data = [], runfiles = [], expanded_args = []):
 
     # Add all env vars from the ctx attr
     for [key, value] in ctx.attr.env.items():
-        env_vars += "export %s=%s\n" % (key, expand_location_into_runfiles(ctx, value, data))
+        env_vars += "export %s=%s\n" % (key, ctx.expand_make_variables("env", expand_location_into_runfiles(ctx, value, data), {}))
 
     # While we can derive the workspace from the pwd when running locally
     # because it is in the execroot path `execroot/my_wksp`, on RBE the
@@ -502,7 +502,7 @@ nodejs_binary(
     ),
     "env": attr.string_dict(
         doc = """Specifies additional environment variables to set when the target is executed, subject to location
-expansion.
+and make variable expansion.
         """,
         default = {},
     ),

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -409,6 +409,7 @@ nodejs_binary(
     entry_point = "dump_build_env.js",
     env = {
         "LOC": "$(location :dump_build_env.js)",
+        "SOME_TEST_ENV": "$(SOME_TEST_ENV)",
     },
 )
 

--- a/internal/node/test/env.spec.js
+++ b/internal/node/test/env.spec.js
@@ -118,4 +118,9 @@ describe('launcher.sh environment', function() {
     expect(env['FOO']).toBe('BAR');
     expect(env['LOC']).toBe('build_bazel_rules_nodejs/internal/node/test/dump_build_env.js');
   });
+
+  it('should expand make variables from env attr', function() {
+      const env = require(runfiles.resolvePackageRelative('dump_build_env_attr.json'));
+      expect(env['SOME_TEST_ENV']).toBe('some_value')
+  });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`nodejs_binary`/`nodejs_test` does not perform make variable substitution.


## What is the new behavior?

`nodejs_binary`/`nodejs_test` now performs make variable substitution.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The motivating use case is to pass a browser toolchain to an `architect_test` rule. The path to the browser and driver binaries are provided via a make variable which protractor references.