### PR TITLE
fix(create): make `--packageManager` flag work

### DIFF
--- a/packages/create/index.js
+++ b/packages/create/index.js
@@ -75,7 +75,15 @@ function main(argv, error = console.error, log = console.log) {
   }
 
   // Which package manager will be used in the new project
-  const pkgMgr = args['packageManager'] || detectRunningUnderYarn() ? 'yarn' : 'npm';
+  let pkgMgr = args['packageManager'];
+
+  if (!pkgMgr) {
+    pkgMgr = detectRunningUnderYarn() ? 'yarn' : 'npm';
+  } else if(pkgMgr !== 'yarn' && pkgMgr !== 'npm') {
+    error('Please select between \'yarn\' and \'npm\' when providing --packageManager');
+    usage(error);
+    return 1;
+  }
 
   log_verbose('Running with', process.argv);
   log_verbose('Environment', process.env);

--- a/packages/create/test.js
+++ b/packages/create/test.js
@@ -70,6 +70,16 @@ wkspContent = read('default_to_yarn/WORKSPACE');
 if (wkspContent.indexOf('yarn_install(') < 0) {
   fail('should use yarn by default');
 }
+
+exitCode = main(['use_npm_with_yarn', '--packageManager=npm']);
+if (exitCode != 0) fail('should be success');
+wkspContent = read('use_npm_with_yarn/WORKSPACE');
+if (wkspContent.indexOf('npm_install(') < 0) {
+  fail('should use npm as selected');
+}
+
+exitCode = main(['neither_yarn_nor_npm', '--packageManager=foo']);
+if (exitCode != 1) fail('should exit 1 when selecting neither \'yarn\' nor \'npm\'');
 // TODO: run bazel in the new directory to verify a build works
 
 exitCode = main(['--typescript', 'with_ts'], captureError);


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

When running `yarn create @bazel my_test_workspace --typescript --packageManager=npm` the script will create a new workspace with `yarn` as a package manager instead of `npm`.

## What is the new behavior?

The flag `--packageManager` now is respected and takes effect. This also improves the script by checking, if 'yarn' or 'npm' is given with that flag.

## Does this PR introduce a breaking change?

- [x] No

