### PR TITLE
fix: canonicalize @platforms//cpu:aarch64

### DIFF
--- a/nodejs/private/toolchains_repo.bzl
+++ b/nodejs/private/toolchains_repo.bzl
@@ -27,7 +27,7 @@ PLATFORMS = {
     "linux_arm64": struct(
         compatible_with = [
             "@platforms//os:linux",
-            "@platforms//cpu:aarch64",
+            "@platforms//cpu:arm64",
         ],
     ),
     "linux_s390x": struct(
@@ -51,7 +51,7 @@ PLATFORMS = {
     "darwin_arm64": struct(
         compatible_with = [
             "@platforms//os:macos",
-            "@platforms//cpu:aarch64",
+            "@platforms//cpu:arm64",
         ],
     ),
     "windows_amd64": struct(

--- a/packages/concatjs/devserver/BUILD.bazel
+++ b/packages/concatjs/devserver/BUILD.bazel
@@ -103,7 +103,7 @@ config_setting(
     name = "linux_arm64",
     constraint_values = [
         "@platforms//os:linux",
-        "@platforms//cpu:aarch64",
+        "@platforms//cpu:arm64",
     ],
 )
 

--- a/toolchains/esbuild/esbuild_packages.bzl
+++ b/toolchains/esbuild/esbuild_packages.bzl
@@ -30,7 +30,7 @@ ESBUILD_PACKAGES = struct(
             binary_path = "bin/esbuild",
             exec_compatible_with = [
                 "@platforms//os:macos",
-                "@platforms//cpu:aarch64",
+                "@platforms//cpu:arm64",
             ],
         ),
         "linux_amd64": struct(
@@ -52,7 +52,7 @@ ESBUILD_PACKAGES = struct(
             binary_path = "bin/esbuild",
             exec_compatible_with = [
                 "@platforms//os:linux",
-                "@platforms//cpu:aarch64",
+                "@platforms//cpu:arm64",
             ],
         ),
         "windows_amd64": struct(


### PR DESCRIPTION
This is defined as an alias to :arm64:
https://github.com/bazelbuild/platforms/blob/212a486d66569b29c95b00364e2584e80fd08614/cpu/BUILD#L16-L20 but toolchain resolution doesn't understand the two to be equivalent.

Fixes https://github.com/aspect-build/rules_js/issues/469
