### PR TITLE
Use `headers` attribute for toolchains only if it is set

### DIFF
--- a/nodejs/toolchain.bzl
+++ b/nodejs/toolchain.bzl
@@ -102,7 +102,7 @@ def _node_toolchain_impl(ctx):
                 "CcInfo": ctx.attr.headers[CcInfo],
                 "DefaultInfo": ctx.attr.headers[DefaultInfo],
             },
-        ),
+        ) if ctx.attr.headers else None,
     )
 
     # Export all the providers inside our ToolchainInfo


### PR DESCRIPTION
This effectively establishes backward compatibility with users of previous
rules_nodejs that create custom toolchains and do not pass the `headers`
attribute to `node_toolchain` which would otherwise fail with:

```
ERROR: /.../external/rules_haskell_nix_node_toolchain/BUILD:4:15: in node_toolchain rule @rules_haskell_nix_node_toolchain//:node_nixpkgs:
Traceback (most recent call last):
  File "/.../external/rules_nodejs/nodejs/toolchain.bzl", line 102, column 43, in _node_toolchain_impl
     "CcInfo": ctx.attr.headers[CcInfo],
Error: type \'NoneType\' has no operator [](Provider)
```

See comments in https://github.com/bazelbuild/rules_nodejs/pull/3694 

cc @DavidZbarsky-at

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: backward-compatibility enhancement


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No (quite contrary actually ;-))


## Other information

