### PR TITLE
fix: register Node.js toolchains in correct order

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,4 +17,22 @@ node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 node.toolchain(name = "nodejs")
 use_repo(node, "nodejs_toolchains")
 
-register_toolchains("@nodejs_toolchains//:all")
+# Toolchain registration under bzlmod should match the order of WORKSPACE registration
+# which is the order specified in the PLATFORMS dict https://github.com/bazelbuild/rules_nodejs/blob/4c373209b058d46f2a5f9ab9f8abf11b161ae459/nodejs/private/nodejs_toolchains_repo.bzl#L20.
+# For each platform, `:<PLATFORM>_toolchain_target` should be registered before `:<PLATFORM>_toolchain`,
+# https://github.com/bazelbuild/rules_nodejs/blob/4c373209b058d46f2a5f9ab9f8abf11b161ae459/nodejs/repositories.bzl#L461/.
+# See https://github.com/bazelbuild/bazel/issues/19645 and https://github.com/bazelbuild/rules_nodejs/pull/3750 for more context.
+register_toolchains("@nodejs_toolchains//:linux_amd64_toolchain_target")
+register_toolchains("@nodejs_toolchains//:linux_amd64_toolchain")
+register_toolchains("@nodejs_toolchains//:linux_arm64_toolchain_target")
+register_toolchains("@nodejs_toolchains//:linux_arm64_toolchain")
+register_toolchains("@nodejs_toolchains//:linux_s390x_toolchain_target")
+register_toolchains("@nodejs_toolchains//:linux_s390x_toolchain")
+register_toolchains("@nodejs_toolchains//:linux_ppc64le_toolchain_target")
+register_toolchains("@nodejs_toolchains//:linux_ppc64le_toolchain")
+register_toolchains("@nodejs_toolchains//:darwin_amd64_toolchain_target")
+register_toolchains("@nodejs_toolchains//:darwin_amd64_toolchain")
+register_toolchains("@nodejs_toolchains//:darwin_arm64_toolchain_target")
+register_toolchains("@nodejs_toolchains//:darwin_arm64_toolchain")
+register_toolchains("@nodejs_toolchains//:windows_amd64_toolchain_target")
+register_toolchains("@nodejs_toolchains//:windows_amd64_toolchain")


### PR DESCRIPTION
Fixes https://github.com/aspect-build/rules_js/issues/1530.

Related to https://github.com/bazelbuild/bazel/issues/19645.

Toolchain registration ordering matters since it affects which toolchain Bazel resolves. This PR makes the bzlmod registration match the registration order in WORKSPACE.

In particular, the `:<PLATFORM>_toolchain_target` (which defines `target_compatible_with`) should be registered before `:<PLATFORM>_toolchain` (which defines `exec_compatible_with`) for each platform. In WORKSPACE this is done here: https://github.com/bazelbuild/rules_nodejs/blob/4c373209b058d46f2a5f9ab9f8abf11b161ae459/nodejs/repositories.bzl#L461/. This is important so that Bazel selects the target compatible toolchain before it selects the execution compatible toolchain. The opposite ordering causes the issue seen in https://github.com/aspect-build/rules_js/issues/1530.

```
toolchain(
  name = "linux_amd64_toolchain_target",
  toolchain_type = "//nodejs:toolchain_type",
  target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
  toolchain = "@@_main~node~nodejs_linux_amd64//:toolchain",
)
```

```
toolchain(
  name = "linux_amd64_toolchain",
  toolchain_type = "//nodejs:toolchain_type",
  exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
  toolchain = "@@_main~node~nodejs_linux_amd64//:toolchain",
)
```