### PR TITLE
fix: limit concurrency when generating BUILD files in npm_install and yarn_install

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+docs/Built-ins.md linguist-generated=true
+docs/Concatjs.md linguist-generated=true
+docs/Cypress.md linguist-generated=true
+docs/esbuild.md linguist-generated=true
+docs/Jasmine.md linguist-generated=true
+docs/Karma.md linguist-generated=true
+docs/Protractor.md linguist-generated=true
+docs/Providers.md linguist-generated=true
+docs/Rollup.md linguist-generated=true
+docs/Terser.md linguist-generated=true
+docs/Toolchains.md linguist-generated=true
+docs/TypeScript.md linguist-generated=true

--- a/docs/Built-ins.md
+++ b/docs/Built-ins.md
@@ -513,11 +513,11 @@ Defaults to `None`
 
 <pre>
 npm_install(<a href="#npm_install-name">name</a>, <a href="#npm_install-args">args</a>, <a href="#npm_install-data">data</a>, <a href="#npm_install-environment">environment</a>, <a href="#npm_install-exports_directories_only">exports_directories_only</a>,
-            <a href="#npm_install-generate_local_modules_build_files">generate_local_modules_build_files</a>, <a href="#npm_install-included_files">included_files</a>, <a href="#npm_install-links">links</a>, <a href="#npm_install-manual_build_file_contents">manual_build_file_contents</a>,
-            <a href="#npm_install-node_repository">node_repository</a>, <a href="#npm_install-npm_command">npm_command</a>, <a href="#npm_install-package_json">package_json</a>, <a href="#npm_install-package_json_remove">package_json_remove</a>, <a href="#npm_install-package_json_replace">package_json_replace</a>,
-            <a href="#npm_install-package_lock_json">package_lock_json</a>, <a href="#npm_install-package_path">package_path</a>, <a href="#npm_install-patch_args">patch_args</a>, <a href="#npm_install-patch_tool">patch_tool</a>, <a href="#npm_install-post_install_patches">post_install_patches</a>,
-            <a href="#npm_install-pre_install_patches">pre_install_patches</a>, <a href="#npm_install-quiet">quiet</a>, <a href="#npm_install-repo_mapping">repo_mapping</a>, <a href="#npm_install-strict_visibility">strict_visibility</a>, <a href="#npm_install-symlink_node_modules">symlink_node_modules</a>,
-            <a href="#npm_install-timeout">timeout</a>)
+            <a href="#npm_install-generate_build_files_concurrency_limit">generate_build_files_concurrency_limit</a>, <a href="#npm_install-generate_local_modules_build_files">generate_local_modules_build_files</a>,
+            <a href="#npm_install-included_files">included_files</a>, <a href="#npm_install-links">links</a>, <a href="#npm_install-manual_build_file_contents">manual_build_file_contents</a>, <a href="#npm_install-node_repository">node_repository</a>, <a href="#npm_install-npm_command">npm_command</a>,
+            <a href="#npm_install-package_json">package_json</a>, <a href="#npm_install-package_json_remove">package_json_remove</a>, <a href="#npm_install-package_json_replace">package_json_replace</a>, <a href="#npm_install-package_lock_json">package_lock_json</a>, <a href="#npm_install-package_path">package_path</a>,
+            <a href="#npm_install-patch_args">patch_args</a>, <a href="#npm_install-patch_tool">patch_tool</a>, <a href="#npm_install-post_install_patches">post_install_patches</a>, <a href="#npm_install-pre_install_patches">pre_install_patches</a>, <a href="#npm_install-quiet">quiet</a>, <a href="#npm_install-repo_mapping">repo_mapping</a>,
+            <a href="#npm_install-strict_visibility">strict_visibility</a>, <a href="#npm_install-symlink_node_modules">symlink_node_modules</a>, <a href="#npm_install-timeout">timeout</a>)
 </pre>
 
 Runs npm install during workspace setup.
@@ -603,6 +603,16 @@ $(rootpath @npm///:node_modules/prettier)/bin-prettier.js
 ```
 
 Defaults to `True`
+
+<h4 id="npm_install-generate_build_files_concurrency_limit">generate_build_files_concurrency_limit</h4>
+
+(*Integer*): Limit the maximum concurrency of npm package processing when generating
+        BUILD files from the node_modules tree. Unlimited concurrency can lead to too many
+        open files errors (https://github.com/bazelbuild/rules_nodejs/issues/3507).
+
+        Set to 0 or negative for unlimited concurrency.
+
+Defaults to `64`
 
 <h4 id="npm_install-generate_local_modules_build_files">generate_local_modules_build_files</h4>
 
@@ -1174,10 +1184,11 @@ Defaults to `{}`
 
 <pre>
 yarn_install(<a href="#yarn_install-name">name</a>, <a href="#yarn_install-args">args</a>, <a href="#yarn_install-data">data</a>, <a href="#yarn_install-environment">environment</a>, <a href="#yarn_install-exports_directories_only">exports_directories_only</a>, <a href="#yarn_install-frozen_lockfile">frozen_lockfile</a>,
-             <a href="#yarn_install-generate_local_modules_build_files">generate_local_modules_build_files</a>, <a href="#yarn_install-included_files">included_files</a>, <a href="#yarn_install-links">links</a>, <a href="#yarn_install-manual_build_file_contents">manual_build_file_contents</a>,
-             <a href="#yarn_install-node_repository">node_repository</a>, <a href="#yarn_install-package_json">package_json</a>, <a href="#yarn_install-package_json_remove">package_json_remove</a>, <a href="#yarn_install-package_json_replace">package_json_replace</a>, <a href="#yarn_install-package_path">package_path</a>,
-             <a href="#yarn_install-patch_args">patch_args</a>, <a href="#yarn_install-patch_tool">patch_tool</a>, <a href="#yarn_install-post_install_patches">post_install_patches</a>, <a href="#yarn_install-pre_install_patches">pre_install_patches</a>, <a href="#yarn_install-quiet">quiet</a>, <a href="#yarn_install-repo_mapping">repo_mapping</a>,
-             <a href="#yarn_install-strict_visibility">strict_visibility</a>, <a href="#yarn_install-symlink_node_modules">symlink_node_modules</a>, <a href="#yarn_install-timeout">timeout</a>, <a href="#yarn_install-use_global_yarn_cache">use_global_yarn_cache</a>, <a href="#yarn_install-yarn">yarn</a>, <a href="#yarn_install-yarn_lock">yarn_lock</a>)
+             <a href="#yarn_install-generate_build_files_concurrency_limit">generate_build_files_concurrency_limit</a>, <a href="#yarn_install-generate_local_modules_build_files">generate_local_modules_build_files</a>,
+             <a href="#yarn_install-included_files">included_files</a>, <a href="#yarn_install-links">links</a>, <a href="#yarn_install-manual_build_file_contents">manual_build_file_contents</a>, <a href="#yarn_install-node_repository">node_repository</a>, <a href="#yarn_install-package_json">package_json</a>,
+             <a href="#yarn_install-package_json_remove">package_json_remove</a>, <a href="#yarn_install-package_json_replace">package_json_replace</a>, <a href="#yarn_install-package_path">package_path</a>, <a href="#yarn_install-patch_args">patch_args</a>, <a href="#yarn_install-patch_tool">patch_tool</a>,
+             <a href="#yarn_install-post_install_patches">post_install_patches</a>, <a href="#yarn_install-pre_install_patches">pre_install_patches</a>, <a href="#yarn_install-quiet">quiet</a>, <a href="#yarn_install-repo_mapping">repo_mapping</a>, <a href="#yarn_install-strict_visibility">strict_visibility</a>,
+             <a href="#yarn_install-symlink_node_modules">symlink_node_modules</a>, <a href="#yarn_install-timeout">timeout</a>, <a href="#yarn_install-use_global_yarn_cache">use_global_yarn_cache</a>, <a href="#yarn_install-yarn">yarn</a>, <a href="#yarn_install-yarn_lock">yarn_lock</a>)
 </pre>
 
 Runs yarn install during workspace setup.
@@ -1285,6 +1296,16 @@ vendored yarn binary. `bazel run @nodejs_host//:yarn install`. You can pass the 
 `bazel run @nodejs_host//:yarn install -- -D <dep-name>`.
 
 Defaults to `True`
+
+<h4 id="yarn_install-generate_build_files_concurrency_limit">generate_build_files_concurrency_limit</h4>
+
+(*Integer*): Limit the maximum concurrency of npm package processing when generating
+        BUILD files from the node_modules tree. Unlimited concurrency can lead to too many
+        open files errors (https://github.com/bazelbuild/rules_nodejs/issues/3507).
+
+        Set to 0 or negative for unlimited concurrency.
+
+Defaults to `64`
 
 <h4 id="yarn_install-generate_local_modules_build_files">generate_local_modules_build_files</h4>
 

--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -357,6 +357,14 @@ Using managed_directories will mean that
         default = 3600,
         doc = """Maximum duration of the package manager execution in seconds.""",
     ),
+    "generate_build_files_concurrency_limit": attr.int(
+        default = 64,
+        doc = """Limit the maximum concurrency of npm package processing when generating
+        BUILD files from the node_modules tree. Unlimited concurrency can lead to too many
+        open files errors (https://github.com/bazelbuild/rules_nodejs/issues/3507).
+
+        Set to 0 or negative for unlimited concurrency.""",
+    ),
 })
 
 def _apply_pre_install_patches(repository_ctx):
@@ -461,6 +469,7 @@ def _create_build_files(repository_ctx, rule_type, node, lock_file, generate_loc
     generate_config_json = json.encode(
         struct(
             exports_directories_only = repository_ctx.attr.exports_directories_only,
+            generate_build_files_concurrency_limit = repository_ctx.attr.generate_build_files_concurrency_limit,
             generate_local_modules_build_files = generate_local_modules_build_files,
             included_files = repository_ctx.attr.included_files,
             links = validated_links,
@@ -470,8 +479,8 @@ def _create_build_files(repository_ctx, rule_type, node, lock_file, generate_loc
             rule_type = rule_type,
             strict_visibility = repository_ctx.attr.strict_visibility,
             workspace = repository_ctx.attr.name,
-            workspace_rerooted_path = _WORKSPACE_REROOTED_PATH,
             workspace_rerooted_package_json_dir = paths.normalize(paths.join(_WORKSPACE_REROOTED_PATH, package_json_dir)),
+            workspace_rerooted_path = _WORKSPACE_REROOTED_PATH,
         ),
     )
     repository_ctx.file("generate_config.json", generate_config_json)

--- a/npm_deps.bzl
+++ b/npm_deps.bzl
@@ -155,24 +155,28 @@ js_library(
         },
         package_json = "//internal/linker/test/multi_linker/test_a:package.json",
         yarn_lock = "//internal/linker/test/multi_linker/test_a:yarn.lock",
+        generate_build_files_concurrency_limit = 0,
     )
 
     yarn_install(
         name = "internal_test_multi_linker_test_b_deps",
         package_json = "//internal/linker/test/multi_linker/test_b:package.json",
         yarn_lock = "//internal/linker/test/multi_linker/test_b:yarn.lock",
+        generate_build_files_concurrency_limit = 0,
     )
 
     yarn_install(
         name = "internal_test_multi_linker_test_c_deps",
         package_json = "//internal/linker/test/multi_linker/test_c:package.json",
         yarn_lock = "//internal/linker/test/multi_linker/test_c:yarn.lock",
+        generate_build_files_concurrency_limit = 0,
     )
 
     yarn_install(
         name = "internal_test_multi_linker_test_d_deps",
         package_json = "//internal/linker/test/multi_linker/test_d:package.json",
         yarn_lock = "//internal/linker/test/multi_linker/test_d:yarn.lock",
+        generate_build_files_concurrency_limit = 0,
     )
 
     yarn_install(
@@ -181,6 +185,7 @@ js_library(
         args = ["--production"],
         package_json = "//internal/linker/test/multi_linker/lib_b:package.json",
         yarn_lock = "//internal/linker/test/multi_linker/lib_b:yarn.lock",
+        generate_build_files_concurrency_limit = 0,
     )
 
     yarn_install(
@@ -189,6 +194,7 @@ js_library(
         args = ["--production"],
         package_json = "//internal/linker/test/multi_linker/lib_c:lib/package.json",
         yarn_lock = "//internal/linker/test/multi_linker/lib_c:lib/yarn.lock",
+        generate_build_files_concurrency_limit = 0,
     )
 
     yarn_install(


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_nodejs/issues/3507

I set the default to an arbitrary reasonable value of 64