### PR TITLE
{npm,yarn}_install: add note that exports_directories_only is incompatible with RE

### DIFF
--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -48,7 +48,7 @@ repository so all files that the package manager depends on must be listed.
         default = True,
         doc = """Export only top-level package directory artifacts from node_modules.
 
-Set to `False` to export all individual files from node_modules.
+Set to `False` to export all individual files from node_modules, or when using remote execution.
 
 When enabled, this decreases the time it takes for Bazel to setup runfiles and sandboxing when
 there are a large number of npm dependencies as inputs to an action.
@@ -59,6 +59,8 @@ Note, some rules still need upgrading to support consuming `DirectoryFilePathInf
 NB: This feature requires runfiles be enabled due to an issue in Bazel which we are still investigating.
     On Windows runfiles are off by default and must be enabled with the `--enable_runfiles` flag when
     using this feature.
+
+NB: This feature is incompatible with remote execution.
 
 NB: `ts_library` does not support directory npm deps due to internal dependency on having all input sources files explicitly specified.
 


### PR DESCRIPTION
If enabled, only the top-level directories will be uploaded as inputs, so the remote
action will see an empty directory under `node_modules` and fail.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

