### PR TITLE
chore: in rules_js MODULE.bazel use default value for name of node.toolchain()

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 
 # Note, this gets the default version of Node.js from
 # https://github.com/bazelbuild/rules_nodejs/blob/main/nodejs/repositories.bzl#L11
-node.toolchain(name = "nodejs")
+node.toolchain()
 use_repo(node, "nodejs_toolchains")
 
 # Toolchain registration under bzlmod should match the order of WORKSPACE registration


### PR DESCRIPTION
No reason to set an explicit name here since it always has to be `DEFAULT_NODE_REPOSITORY` or else the following line in `extensions.bzl` will fail downstream:
```
            if toolchain.name != DEFAULT_NODE_REPOSITORY and not mod.is_root:
                fail("Only the root module may provide a name for the node toolchain.")
```