### PR TITLE
feat: add npm binary & files to toolchain provider

### DIFF
--- a/docs/Core.md
+++ b/docs/Core.md
@@ -185,10 +185,10 @@ Defaults to `None`
 **USAGE**
 
 <pre>
-node_toolchain(<a href="#node_toolchain-name">name</a>, <a href="#node_toolchain-run_npm">run_npm</a>, <a href="#node_toolchain-target_tool">target_tool</a>, <a href="#node_toolchain-target_tool_path">target_tool_path</a>)
+node_toolchain(<a href="#node_toolchain-name">name</a>, <a href="#node_toolchain-npm">npm</a>, <a href="#node_toolchain-npm_files">npm_files</a>, <a href="#node_toolchain-npm_path">npm_path</a>, <a href="#node_toolchain-run_npm">run_npm</a>, <a href="#node_toolchain-target_tool">target_tool</a>, <a href="#node_toolchain-target_tool_path">target_tool_path</a>)
 </pre>
 
-Defines a node toolchain.
+Defines a node toolchain for a platform.
 
 You can use this to refer to a vendored nodejs binary in your repository,
 or even to compile nodejs from sources using rules_foreign_cc or other rules.
@@ -204,7 +204,9 @@ node_toolchain(
 )
 ```
 
-Next, declare which execution platforms or target platforms the toolchain should be selected for:
+Next, declare which execution platforms or target platforms the toolchain should be selected for
+based on constraints.
+
 ```starlark
 toolchain(
     name = "my_nodejs",
@@ -216,6 +218,9 @@ toolchain(
     toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
 )
 ```
+
+See https://bazel.build/extending/toolchains#toolchain-resolution for more information on toolchain
+resolution.
 
 Finally in your `WORKSPACE`, register it with `register_toolchains("//:my_nodejs")`
 
@@ -231,6 +236,24 @@ You can use the `--toolchain_resolution_debug` flag to `bazel` to help diagnose 
 (*<a href="https://bazel.build/docs/build-ref.html#name">Name</a>, mandatory*): A unique name for this target.
 
 
+<h4 id="node_toolchain-npm">npm</h4>
+
+(*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>*): A hermetically downloaded npm executable target for this target's platform.
+
+Defaults to `None`
+
+<h4 id="node_toolchain-npm_files">npm_files</h4>
+
+(*<a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a>*): Files required in runfiles to run npm.
+
+Defaults to `[]`
+
+<h4 id="node_toolchain-npm_path">npm_path</h4>
+
+(*String*): Path to an existing npm executable for this target's platform.
+
+Defaults to `""`
+
 <h4 id="node_toolchain-run_npm">run_npm</h4>
 
 (*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>*): A template file that allows us to execute npm
@@ -239,13 +262,13 @@ Defaults to `None`
 
 <h4 id="node_toolchain-target_tool">target_tool</h4>
 
-(*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>*): A hermetically downloaded nodejs executable target for the target platform.
+(*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>*): A hermetically downloaded nodejs executable target for this target's platform.
 
 Defaults to `None`
 
 <h4 id="node_toolchain-target_tool_path">target_tool_path</h4>
 
-(*String*): Path to an existing nodejs executable for the target platform.
+(*String*): Path to an existing nodejs executable for this target's platform.
 
 Defaults to `""`
 

--- a/nodejs/repositories.bzl
+++ b/nodejs/repositories.bzl
@@ -341,6 +341,8 @@ load("@rules_nodejs//nodejs:toolchain.bzl", "node_toolchain")
 node_toolchain(
     name = "node_toolchain",
     target_tool = ":node_bin",
+    npm = ":npm",
+    npm_files = [":npm_files"],
     run_npm = ":run_npm.template",
 )
 """

--- a/nodejs/toolchain.bzl
+++ b/nodejs/toolchain.bzl
@@ -20,10 +20,14 @@ See /examples/toolchain for usage example.
 NodeInfo = provider(
     doc = "Information about how to invoke the node executable.",
     fields = {
-        "target_tool_path": "Path to the nodejs executable for the target platform.",
+        "target_tool_path": "Path to the nodejs executable for this target's platform.",
         "tool_files": """Files required in runfiles to make the nodejs executable available.
 
 May be empty if the target_tool_path points to a locally installed node binary.""",
+        "npm_path": "Path to the npm executable for this target's platform.",
+        "npm_files": """Files required in runfiles to make the npm executable available.
+
+May be empty if the npm_path points to a locally installed npm binary.""",
         "run_npm": """A template for a script that wraps npm.
         On Windows, this is a Batch script, otherwise it uses Bash.""",
     },
@@ -41,18 +45,28 @@ def _node_toolchain_impl(ctx):
         fail("Can only set one of target_tool or target_tool_path but both were set.")
     if not ctx.attr.target_tool and not ctx.attr.target_tool_path:
         fail("Must set one of target_tool or target_tool_path.")
+    if ctx.attr.npm and ctx.attr.npm_path:
+        fail("Can only set one of npm or npm_path but both were set.")
 
     tool_files = []
     target_tool_path = ctx.attr.target_tool_path
 
     if ctx.attr.target_tool:
-        tool_files = ctx.attr.target_tool.files.to_list()
-        target_tool_path = _to_manifest_path(ctx, tool_files[0])
+        tool_files = [ctx.file.target_tool]
+        target_tool_path = _to_manifest_path(ctx, ctx.file.target_tool)
+
+    npm_files = []
+    npm_path = ctx.attr.npm_path
+
+    if ctx.attr.npm:
+        npm_files = depset([ctx.file.npm] + ctx.files.npm_files).to_list()
+        npm_path = _to_manifest_path(ctx, ctx.file.npm)
 
     # Make the $(NODE_PATH) variable available in places like genrules.
     # See https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables
     template_variables = platform_common.TemplateVariableInfo({
         "NODE_PATH": target_tool_path,
+        "NPM_PATH": npm_path,
     })
     default = DefaultInfo(
         files = depset(tool_files),
@@ -61,6 +75,8 @@ def _node_toolchain_impl(ctx):
     nodeinfo = NodeInfo(
         target_tool_path = target_tool_path,
         tool_files = tool_files,
+        npm_path = npm_path,
+        npm_files = npm_files,
         run_npm = ctx.file.run_npm,
     )
 
@@ -81,12 +97,25 @@ node_toolchain = rule(
     implementation = _node_toolchain_impl,
     attrs = {
         "target_tool": attr.label(
-            doc = "A hermetically downloaded nodejs executable target for the target platform.",
+            doc = "A hermetically downloaded nodejs executable target for this target's platform.",
             mandatory = False,
             allow_single_file = True,
         ),
         "target_tool_path": attr.string(
-            doc = "Path to an existing nodejs executable for the target platform.",
+            doc = "Path to an existing nodejs executable for this target's platform.",
+            mandatory = False,
+        ),
+        "npm": attr.label(
+            doc = "A hermetically downloaded npm executable target for this target's platform.",
+            mandatory = False,
+            allow_single_file = True,
+        ),
+        "npm_path": attr.string(
+            doc = "Path to an existing npm executable for this target's platform.",
+            mandatory = False,
+        ),
+        "npm_files": attr.label_list(
+            doc = "Files required in runfiles to run npm.",
             mandatory = False,
         ),
         "run_npm": attr.label(
@@ -94,7 +123,7 @@ node_toolchain = rule(
             allow_single_file = True,
         ),
     },
-    doc = """Defines a node toolchain.
+    doc = """Defines a node toolchain for a platform.
 
 You can use this to refer to a vendored nodejs binary in your repository,
 or even to compile nodejs from sources using rules_foreign_cc or other rules.
@@ -110,7 +139,9 @@ node_toolchain(
 )
 ```
 
-Next, declare which execution platforms or target platforms the toolchain should be selected for:
+Next, declare which execution platforms or target platforms the toolchain should be selected for
+based on constraints.
+
 ```starlark
 toolchain(
     name = "my_nodejs",
@@ -122,6 +153,9 @@ toolchain(
     toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
 )
 ```
+
+See https://bazel.build/extending/toolchains#toolchain-resolution for more information on toolchain
+resolution.
 
 Finally in your `WORKSPACE`, register it with `register_toolchains("//:my_nodejs")`
 


### PR DESCRIPTION
Downstream rules that use the toolchain can choose to include the npm binary & files specified by the toolchain as inputs for actions.