### PR TITLE
Fix BAZEL_TARGET values for main-repo labels

### DIFF
--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -195,7 +195,12 @@ def _nodejs_binary_impl(ctx, data = [], runfiles = [], expanded_args = []):
 
     # Provide the target name as an environment variable avaiable to all actions for the
     # runfiles helpers to use.
-    env_vars = "export BAZEL_TARGET=%s\n" % ctx.label
+    target_label = str(ctx.label)
+    if target_label.startswith("@@//"):
+        target_label = target_label[2:]
+    elif target_label.startswith("@//"):
+        target_label = target_label[1:]
+    env_vars = "export BAZEL_TARGET=%s\n" % target_label
 
     # Add all env vars from the ctx attr
     for [key, value] in ctx.attr.env.items():


### PR DESCRIPTION
With https://github.com/bazelbuild/bazel/issues/16196 flipped, labels in the main repo will have an extra '@' prepended when stringified. This breaks stuff like https://github.com/bazelbuild/rules_nodejs/blob/a461224651a2802a53a163bef23d6a3fe2597d4d/internal/runfiles/index.cjs#L72-L76 . This commit fixes the issue by removing leading '@'s in main-repo labels before setting BAZEL_TARGET

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

