### PR TITLE
fix: include npm and npx in node subprocess PATH

### DIFF
--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -260,6 +260,8 @@ fi
 
     node_tool_files = []
     node_tool_files.extend(node_toolchain.nodeinfo.tool_files)
+    if ctx.attr.include_all_node_files:
+        node_tool_files.extend(node_toolchain.nodeinfo.all_node_files)
     node_tool_files.append(ctx.file._link_modules_script)
     node_tool_files.append(ctx.file._runfile_helpers_bundle)
     node_tool_files.append(ctx.file._runfile_helpers_main)
@@ -505,6 +507,12 @@ nodejs_binary(
 and make variable expansion.
         """,
         default = {},
+    ),
+    "include_all_node_files": attr.bool(
+        doc = """Include all files shipped with node as inputs as specified by the toolchain.
+
+By default, only the node executable is specified as an input as the remaining node distribution files
+are not needed by most programs.""",
     ),
     "link_workspace_root": attr.bool(
         doc = """Link the workspace root to the bin_dir to support absolute requires like 'my_wksp/path/to/file'.

--- a/internal/node/node_patches.cjs
+++ b/internal/node/node_patches.cjs
@@ -573,6 +573,18 @@ set Path=${nodeDir};%Path%
 "${process.execPath}" --require "${requireScriptName}" %*
 `);
         }
+        ['npm', 'npx'].forEach(cmd => {
+            const cmdBat = `${cmd}.bat`;
+            const cmdEntry = path__default['default'].join(nodeDir, cmdBat);
+            const cmdActual = path__default['default'].join(path__default['default'].dirname(process.execPath), cmdBat);
+            if (!fs__default['default'].existsSync(cmdEntry)) {
+                fs__default['default'].writeFileSync(cmdEntry, `@if not defined DEBUG_HELPER @ECHO OFF
+set NP_SUBPROCESS_NODE_DIR=${nodeDir}
+set Path=${nodeDir};%Path%
+exec ${cmdActual} %*
+  `, { mode: 0o777 });
+            }
+        });
     }
     else {
         const nodeEntry = path__default['default'].join(nodeDir, 'node');
@@ -587,6 +599,17 @@ else
 fi
 `, { mode: 0o777 });
         }
+        ['npm', 'npx'].forEach(cmd => {
+            const cmdEntry = path__default['default'].join(nodeDir, cmd);
+            const cmdActual = path__default['default'].join(path__default['default'].dirname(process.execPath), `../lib/node_modules/npm/bin/${cmd}-cli.js`);
+            if (!fs__default['default'].existsSync(cmdEntry)) {
+                fs__default['default'].writeFileSync(cmdEntry, `#!/bin/bash
+export NP_SUBPROCESS_NODE_DIR="${nodeDir}"
+export PATH="${nodeDir}":\$PATH
+exec ${cmdActual} "$@"
+  `, { mode: 0o777 });
+            }
+        });
     }
     if (!process.env.PATH) {
         process.env.PATH = nodeDir;

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -702,3 +702,15 @@ nodejs_test(
         ],
     )
 ]
+
+nodejs_test(
+    name = "spawn_npm_test",
+    entry_point = "spawn-npm.js",
+    include_all_node_files = True,
+)
+
+nodejs_test(
+    name = "spawn_npx_test",
+    entry_point = "spawn-npx.js",
+    include_all_node_files = True,
+)

--- a/internal/node/test/spawn-npm.js
+++ b/internal/node/test/spawn-npm.js
@@ -1,0 +1,8 @@
+const spawnSync = require('child_process').spawnSync
+
+const res = spawnSync('npm', ['--version']);
+if (res.status) {
+  process.stderr.write(res.stderr);
+  throw new Error('failed. to execute child process. code ' + res.status);
+}
+console.log(JSON.stringify({version: res.stdout + ''}));

--- a/internal/node/test/spawn-npx.js
+++ b/internal/node/test/spawn-npx.js
@@ -1,0 +1,8 @@
+const spawnSync = require('child_process').spawnSync
+
+const res = spawnSync('npx', ['--version']);
+if (res.status) {
+  process.stderr.write(res.stderr);
+  throw new Error('failed. to execute child process. code ' + res.status);
+}
+console.log(JSON.stringify({version: res.stdout + ''}));

--- a/nodejs/private/nodejs_repo_host_os_alias.bzl
+++ b/nodejs/private/nodejs_repo_host_os_alias.bzl
@@ -20,6 +20,7 @@ alias(name = "node",                    actual = "@{node_repository}_{os_name}//
 alias(name = "npm",                     actual = "@{node_repository}_{os_name}//:npm")
 alias(name = "node_files",              actual = "@{node_repository}_{os_name}//:node_files")
 alias(name = "npm_files",               actual = "@{node_repository}_{os_name}//:npm_files")
+alias(name = "all_node_files",               actual = "@{node_repository}_{os_name}//:all_node_files")
 exports_files([
     "index.bzl",
     "bin/node{ext}",

--- a/nodejs/repositories.bzl
+++ b/nodejs/repositories.bzl
@@ -322,11 +322,16 @@ filegroup(
   name = "npm_files",
   srcs = {npm_files_glob}[":node_files"],
 )
+filegroup(
+  name = "all_node_files",
+  srcs = {all_node_files_glob}[":node_files"],
+)
 """.format(
         node_bin_export = "\n  \"%s\"," % node_bin,
         npm_bin_export = "\n  \"%s\"," % npm_bin,
         npx_bin_export = "\n  \"%s\"," % npx_bin,
         npm_files_glob = "glob([\"bin/nodejs/**\"]) + ",
+        all_node_files_glob = "glob([\"bin/nodejs/**\"]) + ",
         node_bin_label = node_bin_label,
         npm_bin_label = npm_bin_label,
         npx_bin_label = npx_bin_label,
@@ -342,6 +347,7 @@ node_toolchain(
     name = "node_toolchain",
     target_tool = ":node_bin",
     run_npm = ":run_npm.template",
+    all_node_files = ":all_node_files",
 )
 """
     repository_ctx.file("BUILD.bazel", content = build_content)

--- a/nodejs/toolchain.bzl
+++ b/nodejs/toolchain.bzl
@@ -26,6 +26,9 @@ NodeInfo = provider(
 May be empty if the target_tool_path points to a locally installed node binary.""",
         "run_npm": """A template for a script that wraps npm.
         On Windows, this is a Batch script, otherwise it uses Bash.""",
+        "all_node_files": """All files in the node distrubution.
+        
+These are generally not needed for most programs since the node executable is self-contained.""",
     },
 )
 
@@ -44,10 +47,14 @@ def _node_toolchain_impl(ctx):
 
     tool_files = []
     target_tool_path = ctx.attr.target_tool_path
+    all_node_files = []
 
     if ctx.attr.target_tool:
-        tool_files = ctx.attr.target_tool.files.to_list()
+        tool_files.extend(ctx.attr.target_tool.files.to_list())
         target_tool_path = _to_manifest_path(ctx, tool_files[0])
+
+    if ctx.attr.all_node_files:
+        all_node_files.extend(ctx.attr.all_node_files.files.to_list())
 
     # Make the $(NODE_PATH) variable available in places like genrules.
     # See https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables
@@ -62,6 +69,7 @@ def _node_toolchain_impl(ctx):
         target_tool_path = target_tool_path,
         tool_files = tool_files,
         run_npm = ctx.file.run_npm,
+        all_node_files = all_node_files,
     )
 
     # Export all the providers inside our ToolchainInfo
@@ -92,6 +100,10 @@ node_toolchain = rule(
         "run_npm": attr.label(
             doc = "A template file that allows us to execute npm",
             allow_single_file = True,
+        ),
+        "all_node_files": attr.label(
+            doc = "All files in the node distribution",
+            allow_files = True,
         ),
     },
     doc = """Defines a node toolchain.


### PR DESCRIPTION
Currently only the `node` executable is put onto the PATH when running node. This adds `npm` and `npx` scripts along side the `node` one.
