### PR TITLE
Revert "chore: remove fasterci which is often red"

### DIFF
--- a/.fasterci/config.yaml
+++ b/.fasterci/config.yaml
@@ -1,0 +1,22 @@
+# configure vscode yaml support https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
+# yaml-language-server: $schema=https://fasterci.com/config.schema.json
+workflows:
+  - name: faster CI
+    image: us.gcr.io/fasterci/bazelbuilder:d278ee1
+    on:
+      push:
+        branches:
+          - stable
+      pull_request:
+        branches:
+          - "**"
+    steps:
+      - name: bazel test
+        bazel:
+          build_targets:
+            - "//..."
+          test_flags: 
+            - "--test_tag_filters=-e2e,-examples"
+          test_targets: 
+            - //... 
+    cleanup: git clean -ffdx


### PR DESCRIPTION
This reverts commit 66f2849bf38ebfc6dd6df95bf5d9cb18b87a3364. I need to find someone at Google to fix the settings, as the absence of this file just guarantees that EVERY PR is red.

In the meantime, FasterCI was at least green some of the time.
