### PR TITLE
feat(create): introduce `--workspaceDir` flag

### DIFF
--- a/packages/create/index.js
+++ b/packages/create/index.js
@@ -53,6 +53,8 @@ function usage(error) {
     --packageManager=[yarn|npm]   Select npm or yarn to install packages
                                   (default: npm if you ran npm/npx, yarn if you ran yarn create)
     --typescript                  Set up the workspace for TypeScript development
+    --workspaceDir                Set a name for the directory containing the workspace
+                                  (default: workspace name)
 
   Run @bazel/create --help to see all options
   `);
@@ -88,16 +90,17 @@ function main(argv, error = console.error, log = console.log) {
   log_verbose('Running with', process.argv);
   log_verbose('Environment', process.env);
 
-  const [wkspDir] = args['_'];
-  // TODO: user might want these to differ
-  const wkspName = wkspDir;
+  const [wkspName] = args['_'];
+  const wkspDir = args['workspaceDir'] || wkspName;
 
   if (!validateWorkspaceName(wkspName, error)) {
     return 1;
   }
 
   log(`Creating Bazel workspace ${wkspName}...`);
-  fs.mkdirSync(wkspDir);
+  if (!fs.existsSync(wkspDir)) {
+    fs.mkdirSync(wkspDir);
+  }
   fs.mkdirSync(path.join(wkspDir, 'tools'));
 
   function write(workspaceRelativePath, content) {

--- a/packages/create/test.js
+++ b/packages/create/test.js
@@ -89,5 +89,13 @@ if (pkgContent.indexOf('"@bazel/typescript": "latest"') < 0) {
   fail('should install @bazel/typescript dependency', pkgContent);
 }
 
+exitCode = main(['different_workspace_dir', '--workspaceDir=some-other-dir'])
+if (exitCode != 0) fail('should be success');
+if (!fs.existsSync('some-other-dir')) fail('should create directory');
+
+exitCode = main(['workspace_in_current_dir', '--workspaceDir=.'])
+if (exitCode != 0) fail('should be success');
+if (!fs.existsSync('./WORKSPACE')) fail('should create WORKSPACE file in current directory');
+
 exitCode = main(['--help'], captureError);
 if (exitCode != 0) fail('should be success');


### PR DESCRIPTION
users now can set a different name for the directory to create a workspace in

the behaivior also changed, so it is possible to create a workspace e.g. in the current dir

## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [x] Feature (please, look at the "Scope of the project" section in the README.md file)


## What is the current behavior?

Users cannot set a different directory name when creating a new workspace.

## What is the new behavior?

Users can set a different directory name or create a workspace in an existing directory.

## Does this PR introduce a breaking change?

- [x] No

