### PR TITLE
Disable Bzlmod explicitly in .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -42,3 +42,7 @@ build --incompatible_disallow_empty_glob
 
 # Allow exclusive tests to run in a sandbox
 test --incompatible_exclusive_test_sandboxed
+
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://github.com/bazelbuild/stardoc/issues/189
+common --noenable_bzlmod


### PR DESCRIPTION
This will help make sure [Bazel Downstream Pipeline](https://github.com/bazelbuild/continuous-integration/blob/master/docs/downstream-testing.md) is green after enabling Bzlmod at Bazel@HEAD

See https://github.com/bazelbuild/bazel/issues/18958#issuecomment-1749058780

Related https://github.com/bazelbuild/rules_nodejs/issues/3695