### PR TITLE
fix(builtin): use updated rules_js launcher logic to source RUNFILES

### DIFF
--- a/internal/node/launcher.sh
+++ b/internal/node/launcher.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # It helps to determine if we are running on a Windows environment (excludes WSL as it acts like Unix)
-function isWindows {
+function is_windows {
   case "$(uname -s)" in
       CYGWIN*)    local IS_WINDOWS=1 ;;
       MINGW*)     local IS_WINDOWS=1 ;;
@@ -29,14 +29,13 @@ function isWindows {
 # It helps to normalizes paths when running on Windows.
 #
 # Example:
-# C:/Users/XUser/_bazel_XUser/7q7kkv32/execroot/A/b/C -> /c/users/xuser/_bazel_xuser/7q7kkv32/execroot/a/b/c
-function normalizeWindowsPath {
-  # Apply the followings paths transformations to normalize paths on Windows
-  # -process driver letter
-  # -convert path separator
-  # -lowercase everything
-  echo $(sed -e 's#^\(.\):#/\L\1#' -e 's#\\#/#g' -e 's/[A-Z]/\L&/g' <<< "$1")
-  return
+# C:/Users/XUser/_bazel_XUser/7q7kkv32/execroot/A/b/C -> /c/Users/XUser/_bazel_XUser/7q7kkv32/execroot/A/b/C
+function normalize_windows_path {
+    # Apply the followings paths transformations to normalize paths on Windows
+    # -process driver letter
+    # -convert path separator
+    sed -e 's#^\(.\):#/\L\1#' -e 's#\\#/#g' <<< "$1"
+    return
 }
 
 # --- begin runfiles.bash initialization v2 ---
@@ -73,51 +72,66 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
 # blaze.
 # Case 5a is handled like case 1.
 # Case 6a is handled like case 3.
-if [[ -n "${RUNFILES_MANIFEST_ONLY:-}" ]]; then
-  # Windows only has a manifest file instead of symlinks.
-  if [[ $(isWindows) -eq "1" ]]; then
-    # If Windows normalizing the path and case insensitive removing the `/MANIFEST` part of the path
-    NORMALIZED_RUNFILES_MANIFEST_FILE_PATH=$(normalizeWindowsPath $RUNFILES_MANIFEST_FILE)
-    RUNFILES=$(sed 's|\/MANIFEST$||i' <<< $NORMALIZED_RUNFILES_MANIFEST_FILE_PATH)
-  else
-    RUNFILES=${RUNFILES_MANIFEST_FILE%/MANIFEST}
-  fi
-elif [[ -n "${TEST_SRCDIR:-}" ]]; then
-  # Case 4, bazel has identified runfiles for us.
-  RUNFILES="${TEST_SRCDIR:-}"
-else
-  case "$0" in
-  /*) self="$0" ;;
-  *) self="$PWD/$0" ;;
-  esac
-  while true; do
-    if [[ -e "$self.runfiles" ]]; then
-      RUNFILES="$self.runfiles"
-      break
-    fi
-
-    if [[ $self == *.runfiles/* ]]; then
-      RUNFILES="${self%%.runfiles/*}.runfiles"
-      # don't break; this is a last resort for case 6b
-    fi
-
-    if [[ ! -L "$self" ]]; then
-      break;
-    fi
-
-    readlink="$(readlink "$self")"
-    if [[ "$readlink" = /* ]]; then
-      self="$readlink"
+if [ "${TEST_SRCDIR:-}" ]; then
+    # Case 4, bazel has identified runfiles for us.
+    RUNFILES="$TEST_SRCDIR"
+elif [ "${RUNFILES_MANIFEST_FILE:-}" ]; then
+    if [ "$(is_windows)" -eq "1" ]; then
+        # If Windows, normalize the path
+        NORMALIZED_RUNFILES_MANIFEST_FILE=$(normalize_windows_path "$RUNFILES_MANIFEST_FILE")
     else
-      # resolve relative symlink
-      self="${self%%/*}/$readlink"
+        NORMALIZED_RUNFILES_MANIFEST_FILE="$RUNFILES_MANIFEST_FILE"
     fi
-  done
+    if [[ "${NORMALIZED_RUNFILES_MANIFEST_FILE}" == *.runfiles_manifest ]]; then
+        # Newer versions of Bazel put the manifest besides the runfiles with the suffix .runfiles_manifest.
+        # For example, the runfiles directory is named my_binary.runfiles then the manifest is beside the
+        # runfiles directory and named my_binary.runfiles_manifest
+        RUNFILES=${NORMALIZED_RUNFILES_MANIFEST_FILE%_manifest}
+    elif [[ "${NORMALIZED_RUNFILES_MANIFEST_FILE}" == */MANIFEST ]]; then
+        # Older versions of Bazel put the manifest file named MANIFEST in the runfiles directory
+        RUNFILES=${NORMALIZED_RUNFILES_MANIFEST_FILE%/MANIFEST}
+    else
+        echo "\n>>>> FAIL: Unexpected RUNFILES_MANIFEST_FILE value $RUNFILES_MANIFEST_FILE. <<<<\n\n" >&2
+        exit 1
+    fi
+else
+    case "$0" in
+    /*) self="$0" ;;
+    *) self="$PWD/$0" ;;
+    esac
+    while true; do
+        if [ -e "$self.runfiles" ]; then
+            RUNFILES="$self.runfiles"
+            break
+        fi
 
-  if [[ -z "$RUNFILES" ]]; then
-    echo " >>>> FAIL: RUNFILES environment variable is not set. <<<<" >&2
-    exit 1
-  fi
+        if [[ "$self" == *.runfiles/* ]]; then
+            RUNFILES="${self%%.runfiles/*}.runfiles"
+            # don't break; this is a last resort for case 6b
+        fi
+
+        if [ ! -L "$self" ]; then
+            break;
+        fi
+
+        readlink="$(readlink "$self")"
+        if [[ "$readlink" == /* ]]; then
+            self="$readlink"
+        else
+            # resolve relative symlink
+            self="${self%%/*}/$readlink"
+        fi
+    done
+
+    if [ -z "${RUNFILES:-}" ]; then
+        echo "\n>>>> FAIL: RUNFILES environment variable is not set. <<<<\n\n" >&2
+        exit 1
+    fi
+fi
+if [ "${RUNFILES:0:1}" != "/" ]; then
+    # Ensure RUNFILES set above is an absolute path. It may be a path relative
+    # to the PWD in case where RUNFILES_MANIFEST_FILE is used above.
+    RUNFILES="$PWD/$RUNFILES"
 fi
 export RUNFILES
 # --- end RUNFILES initialization ---


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`RUNFILES_MANIFEST_ONLY` is always set to `1` (see https://github.com/angular/angular/pull/47527/files#diff-30590eade0d767af96219fac23a137e7996bff554e9569f1db54ed40be435854R17-R23). This seems like a bug. When runfiles are enabled, during a `bazel test` the environment var `RUNFILES` is not set correctly because of it.

Separately from addressing the above, the slightly modified [launcher logic](https://github.com/aspect-build/rules_js/blob/06d51cddbd62e44303b1a0d62af97b3e22dec9d1/js/private/js_binary.sh.tpl#L172) in `rules_js` already works around the issue by getting the runfiles directory from `TEST_SRCDIR`.

## What is the new behavior?

Use rules_js updated launcher logic.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

