### PR TITLE
Remove target constraint

### DIFF
--- a/nodejs/private/nodejs_toolchains_repo.bzl
+++ b/nodejs/private/nodejs_toolchains_repo.bzl
@@ -96,7 +96,6 @@ See https://github.com/bazel-contrib/rules_nodejs/issues/3795.
 toolchain(
     name = "{platform}_toolchain",
     exec_compatible_with = {compatible_with},
-    target_compatible_with = {compatible_with}, # prevent Node from this toolchain being bundled by js_image_oci to incompatible target platforms (https://github.com/bazel-contrib/rules_nodejs/issues/3854)
     toolchain = "@{user_node_repository_name}_{platform}//:toolchain",
     toolchain_type = "@rules_nodejs//nodejs:toolchain_type",
 )


### PR DESCRIPTION
Because `rules_js` 3.x started consuming the runtime toolchain, this constraint is no longer needed. It is in fact problematic now because it prevents building multi-platform images.

See:
https://github.com/bazel-contrib/rules_nodejs/issues/3854 
https://github.com/aspect-build/rules_js/pull/2499

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3854 


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Slack: https://bazelbuild.slack.com/archives/CEZUUKQ6P/p1763167547013579
