### PR TITLE
fix: make catch-all node_modules target name configurable in yarn_install and npm_install

### DIFF
--- a/docs/Built-ins.md
+++ b/docs/Built-ins.md
@@ -512,7 +512,7 @@ Defaults to `None`
 **USAGE**
 
 <pre>
-npm_install(<a href="#npm_install-name">name</a>, <a href="#npm_install-args">args</a>, <a href="#npm_install-data">data</a>, <a href="#npm_install-environment">environment</a>, <a href="#npm_install-exports_directories_only">exports_directories_only</a>,
+npm_install(<a href="#npm_install-name">name</a>, <a href="#npm_install-all_node_modules_target_name">all_node_modules_target_name</a>, <a href="#npm_install-args">args</a>, <a href="#npm_install-data">data</a>, <a href="#npm_install-environment">environment</a>, <a href="#npm_install-exports_directories_only">exports_directories_only</a>,
             <a href="#npm_install-generate_build_files_concurrency_limit">generate_build_files_concurrency_limit</a>, <a href="#npm_install-generate_local_modules_build_files">generate_local_modules_build_files</a>,
             <a href="#npm_install-included_files">included_files</a>, <a href="#npm_install-links">links</a>, <a href="#npm_install-manual_build_file_contents">manual_build_file_contents</a>, <a href="#npm_install-node_repository">node_repository</a>, <a href="#npm_install-npm_command">npm_command</a>,
             <a href="#npm_install-package_json">package_json</a>, <a href="#npm_install-package_json_remove">package_json_remove</a>, <a href="#npm_install-package_json_replace">package_json_replace</a>, <a href="#npm_install-package_lock_json">package_lock_json</a>, <a href="#npm_install-package_path">package_path</a>,
@@ -533,6 +533,16 @@ check if yarn is being run by the `npm_install` repository rule.
 
 (*<a href="https://bazel.build/docs/build-ref.html#name">Name</a>, mandatory*): A unique name for this repository.
 
+
+<h4 id="npm_install-all_node_modules_target_name">all_node_modules_target_name</h4>
+
+(*String*): The name used for the generated all node_modules js_library target.
+
+        This can be used to name the all node_modules target something other than `//:node_modules`,
+        such as `//:node_modules_all`, so you can use the `//:node_modules` label to reference the
+        `node_modules` source directory in `manual_build_file_contents` for custom use cases.
+
+Defaults to `"node_modules"`
 
 <h4 id="npm_install-args">args</h4>
 
@@ -1185,12 +1195,12 @@ Defaults to `{}`
 **USAGE**
 
 <pre>
-yarn_install(<a href="#yarn_install-name">name</a>, <a href="#yarn_install-args">args</a>, <a href="#yarn_install-data">data</a>, <a href="#yarn_install-environment">environment</a>, <a href="#yarn_install-exports_directories_only">exports_directories_only</a>, <a href="#yarn_install-frozen_lockfile">frozen_lockfile</a>,
-             <a href="#yarn_install-generate_build_files_concurrency_limit">generate_build_files_concurrency_limit</a>, <a href="#yarn_install-generate_local_modules_build_files">generate_local_modules_build_files</a>,
-             <a href="#yarn_install-included_files">included_files</a>, <a href="#yarn_install-links">links</a>, <a href="#yarn_install-manual_build_file_contents">manual_build_file_contents</a>, <a href="#yarn_install-node_repository">node_repository</a>, <a href="#yarn_install-package_json">package_json</a>,
-             <a href="#yarn_install-package_json_remove">package_json_remove</a>, <a href="#yarn_install-package_json_replace">package_json_replace</a>, <a href="#yarn_install-package_path">package_path</a>, <a href="#yarn_install-patch_args">patch_args</a>, <a href="#yarn_install-patch_tool">patch_tool</a>,
-             <a href="#yarn_install-post_install_patches">post_install_patches</a>, <a href="#yarn_install-pre_install_patches">pre_install_patches</a>, <a href="#yarn_install-quiet">quiet</a>, <a href="#yarn_install-repo_mapping">repo_mapping</a>, <a href="#yarn_install-strict_visibility">strict_visibility</a>,
-             <a href="#yarn_install-symlink_node_modules">symlink_node_modules</a>, <a href="#yarn_install-timeout">timeout</a>, <a href="#yarn_install-use_global_yarn_cache">use_global_yarn_cache</a>, <a href="#yarn_install-yarn">yarn</a>, <a href="#yarn_install-yarn_lock">yarn_lock</a>)
+yarn_install(<a href="#yarn_install-name">name</a>, <a href="#yarn_install-all_node_modules_target_name">all_node_modules_target_name</a>, <a href="#yarn_install-args">args</a>, <a href="#yarn_install-data">data</a>, <a href="#yarn_install-environment">environment</a>, <a href="#yarn_install-exports_directories_only">exports_directories_only</a>,
+             <a href="#yarn_install-frozen_lockfile">frozen_lockfile</a>, <a href="#yarn_install-generate_build_files_concurrency_limit">generate_build_files_concurrency_limit</a>,
+             <a href="#yarn_install-generate_local_modules_build_files">generate_local_modules_build_files</a>, <a href="#yarn_install-included_files">included_files</a>, <a href="#yarn_install-links">links</a>, <a href="#yarn_install-manual_build_file_contents">manual_build_file_contents</a>,
+             <a href="#yarn_install-node_repository">node_repository</a>, <a href="#yarn_install-package_json">package_json</a>, <a href="#yarn_install-package_json_remove">package_json_remove</a>, <a href="#yarn_install-package_json_replace">package_json_replace</a>, <a href="#yarn_install-package_path">package_path</a>,
+             <a href="#yarn_install-patch_args">patch_args</a>, <a href="#yarn_install-patch_tool">patch_tool</a>, <a href="#yarn_install-post_install_patches">post_install_patches</a>, <a href="#yarn_install-pre_install_patches">pre_install_patches</a>, <a href="#yarn_install-quiet">quiet</a>, <a href="#yarn_install-repo_mapping">repo_mapping</a>,
+             <a href="#yarn_install-strict_visibility">strict_visibility</a>, <a href="#yarn_install-symlink_node_modules">symlink_node_modules</a>, <a href="#yarn_install-timeout">timeout</a>, <a href="#yarn_install-use_global_yarn_cache">use_global_yarn_cache</a>, <a href="#yarn_install-yarn">yarn</a>, <a href="#yarn_install-yarn_lock">yarn_lock</a>)
 </pre>
 
 Runs yarn install during workspace setup.
@@ -1206,6 +1216,16 @@ check if yarn is being run by the `yarn_install` repository rule.
 
 (*<a href="https://bazel.build/docs/build-ref.html#name">Name</a>, mandatory*): A unique name for this repository.
 
+
+<h4 id="yarn_install-all_node_modules_target_name">all_node_modules_target_name</h4>
+
+(*String*): The name used for the generated all node_modules js_library target.
+
+        This can be used to name the all node_modules target something other than `//:node_modules`,
+        such as `//:node_modules_all`, so you can use the `//:node_modules` label to reference the
+        `node_modules` source directory in `manual_build_file_contents` for custom use cases.
+
+Defaults to `"node_modules"`
 
 <h4 id="yarn_install-args">args</h4>
 

--- a/internal/npm_install/generate_build_file.ts
+++ b/internal/npm_install/generate_build_file.ts
@@ -65,6 +65,7 @@ let config: any = {
   strict_visibility: true,
   workspace_rerooted_path: '',
   workspace: '',
+  all_node_modules_target_name: 'node_modules',
 };
 
 function generateBuildFileHeader(visibility = PUBLIC_VISIBILITY): string {
@@ -314,7 +315,7 @@ ${exportsStarlark}])
 # there are many files in target.
 # See https://github.com/bazelbuild/bazel/issues/5153.
 js_library(
-    name = "node_modules",
+    name = "${config.all_node_modules_target_name}",
     package_name = "${LEGACY_NODE_MODULES_PACKAGE_NAME}",
     package_path = "${config.package_path}",${pkgFilesStarlark}${depsStarlark}
 )

--- a/internal/npm_install/index.js
+++ b/internal/npm_install/index.js
@@ -23,6 +23,7 @@ let config = {
     strict_visibility: true,
     workspace_rerooted_path: '',
     workspace: '',
+    all_node_modules_target_name: 'node_modules',
 };
 function generateBuildFileHeader(visibility = PUBLIC_VISIBILITY) {
     return `# Generated file from ${config.rule_type} rule.
@@ -208,7 +209,7 @@ ${exportsStarlark}])
 # there are many files in target.
 # See https://github.com/bazelbuild/bazel/issues/5153.
 js_library(
-    name = "node_modules",
+    name = "${config.all_node_modules_target_name}",
     package_name = "${LEGACY_NODE_MODULES_PACKAGE_NAME}",
     package_path = "${config.package_path}",${pkgFilesStarlark}${depsStarlark}
 )

--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -359,6 +359,15 @@ Using managed_directories will mean that
         default = 3600,
         doc = """Maximum duration of the package manager execution in seconds.""",
     ),
+    "all_node_modules_target_name": attr.string(
+        default = "node_modules",
+        doc = """The name used for the generated all node_modules js_library target.
+
+        This can be used to name the all node_modules target something other than `//:node_modules`,
+        such as `//:node_modules_all`, so you can use the `//:node_modules` label to reference the
+        `node_modules` source directory in `manual_build_file_contents` for custom use cases.
+        """,
+    ),
     "generate_build_files_concurrency_limit": attr.int(
         default = 64,
         doc = """Limit the maximum concurrency of npm package processing when generating
@@ -486,6 +495,7 @@ def _create_build_files(repository_ctx, rule_type, node, lock_file, generate_loc
             workspace = repository_ctx.attr.name,
             workspace_rerooted_package_json_dir = paths.normalize(paths.join(_WORKSPACE_REROOTED_PATH, package_json_dir)),
             workspace_rerooted_path = _WORKSPACE_REROOTED_PATH,
+            all_node_modules_target_name = repository_ctx.attr.all_node_modules_target_name,
         ),
     )
     repository_ctx.file("generate_config.json", generate_config_json)


### PR DESCRIPTION
The default target name obfuscates the "node_modules" source directory for use in `manual_build_file_contents` for custom use cases.