### PR TITLE
Update yarn version check

### DIFF
--- a/internal/npm_install/npm_install.bzl
+++ b/internal/npm_install/npm_install.bzl
@@ -836,7 +836,10 @@ check if yarn is being run by the `npm_install` repository rule.""",
 )
 
 def _detect_yarn_version(rctx, yarn):
-    result = rctx.execute(yarn + ["--version"])
+    result = rctx.execute(
+        yarn + ["--version"],
+        working_directory = str(rctx.path(rctx.attr.package_json).dirname),
+    )
     if result.return_code:
         fail("yarn --version failed: %s (%s)" % (result.stdout, result.stderr))
     if result.stdout.startswith("1."):


### PR DESCRIPTION
Ensure version check is run inside the project workspace, i.e. the directory with package.json

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
a project with multiple sub projects, but no root package.json/yarn.lock/.yarnrc.yml that uses yarn berry will fail to detect project using yarn berry. E.G.

```
WORKSPACE
proj1/
  package.json
  yarn.lock
  BUILD
proj2/
  .yarn/...
  package.json
  yarn.lock
  .yarnrc.yml
  BUILD
```

WORKSPACE having the following:
```
yarn_install(
    name = "proj1_npm",
    package_json = "@//proj1:package.json",
    yarn_lock = "@//proj1:yarn.lock",
)

yarn_install(
    name = "proj2_npm",
    package_json = "@//proj2:package.json",
    yarn_lock = "@//proj2:yarn.lock",
    data = [
        "@//proj2:.yarnrc.yml",
        "@//proj2:.yarn/releases/yarn-3.2.4.cjs",
    ]
)
```

Will detect yarn1 for proj2 and fail trying to use yarn1 command line options
Issue Number: N/A


## What is the new behavior?
Both proj1 and proj2 will use the correct version of yarn for that project

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

