### PR TITLE
fix(concatjs): sync with internal change to ensure it works with `tsickle` host

### DIFF
--- a/packages/concatjs/internal/tsc_wrapped/compiler_host.ts
+++ b/packages/concatjs/internal/tsc_wrapped/compiler_host.ts
@@ -84,6 +84,8 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
 
   getCancelationToken?: () => ts.CancellationToken;
   directoryExists?: (dir: string) => boolean;
+    
+  generateExtraSuppressions: boolean;
 
   googmodule: boolean;
   es5Mode: boolean;
@@ -128,6 +130,8 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
     if (this.allowActionInputReads && delegate && delegate.directoryExists) {
       this.directoryExists = delegate.directoryExists.bind(delegate);
     }
+          
+    this.generateExtraSuppressions = true;
 
     validateBazelOptions(bazelOpts);
     this.googmodule = bazelOpts.googmodule;


### PR DESCRIPTION
Tsickle now requires a `generateExtraSuppressions` public property on the TS host. This change has been implemented internally but hasn't been synced upstream, making it difficult to update to the latest `tsickle` externally.