### PR TITLE
fix: `ts_project` fails if `root_dir` used deep in source tree

### DIFF
--- a/nodejs/private/ts_lib.bzl
+++ b/nodejs/private/ts_lib.bzl
@@ -169,7 +169,7 @@ def _out_paths(srcs, out_dir, root_dir, allow_js, ext_map):
     outs = []
     for f in srcs:
         if _is_ts_src(f, allow_js):
-            out = _join(out_dir, f[:f.rindex(".")].replace(rootdir_replace_pattern, "") + _replace_ext(f, ext_map))
+            out = _join(out_dir, f[:f.rindex(".")].replace(rootdir_replace_pattern, "", 1) + _replace_ext(f, ext_map))
 
             # Don't declare outputs that collide with inputs
             # for example, a.js -> a.js

--- a/packages/typescript/test/ts_project/rootdir_with_value/BUILD.bazel
+++ b/packages/typescript/test/ts_project/rootdir_with_value/BUILD.bazel
@@ -5,6 +5,7 @@ load("//packages/typescript:index.bzl", "ts_project")
 SRCS = [
     "subdir/a.ts",
     "subdir/file.json",
+    "subdir/deep/subdir/b.ts",
 ]
 
 ts_project(

--- a/packages/typescript/test/ts_project/rootdir_with_value/subdir/deep/subdir/b.ts
+++ b/packages/typescript/test/ts_project/rootdir_with_value/subdir/deep/subdir/b.ts
@@ -1,0 +1,1 @@
+export const a: string = 'so many folders...';

--- a/packages/typescript/test/ts_project/rootdir_with_value/verify.js
+++ b/packages/typescript/test/ts_project/rootdir_with_value/verify.js
@@ -2,3 +2,7 @@ const assert = require('assert');
 
 const files = process.argv.slice(2);
 assert.ok(files.some(f => f.endsWith('rootdir_with_value/a.js')), 'Missing a.js');
+
+// Test that the only the top-level matching "rootdir" is removed.
+// NOTE: This should never fail directly, as the bug being fixed is a build-time error.
+assert.ok(files.some(f => f.endsWith('rootdir_with_value/deep/subdir/b.js')), 'Missing b.js');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
    - Unsure if necessary 


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

If `ts_project` is used with the `root_dir` parameter, and has a set of source files where the name of the `root_dir` is repeated within the source tree, then it incorrectly calculates output files (and subsequently breaks, as the filename it calculated was not produced).

For example: using a `root_dir` of `src` with the following tree:
```
- src
  - foo
    - src
      - foo.ts
 ```
would cause a bazel error of the form:
```
ERROR: BUILD.bazel:1:1: output 'foo/foo.js' was not created
```

The build should create (and expect the output) to be at `foo/src/foo.js` instead.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The fix is small but also somewhat magic-number, so I'm happy to re-evaluate the most clear way to fix this for future developers.