### PR TITLE
chore: update bcr metadata

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,6 +1,12 @@
 {
     "homepage": "https://github.com/bazelbuild/rules_nodejs",
-    "maintainers": [],
+    "maintainers": [
+        {
+            "email": "hello@aspect.dev",
+            "github": "aspect-build",
+            "name": "Aspect team"
+        }
+    ],
     "repository": ["github:bazelbuild/rules_nodejs"],
     "versions": [],
     "yanked_versions": {}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -8,3 +8,5 @@ bcr_test_module:
       platform: ${{ platform }}
       test_targets:
         - '//...'
+      test_flags:
+        - '--test_tag_filters=-no-bazelci-windows'


### PR DESCRIPTION
I needed to skip a couple diff_tests on Windows to land https://github.com/bazelbuild/bazel-central-registry/pull/566 so that patch needs to come back upstream for the next release.

Also fill in missing maintainers so it looks better on registry.bazel.build


