### PR TITLE
fix: fixup backward compat on npm_path

### DIFF
--- a/nodejs/toolchain.bzl
+++ b/nodejs/toolchain.bzl
@@ -91,7 +91,7 @@ def _nodejs_toolchain_impl(ctx):
         node = ctx.file.node,
         node_path = ctx.attr.node_path,
         npm = ctx.file.npm,
-        npm_path = ctx.attr.npm_path if ctx.attr.npm_path else _to_manifest_path(ctx, ctx.file.npm),  # _to_manifest_path for backward compat
+        npm_path = ctx.attr.npm_path if ctx.attr.npm_path else (_to_manifest_path(ctx, ctx.file.npm) if ctx.file.npm else ""),  # _to_manifest_path for backward compat
         npm_sources = npm_sources,
         headers = struct(
             providers_map = {


### PR DESCRIPTION
Got this wrong earlier since ctx.file.npm may be None.

Stacked on top of https://github.com/bazelbuild/rules_nodejs/pull/3740 which should land first.