### PR TITLE
fix(typescript): remove protobufjs dependency

### DIFF
--- a/packages/typescript/index.bzl
+++ b/packages/typescript/index.bzl
@@ -528,13 +528,6 @@ def ts_project(
         nodejs_binary(
             name = tsc_worker,
             data = [
-                # BEGIN-INTERNAL
-                # Users get this dependency transitively from @bazel/typescript
-                # but that's our own code, so we don't.
-                # TODO: remove protobuf dependency once rules_typescript also uses
-                # worker package
-                "@npm//protobufjs",
-                # END-INTERNAL
                 Label(typescript_package),
                 Label("//packages/typescript/internal/worker:filegroup"),
                 # BEGIN-INTERNAL

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -23,7 +23,6 @@
         "typescript": ">=3.0.0"
     },
     "dependencies": {
-        "protobufjs": "6.8.8",
         "@bazel/worker": "0.0.0-PLACEHOLDER",
         "semver": "5.6.0",
         "source-map-support": "0.5.9",


### PR DESCRIPTION
protobufjs is not needed anymore by `@bazel/typescript`

prototbufjs <6.11.3 is also vulnerable according to https://github.com/advisories/GHSA-g954-5hwp-pp24

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

`@bazel/typescript` depends on `prototbufjs`.

## What is the new behavior?

The package does not depend on `protobufjs` anymore.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

