### PR TITLE
chore: re-enable GitHub Actions CI for PRs and green up main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,9 @@ name: CI
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow only for the main branch (no need to duplicate Buildkite)
   push:
+    branches: [main]
+  pull_request:
     branches: [main]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,3 +20,8 @@ jobs:
     uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v6
     with:
       folders: '["."]'
+      # stardoc generated docs fail on diff_test with Bazel 6.4.0 so don't test against it
+      exclude: |
+        [
+          {"bazelversion": "6.4.0"},
+        ]

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -72,3 +72,24 @@ register_copy_to_directory_toolchains()
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
+
+# Stardoc
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
+stardoc_repositories()
+
+load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
+
+rules_jvm_external_deps()
+
+load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
+
+rules_jvm_external_setup()
+
+load("@io_bazel_stardoc//:deps.bzl", "stardoc_external_deps")
+
+stardoc_external_deps()
+
+load("@stardoc_maven//:defs.bzl", stardoc_pinned_maven_install = "pinned_maven_install")
+
+stardoc_pinned_maven_install()

--- a/docs/Core.md
+++ b/docs/Core.md
@@ -7,10 +7,9 @@
 # rules_nodejs Bazel module
 
 Features:
-- A [Toolchain](https://docs.bazel.build/versions/main/toolchains.html) 
+- A [Toolchain](https://docs.bazel.build/versions/main/toolchains.html)
   that fetches a hermetic copy of node and npm - independent of what's on the developer's machine.
 - Core [Providers](https://docs.bazel.build/versions/main/skylark/rules.html#providers) to allow interop between JS rules.
-
 
 ## UserBuildSettingInfo
 
@@ -26,7 +25,7 @@ UserBuildSettingInfo(<a href="#UserBuildSettingInfo-value">value</a>)
 
 <h4 id="UserBuildSettingInfo-value">value</h4>
 
- (Undocumented) 
+ - 
 
 
 ## nodejs_repositories

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -42,10 +42,10 @@ def rules_nodejs_dev_dependencies():
 
     http_archive(
         name = "io_bazel_stardoc",
-        sha256 = "d681269c40a368c6eb7e9eccfee44a9919d22f84f80e331e41e74bdf99a3108e",
-        strip_prefix = "stardoc-8f6d22452d088b49b13ba2c224af69ccc8ccbc90",
+        sha256 = "62bd2e60216b7a6fec3ac79341aa201e0956477e7c8f6ccc286f279ad1d96432",
         urls = [
-            "https://github.com/bazelbuild/stardoc/archive/8f6d22452d088b49b13ba2c224af69ccc8ccbc90.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz",
+            "https://github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz",
         ],
     )
 


### PR DESCRIPTION
`main` on GitHub Actions has been red since https://github.com/bazelbuild/rules_nodejs/commit/245a464cba303692d155a78d3dd4e98bfc1ed0b2. Breakage slipped through the PR since GitHub Actions CI is currently only run against the `main` branch. This PR re-enables running it on PRs again and fixes the breakage.