### PR TITLE
refactor(concatjs): sync with internal change that exposes `rootDirsRelative`

### DIFF
--- a/packages/concatjs/internal/tsc_wrapped/compiler_host.ts
+++ b/packages/concatjs/internal/tsc_wrapped/compiler_host.ts
@@ -223,7 +223,7 @@ export class CompilerHost implements ts.CompilerHost, tsickle.TsickleHost {
    * /build/work/bazel-out/local-fastbuild/bin/path/to/file
    * @return the path without any rootDirs, eg. path/to/file
    */
-  private rootDirsRelative(fileName: string): string {
+  rootDirsRelative(fileName: string): string {
     for (const root of this.options.rootDirs) {
       if (fileName.startsWith(root)) {
         // rootDirs are sorted longest-first, so short-circuit the iteration


### PR DESCRIPTION
Tsickle now requires a `rootDirsRelative` public property on the TS host. This change
has been implemented internally but hasn't been synced upstream, making it difficult
to update to the latest `tsickle` externally.

This is hopefully the last change in a while we need to sync up externally. It is still planned to
rework the whole rule to be owned by Angular directly, and not relying on the external
sync (might mean we need to diverge `ngc-wrapped` internally and externally)