### PR TITLE
fix(builtin): properly quote env vars passed to nodejs_binary

### DIFF
--- a/internal/node/node.bzl
+++ b/internal/node/node.bzl
@@ -204,7 +204,7 @@ def _nodejs_binary_impl(ctx, data = [], runfiles = [], expanded_args = []):
 
     # Add all env vars from the ctx attr
     for [key, value] in ctx.attr.env.items():
-        env_vars += "export %s=%s\n" % (key, ctx.expand_make_variables("env", expand_location_into_runfiles(ctx, value, data), {}))
+        env_vars += "export %s=\"%s\"\n" % (key, ctx.expand_make_variables("env", expand_location_into_runfiles(ctx, value, data), {}))
 
     # While we can derive the workspace from the pwd when running locally
     # because it is in the execroot path `execroot/my_wksp`, on RBE the

--- a/internal/node/test/BUILD.bazel
+++ b/internal/node/test/BUILD.bazel
@@ -410,6 +410,7 @@ nodejs_binary(
     env = {
         "LOC": "$(location :dump_build_env.js)",
         "SOME_TEST_ENV": "$(SOME_TEST_ENV)",
+        "BACKSLASHES": "C:\\some path\\on\\windows.exe",
     },
 )
 

--- a/internal/node/test/env.spec.js
+++ b/internal/node/test/env.spec.js
@@ -123,4 +123,9 @@ describe('launcher.sh environment', function() {
       const env = require(runfiles.resolvePackageRelative('dump_build_env_attr.json'));
       expect(env['SOME_TEST_ENV']).toBe('some_value')
   });
+
+  it('should correctly pass environment variables with backslashes', function() {
+    const env = require(runfiles.resolvePackageRelative('dump_build_env_attr.json'));
+    expect(env['BACKSLASHES']).toBe('C:\\some path\\on\\windows.exe');
+  });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Environment variables passed to the launcher script were not escaped.


## What is the new behavior?


Properly surrounded in quotes as is done elsewhere.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->



