### PR TITLE
Upgrade rules_pkg to 0.3.0 to remove Python 2 dependency.

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -117,10 +117,10 @@ def build_bazel_rules_nodejs_dev_dependencies():
         http_archive,
         name = "rules_pkg",
         urls = [
-            "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.6-1/rules_pkg-0.2.6.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.2.6/rules_pkg-0.2.6.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz",
+            "https://github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz",
         ],
-        sha256 = "aeca78988341a2ee1ba097641056d168320ecc51372ef7ff8e64b139516a4937",
+        sha256 = "6b5969a7acd7b60c02f816773b06fcf32fbe8ba0c7919ccdc2df4f8fb923804a",
     )
 
     maybe(


### PR DESCRIPTION
Earlier versions have `build_tar` using `python_version=PY2`, which newer
versions of Bazel will no longer support.

Fixes #3619

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 3619

## What is the new behavior?

rules_pkg version 3.0 is used, which doesn't use a Python 2 binary.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
