### PR TITLE
chore: bump to bazel-lib 2.7.1 (dev dep)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,7 @@ module(
     compatibility_level = 1,
 )
 
+# Lower-bounds (minimum) versions for direct runtime dependencies
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "platforms", version = "0.0.5")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workspace(
-    name = "rules_nodejs",
-)
+workspace(name = "rules_nodejs")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
@@ -59,12 +57,16 @@ http_archive(
 )
 
 #
-# Dependencies to run stardoc & generating documentation
+# Dependencies & toolchains needed for unit tests & generating documentation
 #
 
-load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "register_copy_directory_toolchains", "register_copy_to_directory_toolchains")
 
 aspect_bazel_lib_dependencies()
+
+register_copy_directory_toolchains()
+
+register_copy_to_directory_toolchains()
 
 # Needed for starlark unit testing
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")

--- a/e2e/nodejs_host/MODULE.bazel
+++ b/e2e/nodejs_host/MODULE.bazel
@@ -1,21 +1,13 @@
-"bzlmod dependencies"
-
-module(
-    name = "rules_nodejs_smoke_test",
-    version = "0.0.0",
-    compatibility_level = 1,
-)
-
 bazel_dep(name = "rules_nodejs", version = "0.0.0", dev_dependency = True)
-bazel_dep(name = "bazel_skylib", version = "1.4.1", dev_dependency = True)
-bazel_dep(name = "aspect_bazel_lib", version = "1.30.2", dev_dependency = True)
-
 local_path_override(
     module_name = "rules_nodejs",
     path = "../..",
 )
 
-node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
+bazel_dep(name = "bazel_skylib", version = "1.4.1", dev_dependency = True)
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.1", dev_dependency = True)
+
+node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
 
 # Note, this gets the default version of Node.js from
 # https://github.com/bazelbuild/rules_nodejs/blob/5.8.0/nodejs/repositories.bzl#L11

--- a/e2e/nodejs_host/WORKSPACE
+++ b/e2e/nodejs_host/WORKSPACE
@@ -1,5 +1,3 @@
-workspace(name = "e2e_nodejs_host")
-
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,22 +1,14 @@
-"bzlmod dependencies"
-
-module(
-    name = "rules_nodejs_smoke_test",
-    version = "0.0.0",
-    compatibility_level = 1,
-)
-
 bazel_dep(name = "rules_nodejs", version = "0.0.0", dev_dependency = True)
-bazel_dep(name = "bazel_skylib", version = "1.4.1", dev_dependency = True)
-bazel_dep(name = "aspect_bazel_lib", version = "1.30.2", dev_dependency = True)
-bazel_dep(name = "platforms", version = "0.0.5", dev_dependency = True)
-
 local_path_override(
     module_name = "rules_nodejs",
     path = "../..",
 )
 
-node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
+bazel_dep(name = "bazel_skylib", version = "1.4.1", dev_dependency = True)
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.1", dev_dependency = True)
+bazel_dep(name = "platforms", version = "0.0.5", dev_dependency = True)
+
+node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
 
 node.toolchain(node_version = "16.5.0")
 node.toolchain(

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -1,5 +1,3 @@
-workspace(name = "e2e_core")
-
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
@@ -9,9 +7,9 @@ local_repository(
 
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "97fa63d95cc9af006c4c7b2123ddd2a91fb8d273012f17648e6423bae2c69470",
-    strip_prefix = "bazel-lib-1.30.2",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.30.2/bazel-lib-v1.30.2.tar.gz",
+    sha256 = "b554eb7942a5ab44c90077df6a0c76fc67c5874c9446a007e9ba68be82bd4796",
+    strip_prefix = "bazel-lib-2.7.1",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.7.1/bazel-lib-v2.7.1.tar.gz",
 )
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -60,7 +60,7 @@ def rules_nodejs_dev_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "97fa63d95cc9af006c4c7b2123ddd2a91fb8d273012f17648e6423bae2c69470",
-        strip_prefix = "bazel-lib-1.30.2",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.30.2/bazel-lib-v1.30.2.tar.gz",
+        sha256 = "b554eb7942a5ab44c90077df6a0c76fc67c5874c9446a007e9ba68be82bd4796",
+        strip_prefix = "bazel-lib-2.7.1",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.7.1/bazel-lib-v2.7.1.tar.gz",
     )


### PR DESCRIPTION
Bump is not passed onto users as this is just a dev dep in this repo.