### PR TITLE
feat: use facts to auto-retrieve node versions if possible

### DIFF
--- a/e2e/nodejs_host/BUILD.bazel
+++ b/e2e/nodejs_host/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 # Dummy test target that imports various targets from the
@@ -23,8 +24,9 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
         "node16",
         "node16_nvmrc",
         "node17_custom",
-        "node26_facts",
-    ]
+    ] + (
+        ["node26_facts"] if bazel_features.external_deps.has_facts else []
+    )
 ]
 
 [
@@ -67,7 +69,10 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
         ("node16_nvmrc", "npx"),
         ("node17_custom", "npm"),
         ("node17_custom", "npx"),
-        ("node26_facts", "npm"),
-        ("node26_facts", "npx"),
-    ]
+    ] + (
+        [
+            ("node26_facts", "npm"),
+            ("node26_facts", "npx"),
+        ] if bazel_features.external_deps.has_facts else []
+    )
 ]

--- a/e2e/nodejs_host/BUILD.bazel
+++ b/e2e/nodejs_host/BUILD.bazel
@@ -23,6 +23,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
         "node16",
         "node16_nvmrc",
         "node17_custom",
+        "node26_facts",
     ]
 ]
 
@@ -66,5 +67,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
         ("node16_nvmrc", "npx"),
         ("node17_custom", "npm"),
         ("node17_custom", "npx"),
+        ("node26_facts", "npm"),
+        ("node26_facts", "npx"),
     ]
 ]

--- a/e2e/nodejs_host/MODULE.bazel
+++ b/e2e/nodejs_host/MODULE.bazel
@@ -35,6 +35,10 @@ node.toolchain(
     node_urls = ["https://nodejs.org/dist/v17.0.1/{filename}"],
     node_version = "17.0.1.custom",
 )
+node.toolchain(
+    name = "node26_facts",
+    node_version = "26.3.0",
+)
 
 # FIXME(6.0): a repo rule with name=foo should create a repo named @foo, not @foo_toolchains
 use_repo(
@@ -60,6 +64,13 @@ use_repo(
     "node17_custom_linux_arm64",
     "node17_custom_toolchains",
     "node17_custom_windows_amd64",
+    "node26_facts",
+    "node26_facts_darwin_amd64",
+    "node26_facts_darwin_arm64",
+    "node26_facts_linux_amd64",
+    "node26_facts_linux_arm64",
+    "node26_facts_toolchains",
+    "node26_facts_windows_amd64",
     "nodejs",
     "nodejs_darwin_amd64",
     "nodejs_darwin_arm64",

--- a/e2e/nodejs_host/MODULE.bazel
+++ b/e2e/nodejs_host/MODULE.bazel
@@ -6,14 +6,8 @@ local_path_override(
 
 bazel_dep(name = "bazel_lib", version = "3.0.0-beta.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "bazel_features", version = "1.48.1")
+bazel_dep(name = "bazel_features", version = "1.49.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
-
-git_override(
-    module_name = "bazel_features",
-    commit = "bcc80f8223e1e69343eb25e6d2eee25f23e0fc30",
-    remote = "git@github.com:bazel-contrib/bazel_features.git",
-)
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 

--- a/e2e/nodejs_host/MODULE.bazel
+++ b/e2e/nodejs_host/MODULE.bazel
@@ -6,7 +6,14 @@ local_path_override(
 
 bazel_dep(name = "bazel_lib", version = "3.0.0-beta.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "bazel_features", version = "1.48.1")
 bazel_dep(name = "rules_shell", version = "0.6.1")
+
+git_override(
+    module_name = "bazel_features",
+    commit = "bcc80f8223e1e69343eb25e6d2eee25f23e0fc30",
+    remote = "git@github.com:bazel-contrib/bazel_features.git",
+)
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node")
 

--- a/nodejs/BUILD.bazel
+++ b/nodejs/BUILD.bazel
@@ -12,6 +12,7 @@ bzl_library(
     deps = [
         ":repositories",
         "//nodejs/private:fetch_node_repositories",
+        "//nodejs/private:node_versions",
         "//nodejs/private:version_from_attr",
     ],
 )

--- a/nodejs/BUILD.bazel
+++ b/nodejs/BUILD.bazel
@@ -9,7 +9,11 @@ package(default_visibility = ["//visibility:public"])
 bzl_library(
     name = "extensions",
     srcs = ["extensions.bzl"],
-    deps = [":repositories"],
+    deps = [
+        ":repositories",
+        "//nodejs/private:fetch_node_repositories",
+        "//nodejs/private:version_from_attr",
+    ],
 )
 
 bzl_library(
@@ -29,6 +33,7 @@ bzl_library(
         "//nodejs/private:nodejs_repo_host_os_alias",
         "//nodejs/private:nodejs_toolchains_repo",
         "//nodejs/private:os_name",
+        "//nodejs/private:version_from_attr",
     ],
 )
 

--- a/nodejs/BUILD.bazel
+++ b/nodejs/BUILD.bazel
@@ -14,6 +14,7 @@ bzl_library(
         "//nodejs/private:fetch_node_repositories",
         "//nodejs/private:node_versions",
         "//nodejs/private:version_from_attr",
+        "@bazel_features//:features",
     ],
 )
 

--- a/nodejs/extensions.bzl
+++ b/nodejs/extensions.bzl
@@ -9,6 +9,9 @@ use_repo(node, "nodejs_toolchains")
 ```
 """
 
+load("//nodejs/private:fetch_node_repositories.bzl", "fetch_node_repositories")
+load("//nodejs/private:nodejs_toolchains_repo.bzl", "PLATFORMS")
+load("//nodejs/private:version_from_attr.bzl", "version_from_attr")
 load(
     ":repositories.bzl",
     "DEFAULT_NODE_REPOSITORY",
@@ -28,6 +31,57 @@ def _toolchains_equal(lhs, rhs):
         if getattr(lhs, attr) != getattr(rhs, attr):
             return False
     return True
+
+def _use_repository_facts(registration):
+    """Whether we should use facts (if available) for the given registration."""
+
+    if registration.node_repositories.items():
+        return False  # custom repositories, do not mess with them.
+    if registration.node_urls != [DEFAULT_NODE_URL]:
+        return False  # we do not know how to fetch shas with custom URLs.
+
+    return True
+
+def _update_repository_facts(module_ctx, registrations):
+    """Fetch / update the necessary repository facts for the given registrations.
+
+    * Takes into account existing facts.
+    * Returns empty dict if facts are not supported.
+    """
+
+    if not hasattr(module_ctx, "facts"):
+        # facts not supported.
+        # repository rules will fallback to builtin NODE_VERSIONS.
+        return {}
+
+    new_facts = {}
+
+    for registration in registrations.values():
+        if not _use_repository_facts(registration):
+            continue
+
+        version = version_from_attr(module_ctx, registration)
+
+        should_fetch = False
+
+        # Get repository values for the default PLATFORMS.
+        # These are the only platforms supported by the extension anyways.
+        for platform in PLATFORMS:
+            key = version + "-" + platform
+
+            existing = new_facts.get(key) or module_ctx.facts.get(key)
+            if existing:
+                new_facts[key] = existing
+            else:
+                should_fetch = True
+
+        if should_fetch:
+            # Note: Even after fetching, it is possible that keys are not in facts:
+            # Old node versions might not have all platforms.
+            # In that case, we want to fail lazily when the repository is actually used.
+            new_facts.update(fetch_node_repositories(module_ctx, version))
+
+    return new_facts
 
 def _toolchain_extension(module_ctx):
     registrations = {}
@@ -52,15 +106,25 @@ def _toolchain_extension(module_ctx):
             else:
                 registrations[toolchain.name] = toolchain
 
+    repository_facts = _update_repository_facts(module_ctx, registrations)
+
     for k, v in registrations.items():
         nodejs_register_toolchains(
             name = k,
             node_version = v.node_version,
             node_version_from_nvmrc = v.node_version_from_nvmrc,
             node_urls = v.node_urls,
-            node_repositories = v.node_repositories,
+            node_repositories = (
+                repository_facts if _use_repository_facts(v) else v.node_repositories
+            ),
             include_headers = v.include_headers,
             register = False,
+        )
+
+    if hasattr(module_ctx, "facts"):
+        return module_ctx.extension_metadata(
+            reproducible = True,
+            facts = repository_facts,
         )
 
 _ATTRS = {

--- a/nodejs/extensions.bzl
+++ b/nodejs/extensions.bzl
@@ -126,6 +126,8 @@ def _toolchain_extension(module_ctx):
             reproducible = True,
             facts = repository_facts,
         )
+    else:
+        return  # buildifier: disable=return-value (allow no value)
 
 _ATTRS = {
     "name": attr.string(

--- a/nodejs/extensions.bzl
+++ b/nodejs/extensions.bzl
@@ -10,7 +10,7 @@ use_repo(node, "nodejs_toolchains")
 """
 
 load("//nodejs/private:fetch_node_repositories.bzl", "fetch_node_repositories")
-load("//nodejs/private:nodejs_toolchains_repo.bzl", "PLATFORMS")
+load("//nodejs/private:node_versions.bzl", "NODE_VERSIONS")
 load("//nodejs/private:version_from_attr.bzl", "version_from_attr")
 load(
     ":repositories.bzl",
@@ -31,57 +31,6 @@ def _toolchains_equal(lhs, rhs):
         if getattr(lhs, attr) != getattr(rhs, attr):
             return False
     return True
-
-def _use_repository_facts(registration):
-    """Whether we should use facts (if available) for the given registration."""
-
-    if registration.node_repositories.items():
-        return False  # custom repositories, do not mess with them.
-    if registration.node_urls != [DEFAULT_NODE_URL]:
-        return False  # we do not know how to fetch shas with custom URLs.
-
-    return True
-
-def _update_repository_facts(module_ctx, registrations):
-    """Fetch / update the necessary repository facts for the given registrations.
-
-    * Takes into account existing facts.
-    * Returns empty dict if facts are not supported.
-    """
-
-    if not hasattr(module_ctx, "facts"):
-        # facts not supported.
-        # repository rules will fallback to builtin NODE_VERSIONS.
-        return {}
-
-    new_facts = {}
-
-    for registration in registrations.values():
-        if not _use_repository_facts(registration):
-            continue
-
-        version = version_from_attr(module_ctx, registration)
-
-        should_fetch = False
-
-        # Get repository values for the default PLATFORMS.
-        # These are the only platforms supported by the extension anyways.
-        for platform in PLATFORMS:
-            key = version + "-" + platform
-
-            existing = new_facts.get(key) or module_ctx.facts.get(key)
-            if existing:
-                new_facts[key] = existing
-            else:
-                should_fetch = True
-
-        if should_fetch:
-            # Note: Even after fetching, it is possible that keys are not in facts:
-            # Old node versions might not have all platforms.
-            # In that case, we want to fail lazily when the repository is actually used.
-            new_facts.update(fetch_node_repositories(module_ctx, version))
-
-    return new_facts
 
 def _toolchain_extension(module_ctx):
     registrations = {}
@@ -106,25 +55,35 @@ def _toolchain_extension(module_ctx):
             else:
                 registrations[toolchain.name] = toolchain
 
-    repository_facts = _update_repository_facts(module_ctx, registrations)
+    supports_facts = hasattr(module_ctx, "facts")
+    new_repository_facts = {}
 
     for k, v in registrations.items():
+        node_version = version_from_attr(module_ctx, v)
+        node_repositories = v.node_repositories or NODE_VERSIONS.get(node_version, {})
+
+        if supports_facts and not node_repositories:
+            node_repositories = (
+                new_repository_facts.get(node_version) or
+                module_ctx.facts.get(node_version) or
+                # TODO: Add support for node_urls?
+                fetch_node_repositories(module_ctx, node_version)
+            )
+            new_repository_facts[node_version] = node_repositories
+
         nodejs_register_toolchains(
             name = k,
-            node_version = v.node_version,
-            node_version_from_nvmrc = v.node_version_from_nvmrc,
+            node_version = node_version,
             node_urls = v.node_urls,
-            node_repositories = (
-                repository_facts if _use_repository_facts(v) else v.node_repositories
-            ),
+            node_repositories = node_repositories,
             include_headers = v.include_headers,
             register = False,
         )
 
-    if hasattr(module_ctx, "facts"):
+    if supports_facts:
         return module_ctx.extension_metadata(
             reproducible = True,
-            facts = repository_facts,
+            facts = new_repository_facts,
         )
     else:
         return  # buildifier: disable=return-value (allow no value)

--- a/nodejs/extensions.bzl
+++ b/nodejs/extensions.bzl
@@ -9,6 +9,7 @@ use_repo(node, "nodejs_toolchains")
 ```
 """
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//nodejs/private:fetch_node_repositories.bzl", "fetch_node_repositories")
 load("//nodejs/private:node_versions.bzl", "NODE_VERSIONS")
 load("//nodejs/private:version_from_attr.bzl", "version_from_attr")
@@ -80,13 +81,19 @@ def _toolchain_extension(module_ctx):
             register = False,
         )
 
-    if supports_facts:
-        return module_ctx.extension_metadata(
-            reproducible = True,
-            facts = new_repository_facts,
-        )
-    else:
+    if not hasattr(module_ctx, "extension_metadata"):
         return  # buildifier: disable=return-value (allow no value)
+
+    if not bazel_features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata()
+
+    if not supports_facts:
+        return module_ctx.extension_metadata(reproducible = True)
+
+    return module_ctx.extension_metadata(
+        reproducible = True,
+        facts = new_repository_facts,
+    )
 
 _ATTRS = {
     "name": attr.string(

--- a/nodejs/private/BUILD.bazel
+++ b/nodejs/private/BUILD.bazel
@@ -41,3 +41,13 @@ bzl_library(
     srcs = ["user_build_settings.bzl"],
     deps = ["//nodejs/private/providers:user_build_settings"],
 )
+
+bzl_library(
+    name = "version_from_attr",
+    srcs = ["version_from_attr.bzl"],
+)
+
+bzl_library(
+    name = "fetch_node_repositories",
+    srcs = ["fetch_node_repositories.bzl"],
+)

--- a/nodejs/private/fetch_node_repositories.bzl
+++ b/nodejs/private/fetch_node_repositories.bzl
@@ -1,0 +1,51 @@
+"""Implementation of node SHASUM fetching for facts."""
+
+_REPOSITORY_TYPES = {
+    "darwin-arm64.tar.gz": "darwin_arm64",
+    "darwin-x64.tar.gz": "darwin_amd64",
+    "linux-x64.tar.xz": "linux_amd64",
+    "linux-arm64.tar.xz": "linux_arm64",
+    "linux-s390x.tar.xz": "linux_s390x",
+    "win-x64.zip": "windows_amd64",
+    "win-arm64.zip": "windows_arm64",
+    "linux-ppc64le.tar.xz": "linux_ppc64le",
+}
+
+def fetch_node_repositories(module_ctx, version):
+    """Fetches node repositories for the given node version.
+
+    Port of scripts/update-nodejs-versions.js
+    """
+
+    shasums_filename = "{version}-SHASUMS256.txt".format(version = version)
+    url = "https://nodejs.org/dist/v{version}/SHASUMS256.txt".format(version = version)
+
+    result = module_ctx.download(url = url, output = shasums_filename)
+    if not result.success:
+        fail("Failed to fetch node shasums:", url, result, sep = "\n")
+
+    shasums = module_ctx.read(shasums_filename)
+
+    result = {}
+
+    for line in shasums.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+
+        parts = line.split("  ")
+        if len(parts) != 2:
+            fail("{url} contains unexpected line:\n{line}".format(
+                url = url,
+                line = line,
+            ))
+
+        sha, filename = parts
+        type = _REPOSITORY_TYPES.get(filename.removeprefix("node-v%s-" % version))
+        if not type:
+            continue
+
+        strip_prefix = filename.removesuffix(".tar.gz").removesuffix(".tar.xz").removesuffix(".zip")
+        result[version + "-" + type] = (filename, strip_prefix, sha)
+
+    return result

--- a/nodejs/private/fetch_node_repositories.bzl
+++ b/nodejs/private/fetch_node_repositories.bzl
@@ -15,6 +15,13 @@ def fetch_node_repositories(module_ctx, version):
     """Fetches node repositories for the given node version.
 
     Port of scripts/update-nodejs-versions.js
+
+    Args:
+      module_ctx: Module context
+      version: The node version to fetch repositories for.
+
+    Returns:
+      A dictionary in the shape of node_repositories.
     """
 
     shasums_filename = "{version}-SHASUMS256.txt".format(version = version)

--- a/nodejs/private/version_from_attr.bzl
+++ b/nodejs/private/version_from_attr.bzl
@@ -14,7 +14,8 @@ def version_from_attr(ctx, attr):
       ctx: repository or module context
       attr: A struct with fields node_version and node_version_from_nvmrc
 
-    Returns: node version.
+    Returns:
+      The node version.
     """
 
     node_version = attr.node_version

--- a/nodejs/private/version_from_attr.bzl
+++ b/nodejs/private/version_from_attr.bzl
@@ -1,0 +1,27 @@
+"""Helper to get node version from user config."""
+
+def _verify_version_is_valid(version):
+    major, minor, patch = (version.split(".") + [None, None, None])[:3]
+    if not major.isdigit() or not minor.isdigit() or not patch.isdigit():
+        fail("Invalid node version: %s" % version)
+
+def version_from_attr(ctx, attr):
+    """Extract the node version from attr.
+
+    Verifies if the extracted version is valid.
+
+    Args:
+      ctx: repository or module context
+      attr: A struct with fields node_version and node_version_from_nvmrc
+
+    Returns: node version.
+    """
+
+    node_version = attr.node_version
+
+    if attr.node_version_from_nvmrc:
+        node_version = str(ctx.read(attr.node_version_from_nvmrc)).strip()
+
+    _verify_version_is_valid(node_version)
+
+    return node_version

--- a/nodejs/repositories.bzl
+++ b/nodejs/repositories.bzl
@@ -3,6 +3,7 @@
 load("//nodejs/private:node_versions.bzl", "NODE_VERSIONS")
 load("//nodejs/private:nodejs_repo_host_os_alias.bzl", "nodejs_repo_host_os_alias")
 load("//nodejs/private:nodejs_toolchains_repo.bzl", "PLATFORMS", "nodejs_toolchains_repo")
+load("//nodejs/private:version_from_attr.bzl", "version_from_attr")
 
 # Default base name for node toolchain repositories
 # created by the module extension
@@ -66,12 +67,7 @@ def _download_node(repository_ctx):
     # @nodejs_PLATFORM where PLATFORM is one of BUILT_IN_NODE_PLATFORMS
     host_os = repository_ctx.attr.platform or repository_ctx.name.split("nodejs_", 1)[1]
 
-    node_version = repository_ctx.attr.node_version
-
-    if repository_ctx.attr.node_version_from_nvmrc:
-        node_version = str(repository_ctx.read(repository_ctx.attr.node_version_from_nvmrc)).strip()
-
-    _verify_version_is_valid(node_version)
+    node_version = version_from_attr(repository_ctx, repository_ctx.attr)
 
     node_repositories = repository_ctx.attr.node_repositories
 
@@ -301,11 +297,6 @@ def _strip_bin(path):
         fail("Expected path to start with 'bin/' but was %s" % path)
 
     return path[len("bin/"):]
-
-def _verify_version_is_valid(version):
-    major, minor, patch = (version.split(".") + [None, None, None])[:3]
-    if not major.isdigit() or not minor.isdigit() or not patch.isdigit():
-        fail("Invalid node version: %s" % version)
 
 def _nodejs_repositories_impl(repository_ctx):
     reproducible = _download_node(repository_ctx)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

Node versions / digests are hardcoded and shipped with rules_nodejs.

## What is the new behavior?

If the bazel facts feature is available (bazel >= 8.5.0) rules_nodejs retrieves required Node digests as needed and stores them in facts.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Sorry for the out of the blue PR, I felt it was faster to just build this and discuss whether this is worth including on the PR directly.

