### PR TITLE
migrating to rbe_preconfig

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -166,17 +166,18 @@ bazel_skylib_workspace()
 #
 
 load("//:index.bzl", "BAZEL_VERSION", "SUPPORTED_BAZEL_VERSIONS")
-load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
 
 # Creates toolchain configuration for remote execution with BuildKite CI
 # for rbe_ubuntu1604
-rbe_autoconfig(
+rbe_preconfig(
     name = "buildkite_config",
+    toolchain = "ubuntu1804-bazel-java11",
 )
 
-rbe_autoconfig(
+rbe_preconfig(
     name = "rbe_default",
-    bazel_version = BAZEL_VERSION,
+    toolchain = "ubuntu1804-bazel-java11",
 )
 
 load("@build_bazel_integration_testing//tools:repositories.bzl", "bazel_binaries")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -165,7 +165,7 @@ bazel_skylib_workspace()
 # RBE configuration
 #
 
-load("//:index.bzl", "BAZEL_VERSION", "SUPPORTED_BAZEL_VERSIONS")
+load("//:index.bzl", "SUPPORTED_BAZEL_VERSIONS")
 load("@bazelci_rules//:rbe_repo.bzl", "rbe_preconfig")
 
 # Creates toolchain configuration for remote execution with BuildKite CI

--- a/examples/angular/WORKSPACE
+++ b/examples/angular/WORKSPACE
@@ -100,14 +100,12 @@ sass_repositories()
 ################################
 # Support for Remote Execution #
 ################################
-
 http_archive(
-    name = "bazel_toolchains",
-    sha256 = "179ec02f809e86abf56356d8898c8bd74069f1bd7c56044050c2cd3d79d0e024",
-    strip_prefix = "bazel-toolchains-4.1.0",
+    name = "bazelci_rules",
+    sha256 = "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
+    strip_prefix = "bazelci_rules-1.0.0",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
+        "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
     ],
 )
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -84,16 +84,13 @@ def build_bazel_rules_nodejs_dev_dependencies():
     )
 
     # Needed for Remote Build Execution
-    # See https://releases.bazel.build/bazel-toolchains.html
+    # See https://github.com/bazelbuild/continuous-integration/releases/tag/rules-1.0.0
     maybe(
         http_archive,
-        name = "bazel_toolchains",
-        sha256 = "179ec02f809e86abf56356d8898c8bd74069f1bd7c56044050c2cd3d79d0e024",
-        strip_prefix = "bazel-toolchains-4.1.0",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-toolchains/releases/download/4.1.0/bazel-toolchains-4.1.0.tar.gz",
-        ],
+        name = "bazelci_rules",
+        sha256 = "eca21884e6f66a88c358e580fd67a6b148d30ab57b1680f62a96c00f9bc6a07e",
+        strip_prefix = "bazelci_rules-1.0.0",
+        url = "https://github.com/bazelbuild/continuous-integration/releases/download/rules-1.0.0/bazelci_rules-1.0.0.tar.gz",
     )
 
     maybe(


### PR DESCRIPTION
## PR Checklist

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently `rules_nodejs` uses the deprecated `rbe_autoconfig` that still has reference to `@bazeltools_platforms:xxx`. It was also linked with `bazel_toolchains` repo. The flag `--incompatible_use_platforms_repo_for_constraints` is flipped causing failures for `rules_nodejs` in downstream pipelines.

Issue Number: https://github.com/bazelbuild/continuous-integration/issues/1404
https://github.com/bazelbuild/rules_nodejs/issues/3537


## What is the new behavior?
This pr updates to use the new `rbe_preconfig` and remove `bazel_toolchains` from rules_nodejs as there are no other usage for `bazel_toolchains`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No