### PR TITLE
fix(windows): unbreak CI with allow_empty

### DIFF
--- a/nodejs/repositories.bzl
+++ b/nodejs/repositories.bzl
@@ -341,7 +341,17 @@ filegroup(
 )
 cc_library(
   name = "headers",
-  hdrs = glob(["bin/nodejs/include/node/**"]),
+  hdrs = glob(
+    ["bin/nodejs/include/node/**"],
+    # Apparently, node.js doesn't ship the headers in their Windows package.
+    # https://stackoverflow.com/questions/50745670/nodejs-headers-on-windows-are-not-installed-automatically
+    # I see the same thing from downloading
+    # https://nodejs.org/dist/v18.17.1/node-v18.17.1-win-x64.zip
+    # and run
+    # unzip -t ~/Downloads/node-v18.17.1-win-x64.zip  | grep uv\\.h
+    # -> no results ...
+    allow_empty = True,
+  ),
   includes = ["bin/nodejs/include/node"],
 )
 """.format(


### PR DESCRIPTION
We had an in-flight collision between two PRs. #3679 added a cc_library, but Node.js doesn't ship the required headers on Windows, so it wouldn't work there. #3621 disallows empty glob, which breaks because of the missing headers. Just add the allow_empty here to make it green.


