### PR TITLE
Added support for linux ppc64le and linux s390x

### DIFF
--- a/scripts/update-esbuild-versions.js
+++ b/scripts/update-esbuild-versions.js
@@ -9,7 +9,9 @@ const PLATFORMS = {
   "_DARWIN_ARM64": "esbuild-darwin-arm64",
   "_LINUX_AMD64": "esbuild-linux-64",
   "_LINUX_ARM64": "esbuild-linux-arm64",
-  "_WINDOWS_AMD64": "esbuild-windows-64"
+  "_WINDOWS_AMD64": "esbuild-windows-64",
+  "_LINUX_PPC64LE": "esbuild-linux-ppc64le",
+  "_LINUX_S390X": "esbuild-linux-s390x"
 }
 
 function replaceFileContent(filepath, replacements) {

--- a/toolchains/esbuild/esbuild_packages.bzl
+++ b/toolchains/esbuild/esbuild_packages.bzl
@@ -7,6 +7,8 @@ _DARWIN_ARM64_SHA = "6182ba67f1295e1d6e388048d0c892e8279d475e381f0e2ca22539a904d
 _LINUX_AMD64_SHA = "b8eec10627d3789b312abd2295d52a9979d7d4addf132c328c69977605fb4293"
 _LINUX_ARM64_SHA = "ea58f83ae0a0283dc479afc66a1380f63204105d1571a3b605b058672538bba0"
 _WINDOWS_AMD64_SHA = "681c011044aa813cabdc4f6996967f33f6e27c58417b3fcada95291ebbf60a2f"
+_LINUX_PPC64LE_SHA = "ae12b532da6a331a13ea2cd57be564eff6cf4e8c324763db232dcf328ad9b9a5"
+_LINUX_S390X_SHA = "985b93498ed8e70a4bee7ccbdb68b4da652167299dd081b7e3ea433d4d1869e9"
 
 ESBUILD_PACKAGES = struct(
     version = _VERSION,
@@ -64,6 +66,28 @@ ESBUILD_PACKAGES = struct(
             exec_compatible_with = [
                 "@platforms//os:windows",
                 "@platforms//cpu:x86_64",
+            ],
+        ),
+        "linux_ppc64le": struct(
+            sha = _LINUX_PPC64LE_SHA,
+            urls = [
+                "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-%s.tgz" % _VERSION,
+            ],
+            binary_path = "bin/esbuild",
+            exec_compatible_with = [
+                "@platforms//os:linux",
+                "@platforms//cpu:ppc",
+            ],
+        ),
+        "linux_s390x": struct(
+            sha = _LINUX_S390X_SHA,
+            urls = [
+                "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-%s.tgz" % _VERSION,
+            ],
+            binary_path = "bin/esbuild",
+            exec_compatible_with = [
+                "@platforms//os:linux",
+                "@platforms//cpu:s390x",
             ],
         ),
     }),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Tensorboard uses rules_nodejs during its build. And it fails on linux ppc64le or linux s390x with following error -
```
ERROR: /opt/conda/conda-bld/tensorboard_1665144934672/work/tensorboard/webapp/widgets/line_chart_v2/lib/worker/BUILD:89:13: While resolving toolchains for target //tensorboard/webapp/widgets/line_chart_v2/lib/worker:chart_worker: no matching toolchains found for types @build_bazel_rules_nodejs//toolchains/esbuild:toolchain_type
ERROR: Analysis of target '//tensorboard/pip_package:build_pip_package' failed; build aborted:
INFO: Elapsed time: 112.999s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (118 packages loaded, 1236 targets configured)
FAILED: Build did NOT complete successfully (118 packages loaded, 1236 targets configured)
Traceback (most recent call last):

```
Issue Number: N/A

## What is the new behavior?
Tensorboard 2.10 compiled successfully with this change on linux ppc64le. I'm yet to verify the build on s390x. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


## Other information
