### PR TITLE
fix(jasmine): update jasmine core version check to support versions older then 4

### DIFF
--- a/packages/jasmine/jasmine_runner.js
+++ b/packages/jasmine/jasmine_runner.js
@@ -147,7 +147,7 @@ async function main(args) {
   // TODO(6.0): remove support for deprecated versions of Jasmine that use the old API &
   // remember to update the `peerDependencies` as well.
   // Jasmine versions prior to 4.0.0 should use the old API.
-  if (jrunner.coreVersion().charAt(0) !== '4') {
+  if (+jrunner.coreVersion().charAt(0) < 4) {
     console.warn(`DEPRECATED: Support for Jasmine versions prior to '4.0.x' is deprecated in '@bazel/jasmine'.`);
 
     // Old Jasmine API.


### PR DESCRIPTION


Currently, with jasmine core version 5 the old API is being used which causes errors.
