### PR TITLE
chore: disable RBE on CI to work-around cc toolchain failures at HEAD

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -62,11 +62,12 @@ tasks:
     - "--test_tag_filters=-fix-windows,-no-bazelci-windows"
     test_targets:
     - "//..."
-  rbe_ubuntu1604-smoke:
-    name: rbe_ubuntu1604-smoke
-    platform: rbe_ubuntu1604
-    working_directory: "e2e/smoke"
-    build_targets:
-    - "//..."
-    test_targets:
-    - "//..."
+  # Temporarily disabled RBE CI until cc toolchain failures are resolved
+  # rbe_ubuntu1604-smoke:
+  #   name: rbe_ubuntu1604-smoke
+  #   platform: rbe_ubuntu1604
+  #   working_directory: "e2e/smoke"
+  #   build_targets:
+  #   - "//..."
+  #   test_targets:
+  #   - "//..."

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,11 @@ bazel-out
 node_modules
 yarn-error.log
 .DS_Store
+
+# Disable lockfile for now. It is unstable.
+# https://github.com/bazelbuild/bazel/issues/19026
+# https://github.com/bazelbuild/bazel/issues/19621
+# https://github.com/bazelbuild/bazel/issues/19971
+# https://github.com/bazelbuild/bazel/issues/20272
+# https://github.com/bazelbuild/bazel/issues/20369
+MODULE.bazel.lock


### PR DESCRIPTION
Seeing cc toolchain failures at HEAD that is blocking landing of PRs.

For example,

https://buildkite.com/bazel/rules-nodejs-nodejs/builds/13269#018e9046-54b9-4c20-9202-8e4dbbeae905
https://buildkite.com/bazel/rules-nodejs-nodejs/builds/13267
