### PR TITLE
feat: introduce ts_declaration rule

### DIFF
--- a/docs/Core.md
+++ b/docs/Core.md
@@ -250,6 +250,42 @@ Defaults to `None`
 Defaults to `""`
 
 
+## ts_declaration
+
+**USAGE**
+
+<pre>
+ts_declaration(<a href="#ts_declaration-name">name</a>, <a href="#ts_declaration-deps">deps</a>, <a href="#ts_declaration-srcs">srcs</a>)
+</pre>
+
+Adapter from .d.ts sources to a DeclarationInfo.
+    
+    This rule has no actions, so it's similar to a fileset.
+    It allows you to feed typings into rules which require DeclarationInfo,
+    for example as to `ts_project#deps`.
+    
+
+**ATTRIBUTES**
+
+
+<h4 id="ts_declaration-name">name</h4>
+
+(*<a href="https://bazel.build/docs/build-ref.html#name">Name</a>, mandatory*): A unique name for this target.
+
+
+<h4 id="ts_declaration-deps">deps</h4>
+
+(*<a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a>*)
+
+Defaults to `[]`
+
+<h4 id="ts_declaration-srcs">srcs</h4>
+
+(*<a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a>*)
+
+Defaults to `[]`
+
+
 ## yarn_repositories
 
 **USAGE**

--- a/nodejs/defs.bzl
+++ b/nodejs/defs.bzl
@@ -1,0 +1,15 @@
+"Public API for rules"
+
+load("//nodejs/private:ts_declaration.bzl", lib = "ts_declaration")
+
+ts_declaration = rule(
+    doc = """Adapter from .d.ts sources to a DeclarationInfo.
+    
+    This rule has no actions, so it's similar to a fileset.
+    It allows you to feed typings into rules which require DeclarationInfo,
+    for example as to `ts_project#deps`.
+    """,
+    implementation = lib.implementation,
+    attrs = lib.attrs,
+    provides = lib.provides,
+)

--- a/nodejs/index.for_docs.bzl
+++ b/nodejs/index.for_docs.bzl
@@ -25,6 +25,7 @@ load(
     _declaration_info = "declaration_info",
     _js_module_info = "js_module_info",
 )
+load(":defs.bzl", _ts_declaration = "ts_declaration")
 load(":directory_file_path.bzl", _directory_file_path = "directory_file_path")
 load(":repositories.bzl", _node_repositories = "node_repositories")
 load(":yarn_repositories.bzl", _yarn_repositories = "yarn_repositories")
@@ -32,6 +33,7 @@ load(":toolchain.bzl", _node_toolchain = "node_toolchain")
 
 DeclarationInfo = _DeclarationInfo
 declaration_info = _declaration_info
+ts_declaration = _ts_declaration
 directory_file_path = _directory_file_path
 JSModuleInfo = _JSModuleInfo
 js_module_info = _js_module_info

--- a/nodejs/private/ts_declaration.bzl
+++ b/nodejs/private/ts_declaration.bzl
@@ -1,0 +1,69 @@
+"""Adapter from .d.ts files to DeclarationInfo.
+
+Performs no actions, so it's like a fileset that can be a dep of ts_project.
+"""
+
+load("//nodejs/private/providers:declaration_info.bzl", "DeclarationInfo", "declaration_info")
+
+def _ts_declaration_impl(ctx):
+    typings = []
+
+    for src in ctx.files.srcs:
+        if src.is_directory:
+            # assume a directory contains typings since we can't know that it doesn't
+            typings.append(src)
+        elif (
+            src.path.endswith(".d.ts") or
+            src.path.endswith(".d.ts.map") or
+            # package.json may be required to resolve "typings" key
+            src.path.endswith("/package.json")
+        ):
+            typings.append(src)
+
+    typings_depsets = [depset(typings)]
+    files_depsets = [depset(ctx.files.srcs)]
+
+    for dep in ctx.attr.deps:
+        if DeclarationInfo in dep:
+            typings_depsets.append(dep[DeclarationInfo].declarations)
+        if DefaultInfo in dep:
+            files_depsets.append(dep[DefaultInfo].files)
+
+    runfiles = ctx.runfiles(
+        files = ctx.files.srcs,
+        # We do not include typings_depsets in the runfiles because that would cause type-check actions to occur
+        # in every development workflow.
+        transitive_files = depset(transitive = files_depsets),
+    )
+    deps_runfiles = [d[DefaultInfo].default_runfiles for d in ctx.attr.deps]
+    decls = depset(transitive = typings_depsets)
+
+    # Perf optimization available in newer Bazel releases
+    if "merge_all" in dir(runfiles):
+        runfiles = runfiles.merge_all(deps_runfiles)
+    else:
+        for d in deps_runfiles:
+            runfiles = runfiles.merge(d)
+
+    return [
+        DefaultInfo(
+            files = depset(transitive = files_depsets),
+            runfiles = runfiles,
+        ),
+        declaration_info(
+            declarations = decls,
+            deps = ctx.attr.deps,
+        ),
+        # Users can request the "types" output group to explicitly
+        # cause type-checking to occur on this dependency tree.
+        OutputGroupInfo(types = decls),
+    ]
+
+ts_declaration = struct(
+    implementation = _ts_declaration_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "deps": attr.label_list(allow_files = True),
+    },
+    provides = [DeclarationInfo],
+)


### PR DESCRIPTION
This is a simple adapter to make it easier to provide DeclarationInfo.
It's a subset of the js_library rule, currently used as the final output of ts_project with a custom transpiler.
