### PR TITLE
Work properly on intel CPUs on macos. Normalize x86_64->amd64 naming in `osname()` method

### DIFF
--- a/nodejs/private/os_name.bzl
+++ b/nodejs/private/os_name.bzl
@@ -43,6 +43,9 @@ def os_name(rctx):
     arch = rctx.os.arch
     if arch == "aarch64":
         arch = "arm64"
+
+    # Java os macos is reporting x86_64.
+    # See: https://mail.openjdk.org/pipermail/macosx-port-dev/2012-February/002860.html .
     if arch == "x86_64":
         arch = "amd64"
 

--- a/nodejs/private/os_name.bzl
+++ b/nodejs/private/os_name.bzl
@@ -43,6 +43,8 @@ def os_name(rctx):
     arch = rctx.os.arch
     if arch == "aarch64":
         arch = "arm64"
+    if arch == "x86_64":
+        arch = "amd64"
 
     os_name = rctx.os.name
     if os_name.startswith("mac os"):


### PR DESCRIPTION
Work properly on intel CPUs on ox. Normalize x86_64->amd64 naming in `osname()` method

In particular on x86 macbooks, the rctx.os.arch returns x86_64 (and not 'amd64') as expected by the nodejs namings. This behaviour (and difference vs. linux) is documented here: https://mail.openjdk.org/pipermail/macosx-port-dev/2012-February/002860.html

This led to errors like:

```
... depends on @nodejs-macos-x86_64//:node_toolchain in repository @nodejs-macos-x86_64 which failed to fetch. no such package '@nodejs-macos-x86_64//': Unsupported operating system darwin architecture x86_64
```

The reason was the node_repositories role tries to check whether there is node for the host system on the list.

The problem was most likely introduced in #3698. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

