### PR TITLE
chore: export TsConfigInfo in public interface

### DIFF
--- a/packages/typescript/index.bzl
+++ b/packages/typescript/index.bzl
@@ -20,7 +20,7 @@ Users should not load files under "/internal"
 load("@build_bazel_rules_nodejs//internal/node:node.bzl", "nodejs_binary")
 load("@build_bazel_rules_nodejs//:providers.bzl", "ExternalNpmPackageInfo", "run_node")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "module_mappings_aspect")
-load("//nodejs/private:ts_config.bzl", "write_tsconfig", _ts_config = "ts_config")
+load("//nodejs/private:ts_config.bzl", "write_tsconfig", _TsConfigInfo = "TsConfigInfo", _ts_config = "ts_config")
 load("//nodejs/private:ts_project.bzl", _ts_project_lib = "ts_project")
 load("//nodejs/private:ts_lib.bzl", "DEPS_PROVIDERS", _lib = "lib")
 load("//nodejs/private:ts_validate_options.bzl", validate_lib = "lib")
@@ -31,6 +31,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 # If adding rules here also add to index.docs.bzl
 
 ts_config = _ts_config
+TsConfigInfo = _TsConfigInfo
 
 def _validate_options_impl(ctx):
     return validate_lib.implementation(ctx, run_node)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Add API export


## What is the current behavior?
The typescript package `@npm//@bazel/typescript:index.bzl` exports the public typescript rules interface including a rule called `ts_config`. However, `ts_config` returns a provider `TsConfigInfo` that is not publicly exported and is instead found under `@rules_nodejs//nodejs/private:ts_config.bzl`.

Issue Number: N/A


## What is the new behavior?
`TsConfigInfo` is exported from `@npm//@bazel/typescript:index.bzl` alongside `ts_config`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

