### PR TITLE
feat: update node toolchain to provide File objects

### DIFF
--- a/docs/Core.md
+++ b/docs/Core.md
@@ -12,99 +12,6 @@ Features:
 - Core [Providers](https://docs.bazel.build/versions/main/skylark/rules.html#providers) to allow interop between JS rules.
 
 
-## node_toolchain
-
-**USAGE**
-
-<pre>
-node_toolchain(<a href="#node_toolchain-name">name</a>, <a href="#node_toolchain-headers">headers</a>, <a href="#node_toolchain-npm">npm</a>, <a href="#node_toolchain-npm_files">npm_files</a>, <a href="#node_toolchain-npm_path">npm_path</a>, <a href="#node_toolchain-target_tool">target_tool</a>, <a href="#node_toolchain-target_tool_path">target_tool_path</a>)
-</pre>
-
-Defines a node toolchain for a platform.
-
-You can use this to refer to a vendored nodejs binary in your repository,
-or even to compile nodejs from sources using rules_foreign_cc or other rules.
-
-First, in a BUILD.bazel file, create a node_toolchain definition:
-
-```starlark
-load("@rules_nodejs//nodejs:toolchain.bzl", "node_toolchain")
-
-node_toolchain(
-    name = "node_toolchain",
-    target_tool = "//some/path/bin/node",
-)
-```
-
-Next, declare which execution platforms or target platforms the toolchain should be selected for
-based on constraints.
-
-```starlark
-toolchain(
-    name = "my_nodejs",
-    exec_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-    ],
-    toolchain = ":node_toolchain",
-    toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
-)
-```
-
-See https://bazel.build/extending/toolchains#toolchain-resolution for more information on toolchain
-resolution.
-
-Finally in your `WORKSPACE`, register it with `register_toolchains("//:my_nodejs")`
-
-For usage see https://docs.bazel.build/versions/main/toolchains.html#defining-toolchains.
-You can use the `--toolchain_resolution_debug` flag to `bazel` to help diagnose which toolchain is selected.
-
-
-**ATTRIBUTES**
-
-
-<h4 id="node_toolchain-name">name</h4>
-
-(*<a href="https://bazel.build/docs/build-ref.html#name">Name</a>, mandatory*): A unique name for this target.
-
-
-<h4 id="node_toolchain-headers">headers</h4>
-
-(*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>*): A cc_library that contains the Node/v8 header files for this target platform.
-
-Defaults to `None`
-
-<h4 id="node_toolchain-npm">npm</h4>
-
-(*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>*): A hermetically downloaded npm executable target for this target's platform.
-
-Defaults to `None`
-
-<h4 id="node_toolchain-npm_files">npm_files</h4>
-
-(*<a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a>*): Files required in runfiles to run npm.
-
-Defaults to `[]`
-
-<h4 id="node_toolchain-npm_path">npm_path</h4>
-
-(*String*): Path to an existing npm executable for this target's platform.
-
-Defaults to `""`
-
-<h4 id="node_toolchain-target_tool">target_tool</h4>
-
-(*<a href="https://bazel.build/docs/build-ref.html#labels">Label</a>*): A hermetically downloaded nodejs executable target for this target's platform.
-
-Defaults to `None`
-
-<h4 id="node_toolchain-target_tool_path">target_tool_path</h4>
-
-(*String*): Path to an existing nodejs executable for this target's platform.
-
-Defaults to `""`
-
-
 ## UserBuildSettingInfo
 
 **USAGE**
@@ -238,6 +145,116 @@ If set then the version found in the .nvmrc file is used instead of the one spec
 Defaults to `None`
 
 <h4 id="node_repositories-kwargs">kwargs</h4>
+
+Additional parameters
+
+
+
+
+## node_toolchain
+
+**USAGE**
+
+<pre>
+node_toolchain(<a href="#node_toolchain-name">name</a>, <a href="#node_toolchain-node">node</a>, <a href="#node_toolchain-node_path">node_path</a>, <a href="#node_toolchain-npm">npm</a>, <a href="#node_toolchain-npm_path">npm_path</a>, <a href="#node_toolchain-npm_files">npm_files</a>, <a href="#node_toolchain-headers">headers</a>, <a href="#node_toolchain-kwargs">kwargs</a>)
+</pre>
+
+Defines a node toolchain for a platform.
+
+You can use this to refer to a vendored nodejs binary in your repository,
+or even to compile nodejs from sources using rules_foreign_cc or other rules.
+
+First, in a BUILD.bazel file, create a node_toolchain definition:
+
+```starlark
+load("@rules_nodejs//nodejs:toolchain.bzl", "node_toolchain")
+
+node_toolchain(
+    name = "node_toolchain",
+    node = "//some/path/bin/node",
+)
+```
+
+Next, declare which execution platforms or target platforms the toolchain should be selected for
+based on constraints.
+
+```starlark
+toolchain(
+    name = "my_nodejs",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = ":node_toolchain",
+    toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
+)
+```
+
+See https://bazel.build/extending/toolchains#toolchain-resolution for more information on toolchain
+resolution.
+
+Finally in your `WORKSPACE`, register it with `register_toolchains("//:my_nodejs")`
+
+For usage see https://docs.bazel.build/versions/main/toolchains.html#defining-toolchains.
+You can use the `--toolchain_resolution_debug` flag to `bazel` to help diagnose which toolchain is selected.
+
+
+**PARAMETERS**
+
+
+<h4 id="node_toolchain-name">name</h4>
+
+Unique name for this target
+
+
+
+<h4 id="node_toolchain-node">node</h4>
+
+Node.js executable
+
+Defaults to `None`
+
+<h4 id="node_toolchain-node_path">node_path</h4>
+
+Path to Node.js executable file
+
+This is typically an absolute path to a non-hermetic Node.js executable.
+
+Only one of `node` and `node_path` may be set.
+
+Defaults to `""`
+
+<h4 id="node_toolchain-npm">npm</h4>
+
+Npm JavaScript entry point
+
+Defaults to `None`
+
+<h4 id="node_toolchain-npm_path">npm_path</h4>
+
+Path to npm JavaScript entry point
+
+This is typically an absolute path to a non-hermetic npm installation.
+
+Only one of `npm` and `npm_path` may be set.
+
+Defaults to `""`
+
+<h4 id="node_toolchain-npm_files">npm_files</h4>
+
+Additional files required to run npm
+
+Not necessary if specifying `npm_path` to a non-hermetic npm installation.
+
+Defaults to `[]`
+
+<h4 id="node_toolchain-headers">headers</h4>
+
+cc_library that contains the Node/v8 header files
+
+Defaults to `None`
+
+<h4 id="node_toolchain-kwargs">kwargs</h4>
 
 Additional parameters
 

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -47,7 +47,7 @@ build_test(
     targets = [
         ":call_acorn",
         ":require_acorn",
-        ":use_node_toolchain",
+        ":use_nodejs_toolchain",
     ],
 )
 
@@ -55,7 +55,7 @@ build_test(
 # This gives you complete control over starting the interpreter, but you also have to
 # manually handle module resolution.
 genrule(
-    name = "use_node_toolchain",
+    name = "use_nodejs_toolchain",
     srcs = ["some.js"],
     outs = ["actual1"],
     cmd = "$(NODE_PATH) $(execpath some.js) $@",

--- a/nodejs/index.for_docs.bzl
+++ b/nodejs/index.for_docs.bzl
@@ -11,8 +11,8 @@ load(
     _UserBuildSettingInfo = "UserBuildSettingInfo",
 )
 load(":repositories.bzl", _node_repositories = "node_repositories")
-load(":toolchain.bzl", _node_toolchain = "node_toolchain")
+load(":toolchain.bzl", _nodejs_toolchain = "node_toolchain")
 
 UserBuildSettingInfo = _UserBuildSettingInfo
 node_repositories = _node_repositories
-node_toolchain = _node_toolchain
+node_toolchain = _nodejs_toolchain

--- a/nodejs/repositories.bzl
+++ b/nodejs/repositories.bzl
@@ -275,7 +275,7 @@ cc_library(
 load("@rules_nodejs//nodejs:toolchain.bzl", "node_toolchain")
 node_toolchain(
     name = "node_toolchain",
-    target_tool = ":node_bin",
+    node = ":node_bin",
     npm = ":npm",
     npm_files = [":npm_files"],
     headers = ":headers",

--- a/nodejs/toolchain.bzl
+++ b/nodejs/toolchain.bzl
@@ -16,16 +16,23 @@
 """
 
 NodeInfo = provider(
-    doc = "Information about how to invoke the node executable.",
+    doc = "Information about how to invoke Node.js and npm.",
     fields = {
-        "target_tool_path": "Path to the nodejs executable for this target's platform.",
-        "tool_files": """Files required in runfiles to make the nodejs executable available.
+        "node": """Node.js executable
 
-May be empty if the target_tool_path points to a locally installed node binary.""",
-        "npm_path": "Path to the npm executable for this target's platform.",
-        "npm_files": """Files required in runfiles to make the npm executable available.
+If set, node_path will not be set.""",
+        "node_path": """Path to Node.js executable; typically an absolute path to a non-hermetic Node.js.
 
-May be empty if the npm_path points to a locally installed npm binary.""",
+If set, node will not be set.""",
+        "npm": """Npm JavaScript entry point File
+
+For backward compability, if set then npm_path will be set to the runfiles path of npm.
+""",
+        "npm_path": """Path to npm JavaScript entry point; typically an absolute path to a non-hermetic Node.js.
+
+For backward compability, npm_path is set to the runfiles path of npm if npm is set.
+""",
+        "npm_files": """Additional files required to run npm""",
         "headers": """\
 (struct) Information about the header files, with fields:
   * providers_map: a dict of string to provider instances. The key should be
@@ -47,6 +54,9 @@ May be empty if the npm_path points to a locally installed npm binary.""",
     e.g. `:current_node_cc_headers` to act as the underlying headers target it
     represents).
 """,
+        # DEPRECATED
+        "target_tool_path": "(DEPRECATED) Path to Node.js executable for backward compatibility",
+        "tool_files": """(DEPRECATED) Alias for [node] for backward compatibility""",
     },
 )
 
@@ -57,49 +67,39 @@ def _to_manifest_path(ctx, file):
     else:
         return ctx.workspace_name + "/" + file.short_path
 
-def _node_toolchain_impl(ctx):
-    if ctx.attr.target_tool and ctx.attr.target_tool_path:
-        fail("Can only set one of target_tool or target_tool_path but both were set.")
-    if not ctx.attr.target_tool and not ctx.attr.target_tool_path:
-        fail("Must set one of target_tool or target_tool_path.")
+def _nodejs_toolchain_impl(ctx):
+    if ctx.attr.node and ctx.attr.node_path:
+        fail("Can only set one of node or node_path but both were set.")
+    if not ctx.attr.node and not ctx.attr.node_path:
+        fail("Must set one of node or node_path.")
     if ctx.attr.npm and ctx.attr.npm_path:
         fail("Can only set one of npm or npm_path but both were set.")
-
-    tool_files = []
-    target_tool_path = ctx.attr.target_tool_path
-
-    if ctx.attr.target_tool:
-        tool_files = [ctx.file.target_tool]
-        target_tool_path = _to_manifest_path(ctx, ctx.file.target_tool)
-
-    npm_files = []
-    npm_path = ctx.attr.npm_path
-
-    if ctx.attr.npm:
-        npm_files = depset([ctx.file.npm] + ctx.files.npm_files).to_list()
-        npm_path = _to_manifest_path(ctx, ctx.file.npm)
 
     # Make the $(NODE_PATH) variable available in places like genrules.
     # See https://docs.bazel.build/versions/main/be/make-variables.html#custom_variables
     template_variables = platform_common.TemplateVariableInfo({
-        "NODE_PATH": target_tool_path,
-        "NPM_PATH": npm_path,
+        "NODE_PATH": ctx.file.node.path if ctx.attr.node else ctx.attr.node_path,
+        "NPM_PATH": ctx.file.npm.path if ctx.attr.npm else ctx.attr.npm_path,
     })
     default = DefaultInfo(
-        files = depset(tool_files),
-        runfiles = ctx.runfiles(files = tool_files),
+        files = depset([ctx.file.node]) if ctx.attr.node else depset(),
+        runfiles = ctx.runfiles(files = [ctx.file.node] if ctx.attr.node else []),
     )
     nodeinfo = NodeInfo(
-        target_tool_path = target_tool_path,
-        tool_files = tool_files,
-        npm_path = npm_path,
-        npm_files = npm_files,
+        node = ctx.file.node,
+        node_path = ctx.attr.node_path,
+        npm = ctx.file.npm,
+        npm_path = ctx.attr.npm_path if ctx.attr.npm_path else _to_manifest_path(ctx, ctx.file.npm),  # _to_manifest_path for backward compat
+        npm_files = depset([ctx.file.npm] + ctx.files.npm_files).to_list() if ctx.attr.npm else [],
         headers = struct(
             providers_map = {
                 "CcInfo": ctx.attr.headers[CcInfo],
                 "DefaultInfo": ctx.attr.headers[DefaultInfo],
             },
         ) if ctx.attr.headers else None,
+        # For backward compat
+        target_tool_path = _to_manifest_path(ctx, ctx.file.node) if ctx.attr.node else ctx.attr.node_path,
+        tool_files = [ctx.file.node] if ctx.attr.node else [],
     )
 
     # Export all the providers inside our ToolchainInfo
@@ -115,72 +115,122 @@ def _node_toolchain_impl(ctx):
         template_variables,
     ]
 
-node_toolchain = rule(
-    implementation = _node_toolchain_impl,
+_nodejs_toolchain = rule(
+    implementation = _nodejs_toolchain_impl,
     attrs = {
-        "target_tool": attr.label(
-            doc = "A hermetically downloaded nodejs executable target for this target's platform.",
-            mandatory = False,
+        "node": attr.label(
+            executable = True,
+            cfg = "exec",
             allow_single_file = True,
         ),
-        "target_tool_path": attr.string(
-            doc = "Path to an existing nodejs executable for this target's platform.",
-            mandatory = False,
-        ),
-        "npm": attr.label(
-            doc = "A hermetically downloaded npm executable target for this target's platform.",
-            mandatory = False,
-            allow_single_file = True,
-        ),
-        "npm_path": attr.string(
-            doc = "Path to an existing npm executable for this target's platform.",
-            mandatory = False,
-        ),
-        "npm_files": attr.label_list(
-            doc = "Files required in runfiles to run npm.",
-            mandatory = False,
-        ),
-        "headers": attr.label(
-            doc = "A cc_library that contains the Node/v8 header files for this target platform.",
-        ),
+        "node_path": attr.string(),
+        "npm": attr.label(allow_single_file = True),
+        "npm_path": attr.string(),
+        "npm_files": attr.label_list(),
+        "headers": attr.label(),
     },
-    doc = """Defines a node toolchain for a platform.
-
-You can use this to refer to a vendored nodejs binary in your repository,
-or even to compile nodejs from sources using rules_foreign_cc or other rules.
-
-First, in a BUILD.bazel file, create a node_toolchain definition:
-
-```starlark
-load("@rules_nodejs//nodejs:toolchain.bzl", "node_toolchain")
-
-node_toolchain(
-    name = "node_toolchain",
-    target_tool = "//some/path/bin/node",
 )
-```
 
-Next, declare which execution platforms or target platforms the toolchain should be selected for
-based on constraints.
+def node_toolchain(
+        name,
+        node = None,
+        node_path = "",
+        npm = None,
+        npm_path = "",
+        npm_files = [],
+        headers = None,
+        **kwargs):
+    """Defines a node toolchain for a platform.
 
-```starlark
-toolchain(
-    name = "my_nodejs",
-    exec_compatible_with = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-    ],
-    toolchain = ":node_toolchain",
-    toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
-)
-```
+    You can use this to refer to a vendored nodejs binary in your repository,
+    or even to compile nodejs from sources using rules_foreign_cc or other rules.
 
-See https://bazel.build/extending/toolchains#toolchain-resolution for more information on toolchain
-resolution.
+    First, in a BUILD.bazel file, create a node_toolchain definition:
 
-Finally in your `WORKSPACE`, register it with `register_toolchains("//:my_nodejs")`
+    ```starlark
+    load("@rules_nodejs//nodejs:toolchain.bzl", "node_toolchain")
 
-For usage see https://docs.bazel.build/versions/main/toolchains.html#defining-toolchains.
-You can use the `--toolchain_resolution_debug` flag to `bazel` to help diagnose which toolchain is selected.
-""",
-)
+    node_toolchain(
+        name = "node_toolchain",
+        node = "//some/path/bin/node",
+    )
+    ```
+
+    Next, declare which execution platforms or target platforms the toolchain should be selected for
+    based on constraints.
+
+    ```starlark
+    toolchain(
+        name = "my_nodejs",
+        exec_compatible_with = [
+            "@platforms//os:linux",
+            "@platforms//cpu:x86_64",
+        ],
+        toolchain = ":node_toolchain",
+        toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
+    )
+    ```
+
+    See https://bazel.build/extending/toolchains#toolchain-resolution for more information on toolchain
+    resolution.
+
+    Finally in your `WORKSPACE`, register it with `register_toolchains("//:my_nodejs")`
+
+    For usage see https://docs.bazel.build/versions/main/toolchains.html#defining-toolchains.
+    You can use the `--toolchain_resolution_debug` flag to `bazel` to help diagnose which toolchain is selected.
+
+    Args:
+        name: Unique name for this target
+
+        node: Node.js executable
+
+        node_path: Path to Node.js executable file
+
+            This is typically an absolute path to a non-hermetic Node.js executable.
+
+            Only one of `node` and `node_path` may be set.
+
+        npm: Npm JavaScript entry point
+
+        npm_path: Path to npm JavaScript entry point
+
+            This is typically an absolute path to a non-hermetic npm installation.
+
+            Only one of `npm` and `npm_path` may be set.
+
+        npm_files: Additional files required to run npm
+
+            Not necessary if specifying `npm_path` to a non-hermetic npm installation.
+
+        headers: cc_library that contains the Node/v8 header files
+
+        **kwargs: Additional parameters
+    """
+    target_tool = kwargs.pop("target_tool", None)
+    if target_tool:
+        # buildifier: disable=print
+        print("""\
+WARNING: target_tool attribute of node_toolchain is deprecated; use node instead of target_tool.
+
+If your are not calling node_toolchain directly you may need to upgrade to rules_js 2.x to suppress this warning.
+""")
+        node = target_tool
+
+    target_tool_path = kwargs.pop("target_tool_path", "")
+    if target_tool_path:
+        # buildifier: disable=print
+        print("""\
+WARNING: target_tool_path attribute of node_toolchain is deprecated; use node_path instead of target_tool_path
+""")
+        node_path = target_tool_path
+
+    _nodejs_toolchain(
+        name = name,
+        node = node,
+        node_path = node_path,
+        npm = npm,
+        npm_path = npm_path,
+        npm_files = npm_files,
+        headers = headers,
+        **kwargs
+    )


### PR DESCRIPTION
To-date the node toolchain has provided paths (strings) to node and npm. This complicates downstream usage as they need to convert these paths depending on they are used (between execpath and rootpath for example). This change configures the toolchain to also provide File objects for node and the npm entry point script so downsteam uses can choose to get either the `.path` or `.short_path` as needed.

Deprecates `target_tool` and `target_tool_path` parameters. Maintains backward compat by setting both `target_tool_path` and `tool_files` in the provider. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature (please, look at the "Scope of the project" section in the README.md file)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
