### PR TITLE
fix: add missing windows arm64 in os_arch_names

### DIFF
--- a/nodejs/private/os_name.bzl
+++ b/nodejs/private/os_name.bzl
@@ -19,6 +19,7 @@ load(":node_versions.bzl", "NODE_VERSIONS")
 
 OS_ARCH_NAMES = [
     ("windows", "amd64"),
+    ("windows", "arm64"),
     ("darwin", "amd64"),
     ("darwin", "arm64"),
     ("linux", "amd64"),
@@ -78,4 +79,4 @@ def assert_node_exists_for_host(rctx):
     if not node_exists_for_os(node_version, os_name(rctx), node_repositories):
         fail("No nodejs is available for {} at version {}".format(os_name(rctx), node_version) +
              "\n    Consider upgrading by setting node_version in a call to node_repositories in WORKSPACE." +
-             "\n    Note that Node 16.x is the minimum published for Apple Silicon (M1 Macs)")
+             "\n    Note that Node 16.x is the minimum published for Apple Silicon (M1 Macs), and 20.x is the minimum for Windows ARM64.")


### PR DESCRIPTION
In https://github.com/bazel-contrib/rules_nodejs/pull/3846 we added support for Windows arm64, but I forgot to add it to `OS_ARCH_NAMES`, so it's not _actually_ working yet. This commit adds it.

Ref: https://github.com/bazel-contrib/rules_nodejs/commit/12d90ecf8d2e5431a531b476cfeaa06b6a4e5f50

## PR Checklist

It looks like the CI test suite isn't running on arm64 hosts at all (though e.g. `windows-11-arm` GitHub Actions runners are available nowadays), so I'm not sure whether the team wants to add that to the test matrix. Happy to add it. 

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently, when trying to use the `windows_arm64` toolchain, this error is thrown:

```
Unsupported operating system windows architecture arm64
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Once this has been merged, people will be able to use the `windows_arm64` toolchain.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

