### PR TITLE
refactor: deprecate npm_files list attribute in favor of npm_srcs depset

### DIFF
--- a/docs/Core.md
+++ b/docs/Core.md
@@ -156,7 +156,7 @@ Additional parameters
 **USAGE**
 
 <pre>
-node_toolchain(<a href="#node_toolchain-name">name</a>, <a href="#node_toolchain-node">node</a>, <a href="#node_toolchain-node_path">node_path</a>, <a href="#node_toolchain-npm">npm</a>, <a href="#node_toolchain-npm_path">npm_path</a>, <a href="#node_toolchain-npm_files">npm_files</a>, <a href="#node_toolchain-headers">headers</a>, <a href="#node_toolchain-kwargs">kwargs</a>)
+node_toolchain(<a href="#node_toolchain-name">name</a>, <a href="#node_toolchain-node">node</a>, <a href="#node_toolchain-node_path">node_path</a>, <a href="#node_toolchain-npm">npm</a>, <a href="#node_toolchain-npm_path">npm_path</a>, <a href="#node_toolchain-npm_srcs">npm_srcs</a>, <a href="#node_toolchain-headers">headers</a>, <a href="#node_toolchain-kwargs">kwargs</a>)
 </pre>
 
 Defines a node toolchain for a platform.
@@ -232,7 +232,7 @@ Defaults to `None`
 
 <h4 id="node_toolchain-npm_path">npm_path</h4>
 
-Path to npm JavaScript entry point
+Path to npm JavaScript entry point.
 
 This is typically an absolute path to a non-hermetic npm installation.
 
@@ -240,9 +240,9 @@ Only one of `npm` and `npm_path` may be set.
 
 Defaults to `""`
 
-<h4 id="node_toolchain-npm_files">npm_files</h4>
+<h4 id="node_toolchain-npm_srcs">npm_srcs</h4>
 
-Additional files required to run npm
+Additional source files required to run npm.
 
 Not necessary if specifying `npm_path` to a non-hermetic npm installation.
 

--- a/nodejs/repositories.bzl
+++ b/nodejs/repositories.bzl
@@ -240,7 +240,7 @@ filegroup(
 )
 filegroup(
   name = "npm_files",
-  srcs = {npm_files_glob}[":node_files"],
+  srcs = glob(["bin/nodejs/**"]) + [":node_files"],
 )
 cc_library(
   name = "headers",
@@ -261,7 +261,6 @@ cc_library(
         node_bin_export = "\n  \"%s\"," % node_bin,
         npm_bin_export = "\n  \"%s\"," % npm_bin,
         npx_bin_export = "\n  \"%s\"," % npx_bin,
-        npm_files_glob = "glob([\"bin/nodejs/**\"]) + ",
         node_bin_label = node_bin_label,
         npm_bin_label = npm_bin_label,
         npx_bin_label = npx_bin_label,
@@ -277,7 +276,7 @@ node_toolchain(
     name = "node_toolchain",
     node = ":node_bin",
     npm = ":npm",
-    npm_files = [":npm_files"],
+    npm_srcs = [":npm_files"],
     headers = ":headers",
 )
 """


### PR DESCRIPTION
This simplifies downstream usage since `npm_srcs` can just be used directly instead of having to construct a depset from `npm_files`

The `to_list()` call is still necessary here in the toolchain creation but once the DEPRECATED fields can be removed then that will be go away.  DEPRECATED fields can be removed in a future likely when support for WORKSPACE is dropped.
