### PR TITLE
Teach os_name() about freebsd-amd64

### DIFF
--- a/nodejs/private/os_name.bzl
+++ b/nodejs/private/os_name.bzl
@@ -25,6 +25,7 @@ OS_ARCH_NAMES = [
     ("linux", "arm64"),
     ("linux", "s390x"),
     ("linux", "ppc64le"),
+    ("freebsd", "amd64"),
 ]
 
 OS_NAMES = ["_".join(os_arch_name) for os_arch_name in OS_ARCH_NAMES]
@@ -58,6 +59,9 @@ def os_name(rctx):
             return OS_NAMES[5]
         elif arch == "ppc64le":
             return OS_NAMES[6]
+    elif os_name.startswith("freebsd"):
+        if arch == "amd64":
+            return OS_NAMES[7]
 
     fail("Unsupported operating system {} architecture {}".format(os_name, arch))
 


### PR DESCRIPTION
It is possible to use `rules_nodejs` on operating systems besides
Windows, Linux, and macOS, but they need to be handled in `os_name()`
or else you get a `Unsupported operating system freebsd` error message.
This change allows you to add a FreeBSD toolchain to your project by
declaring a `nodejs_freebsd_amd64` repo with a `bin/node` executable.
cockroachdb/cockroach#82762 is an example of this.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Add (very partial) support for FreeBSD.


## What is the current behavior?
Builds on FreeBSD will fail with an "Unsupported operating system" message.

Issue Number: N/A


## What is the new behavior?

Alone, this change does not make it possible to build on FreeBSD, but it does allow you to add your own toolchain that supports FreeBSD without any additional patches to `rules_nodejs`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

