### PR TITLE
chore: support local development on MacOS ARM

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,8 +40,8 @@ nodejs_register_toolchains(
 )
 
 nodejs_register_toolchains(
-    name = "node15",
-    node_version = "15.14.0",
+    name = "node17",
+    node_version = "17.9.1",
 )
 
 http_archive(

--- a/e2e/nodejs_host/BUILD.bazel
+++ b/e2e/nodejs_host/BUILD.bazel
@@ -30,7 +30,7 @@ sh_test(
         ],
     )
     for id in [
-        "node14",
+        "node16",
         "node16_nvmrc",
     ]
 ]
@@ -61,8 +61,8 @@ sh_test(
         ],
     )
     for (id, bin) in [
-        # Node 14 doesn't include the node version in npx --help --verbose so we only test npm
-        ("node14", "npm"),
+        ("node16", "npm"),
+        ("node16", "npx"),
         ("node16_nvmrc", "npm"),
         ("node16_nvmrc", "npx"),
     ]

--- a/e2e/nodejs_host/MODULE.bazel
+++ b/e2e/nodejs_host/MODULE.bazel
@@ -21,8 +21,8 @@ node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 # https://github.com/bazelbuild/rules_nodejs/blob/5.8.0/nodejs/repositories.bzl#L11
 node.toolchain()
 node.toolchain(
-    name = "node14",
-    node_version = "14.19.0",
+    name = "node16",
+    node_version = "16.20.2",
 )
 node.toolchain(
     name = "node16_nvmrc",
@@ -32,12 +32,12 @@ node.toolchain(
 # FIXME(6.0): a repo rule with name=foo should create a repo named @foo, not @foo_toolchains
 use_repo(
     node,
+    "node16_darwin_amd64",
+    "node16_linux_amd64",
+    "node16_toolchains",
+    "node16_windows_amd64",
     "node16_nvmrc_darwin_amd64",
     "node16_nvmrc_linux_amd64",
     "node16_nvmrc_toolchains",
     "node16_nvmrc_windows_amd64",
-    "node14_darwin_amd64",
-    "node14_linux_amd64",
-    "node14_toolchains",
-    "node14_windows_amd64",
 )

--- a/e2e/nodejs_host/WORKSPACE
+++ b/e2e/nodejs_host/WORKSPACE
@@ -23,8 +23,8 @@ nodejs_register_toolchains()
 
 # Create additional parallel toolchains using explicit nodejs_register_toolchains targets
 nodejs_register_toolchains(
-    name = "node14",
-    node_version = "14.19.0",
+    name = "node16",
+    node_version = "16.20.2",
 )
 
 nodejs_register_toolchains(

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -209,9 +209,9 @@ write_file(
 # Files used in test cases later that contain the correct nodejs version
 # that is imported into the workspace.
 write_file(
-    name = "write_node_version_15",
-    out = "expected_node_15",
-    content = ["v15.14.0"],
+    name = "write_node_version_17",
+    out = "expected_node_17",
+    content = ["v17.9.1"],
 )
 
 write_file(
@@ -237,23 +237,23 @@ diff_test(
 # Output contains the version number of node that is used.
 # This is used in tests later to verify the toolchain specified is resolved correctly
 my_nodejs(
-    name = "run_15",
-    out = "thing_toolchain_15",
+    name = "run_17",
+    out = "thing_toolchain_17",
     entry_point = "version.js",
     # using the select statement will download toolchains for all three platforms
     # you can also just provide an individual toolchain if you don't want to download them all
     toolchain = select({
-        "@bazel_tools//src/conditions:linux_x86_64": "@node15_linux_amd64//:node_toolchain",
-        "@bazel_tools//src/conditions:darwin": "@node15_darwin_amd64//:node_toolchain",
-        "@bazel_tools//src/conditions:windows": "@node15_windows_amd64//:node_toolchain",
+        "@bazel_tools//src/conditions:linux_x86_64": "@node17_linux_amd64//:node_toolchain",
+        "@bazel_tools//src/conditions:darwin": "@node17_darwin_amd64//:node_toolchain",
+        "@bazel_tools//src/conditions:windows": "@node17_windows_amd64//:node_toolchain",
     }),
 )
 
 # Section of test the verify the toolchain work as expected matching node version used with expected
 diff_test(
-    name = "test_node_version_15",
-    file1 = "write_node_version_15",
-    file2 = "thing_toolchain_15",
+    name = "test_node_version_17",
+    file1 = "write_node_version_17",
+    file2 = "thing_toolchain_17",
 )
 
 my_nodejs(

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -20,16 +20,16 @@ node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 
 node.toolchain(node_version = "16.5.0")
 node.toolchain(
-    name = "node15",
-    node_version = "15.14.0",
+    name = "node17",
+    node_version = "17.9.1",
 )
 
 # FIXME(6.0): a repo rule with name=foo should create a repo named @foo, not @foo_toolchains
 use_repo(
     node,
-    "node15_darwin_amd64",
-    "node15_linux_amd64",
-    "node15_windows_amd64",
+    "node17_darwin_amd64",
+    "node17_linux_amd64",
+    "node17_windows_amd64",
     "nodejs_darwin_amd64",
     "nodejs_linux_amd64",
     "nodejs_toolchains",

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -22,14 +22,11 @@ load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
 
 # The order matters because Bazel will provide the first registered toolchain when a rule asks Bazel to select it
 # This applies to the resolved_toolchain
-nodejs_register_toolchains(
-    name = "node16",
-    node_version = "16.5.0",
-)
+nodejs_register_toolchains(node_version = "16.5.0")
 
 nodejs_register_toolchains(
-    name = "node15",
-    node_version = "15.14.0",
+    name = "node17",
+    node_version = "17.9.1",
 )
 
 http_archive(


### PR DESCRIPTION
Node 16 was the first node version that had MacOS arm support so bump usage of Node 14 & 15 to 17 in this PR. We can't go to 18 because Bazel CI runners have an older version of GLIBC that doesn't work with 18.
