### PR TITLE
chore: default node should be latest v16

### DIFF
--- a/docs/Core.md
+++ b/docs/Core.md
@@ -158,7 +158,7 @@ Defaults to `["https://nodejs.org/dist/v{version}/{filename}"]`
 
 (*String*): the specific version of NodeJS to install
 
-Defaults to `"16.15.0"`
+Defaults to `"16.18.1"`
 
 <h4 id="node_repositories-platform">platform</h4>
 

--- a/nodejs/repositories.bzl
+++ b/nodejs/repositories.bzl
@@ -8,7 +8,16 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-DEFAULT_NODE_VERSION = "16.15.0"
+# Currently v16 is the default.
+# We can only change that in a major release of rules_nodejs,
+# as it's a semver-breaking change for our users who rely on it.
+# We use the most recent v16 release.
+DEFAULT_NODE_VERSION = [
+    # 16.18.1-windows_amd64 -> 16.18.1
+    v.split("-")[0]
+    for v in NODE_VERSIONS.keys()
+    if v.startswith("16.")
+][-1]  # Versions are sorted increasing, so last one is the latest version
 
 BUILT_IN_NODE_PLATFORMS = PLATFORMS.keys()
 


### PR DESCRIPTION
Fixes #3573

Tested with:

```
% cd e2e/typescript; bazel run --override_repository=rules_nodejs=/Users/alexeagle/Projects/rules_nodejs @nodejs_host//:bin/node -- --version
INFO: Invocation ID: a7e4a810-2c7c-4e9c-aa6d-1351c3c59b7e

v16.18.1
```