### PR TITLE
Add current_node_cc_headers

### DIFF
--- a/docs/Core.md
+++ b/docs/Core.md
@@ -142,7 +142,7 @@ Defaults to `None`
 **USAGE**
 
 <pre>
-node_toolchain(<a href="#node_toolchain-name">name</a>, <a href="#node_toolchain-npm">npm</a>, <a href="#node_toolchain-npm_files">npm_files</a>, <a href="#node_toolchain-npm_path">npm_path</a>, <a href="#node_toolchain-run_npm">run_npm</a>, <a href="#node_toolchain-target_tool">target_tool</a>, <a href="#node_toolchain-target_tool_path">target_tool_path</a>)
+node_toolchain(<a href="#node_toolchain-name">name</a>, <a href="#node_toolchain-headers">headers</a>, <a href="#node_toolchain-npm">npm</a>, <a href="#node_toolchain-npm_files">npm_files</a>, <a href="#node_toolchain-npm_path">npm_path</a>, <a href="#node_toolchain-run_npm">run_npm</a>, <a href="#node_toolchain-target_tool">target_tool</a>, <a href="#node_toolchain-target_tool_path">target_tool_path</a>)
 </pre>
 
 Defines a node toolchain for a platform.
@@ -192,6 +192,12 @@ You can use the `--toolchain_resolution_debug` flag to `bazel` to help diagnose 
 
 (*<a href="https://bazel.build/docs/build-ref.html#name">Name</a>, mandatory*): A unique name for this target.
 
+
+<h4 id="node_toolchain-headers">headers</h4>
+
+(*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>*): A cc_library that contains the Node/v8 header files for this target platform.
+
+Defaults to `None`
 
 <h4 id="node_toolchain-npm">npm</h4>
 

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -276,3 +276,18 @@ diff_test(
     file1 = "write_node_version_16",
     file2 = "thing_toolchain_16",
 )
+
+cc_binary(
+    name = "using_headers_test",
+    srcs = ["using_headers.cc"],
+    copts = select({
+        "@platforms//os:windows": ["/std:c++14"],
+        "//conditions:default": ["-std=c++14"],
+    }),
+    target_compatible_with = select({
+        # Windows does not ship headers in the release artifact so this won't work yet.
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = ["@rules_nodejs//nodejs:current_node_cc_headers"],
+)

--- a/e2e/smoke/using_headers.cc
+++ b/e2e/smoke/using_headers.cc
@@ -1,0 +1,3 @@
+#include "node.h"
+
+int main() { return 0; }

--- a/nodejs/BUILD.bazel
+++ b/nodejs/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//nodejs/private:toolchains_repo.bzl", "PLATFORMS")
 load("//nodejs/private:user_build_settings.bzl", "user_args")
+load("//nodejs/private:current_node_cc_headers.bzl", "current_node_cc_headers")
 
 exports_files([
     "index.for_docs.bzl",
@@ -41,5 +42,13 @@ toolchain_type(
 user_args(
     name = "default_args",
     build_setting_default = "--preserve-symlinks",
+    visibility = ["//visibility:public"],
+)
+
+# This target provides the C headers for whatever the current toolchain is
+# for the consuming rule. It basically acts like a cc_library by forwarding
+# on the providers for the underlying cc_library that the toolchain is using.
+current_node_cc_headers(
+    name = "current_node_cc_headers",
     visibility = ["//visibility:public"],
 )

--- a/nodejs/private/current_node_cc_headers.bzl
+++ b/nodejs/private/current_node_cc_headers.bzl
@@ -1,0 +1,50 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of current_node_cc_headers rule."""
+
+def _current_node_cc_headers_impl(ctx):
+    return ctx.toolchains["//nodejs:toolchain_type"].nodeinfo.headers.providers_map.values()
+
+current_node_cc_headers = rule(
+    implementation = _current_node_cc_headers_impl,
+    toolchains = ["//nodejs:toolchain_type"],
+    provides = [CcInfo],
+    doc = """\
+Provides the currently active Node toolchain's C++ headers.
+
+This is a wrapper around the underlying `cc_library()` for the
+C headers for the consuming target's currently active Node toolchain.
+
+Note, "node.h" is only usable from C++, and you'll need to
+ensure you are compiling with c++14 or later.
+
+Also, on Windows, NodeJS releases do not ship headers, so this rule is currently
+not usable with the built-in toolchains. If you define your own toolchain on Windows,
+you can include the headers and then this rule will work.
+
+To use, simply depend on this target where you would have wanted the
+toolchain's underlying `:headers` target:
+
+```starlark
+cc_library(
+    name = "foo",
+    srcs = ["foo.cc"],
+    # If toolchain sets this already, you can omit.
+    copts = ["-std=c++14"],
+    deps = ["@rules_nodejs//:current_node_cc_headers"]
+)
+```
+""",
+)

--- a/nodejs/repositories.bzl
+++ b/nodejs/repositories.bzl
@@ -376,6 +376,7 @@ node_toolchain(
     npm = ":npm",
     npm_files = [":npm_files"],
     run_npm = ":run_npm.template",
+    headers = ":headers",
 )
 """
     repository_ctx.file("BUILD.bazel", content = build_content)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently the headers are exposed but they need to be accessed from toolchain-specific repos like `@node_darwin_amd64//:headers`. This is a bit annoying, and I believe these repos are not visible in the main workspace in bzlmod. Copy the rules_python approach to make this more ergonomic.

Issue Number: N/A


## What is the new behavior?

You can depend on `@rules_nodejs//nodejs:current_node_cc_headers`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

(Unless someone was creating their own toolchains, in which case they will need to pass the extra label)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

